### PR TITLE
compress: initial commit, no test added yet

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -126,38 +126,53 @@ function respond(next){
       this.set('Content-Type', 'text/plain');
       body = http.STATUS_CODES[this.status];
     }
-    
+
     // Buffer body
     if (Buffer.isBuffer(body)) {
       var ct = this.responseHeader['content-type'];
       if (!ct) this.set('Content-Type', 'application/octet-stream');
-      this.set('Content-Length', body.length);
-      if (head) return res.end();
-      return res.end(body);
+      if (head) {
+        this.set('Content-Length', body.length);
+        res.end();
+      } else if (!this._createCompressionStream(body)) {
+        this.set('Content-Length', body.length);
+        res.end(body);
+      }
+      return;
     }
 
     // string body
     if ('string' == typeof body) {
       var ct = this.responseHeader['content-type'];
       if (!ct) this.set('Content-Type', 'text/plain; charset=utf-8');
-      this.set('Content-Length', Buffer.byteLength(body));
-      if (head) return res.end();
-      return res.end(body);
+      if (head) {
+        this.set('Content-Length', Buffer.byteLength(body));
+        res.end();
+      } else if (!this._createCompressionStream(body)) {
+        this.set('Content-Length', Buffer.byteLength(body));
+        res.end(body);
+      }
+      return;
     }
 
     // Stream body
     if (body instanceof Stream) {
       body.on('error', this.error.bind(this));
-      if (head) return res.end();
-      return body.pipe(res);
+      if (head) res.end();
+      else if (!this._createCompressionStream(body)) body.pipe(res);
+      return;
     }
-    
+
     // body: json
     body = JSON.stringify(body, null, this.app.jsonSpaces);
-    this.set('Content-Length', body.length);
     this.set('Content-Type', 'application/json');
-    if (head) return res.end();
-    res.end(body);
+    if (head) {
+      this.set('Content-Length', Buffer.byteLength(body));
+      res.end();
+    } else if (!this._createCompressionStream(body)) {
+      this.set('Content-Length', Buffer.byteLength(body));
+      res.end(body);
+    }
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -14,9 +14,15 @@ var basename = path.basename;
 var extname = path.extname;
 var url = require('url');
 var qs = require('qs');
+var zlib = require('zlib');
+var Stream = require('stream');
 var parse = url.parse;
 var stringify = url.format;
 var ctx = Context.prototype;
+var encodingMethods = {
+  gzip: zlib.createGzip,
+  deflate: zlib.createDeflate
+}
 
 /**
  * Expose `Context`.
@@ -509,7 +515,7 @@ Context.prototype = {
   /**
    * Return accepted encodings.
    *
-   * Given `Accept-Encoding: gzip, deflate` 
+   * Given `Accept-Encoding: gzip, deflate`
    * an array sorted by quality is returned:
    *
    *     ['gzip', 'deflate']
@@ -526,7 +532,7 @@ Context.prototype = {
   /**
    * Return accepted charsets.
    *
-   * Given `Accept-Charset: utf-8, iso-8859-1;q=0.2, utf-7;q=0.5` 
+   * Given `Accept-Charset: utf-8, iso-8859-1;q=0.2, utf-7;q=0.5`
    * an array sorted by quality is returned:
    *
    *     ['utf-8', 'utf-7', 'iso-8859-1']
@@ -543,7 +549,7 @@ Context.prototype = {
   /**
    * Return accepted languages.
    *
-   * Given `Accept-Language: en;q=0.8, es, pt` 
+   * Given `Accept-Language: en;q=0.8, es, pt`
    * an array sorted by quality is returned:
    *
    *     ['es', 'pt', 'en']
@@ -560,7 +566,7 @@ Context.prototype = {
   /**
    * Return accepted media types.
    *
-   * Given `Accept: application/*;q=0.2, image/jpeg;q=0.8, text/html` 
+   * Given `Accept: application/*;q=0.2, image/jpeg;q=0.8, text/html`
    * an array sorted by quality is returned:
    *
    *     ['text/html', 'image/jpeg', 'application/*']
@@ -644,7 +650,7 @@ Context.prototype = {
 
     // extension given
     if (!~type.indexOf('/')) type = mime.lookup(type);
-    
+
     // type or subtype match
     if (~type.indexOf('*')) {
       type = type.split('/');
@@ -827,7 +833,7 @@ Context.prototype = {
 
   /**
    * Inspect implementation.
-   * 
+   *
    * TODO: add tests
    *
    * @return {Object}
@@ -855,6 +861,117 @@ Context.prototype = {
       header: this.header,
       responseHeader: this.responseHeader
     }
+  },
+
+  /**
+   * Default compress content-type filter.
+   * Taken from connect.
+   *
+   * this.compressFilter = /text/;
+   *
+   * @param {Regexp}
+   * @api public
+   */
+
+  compressFilter: /json|text|javascript|dart/,
+
+  /**
+   * Minimum size of the body in bytes to compress.
+   * Default 1 kilobyte.
+   *
+   * this.compressTheshold = 1024;
+   *
+   * @param {Integer}
+   * @api public
+   */
+
+  compressThreshold: 1024,
+
+  /**
+   * Default compress options.
+   * Passed to the zlib constructor.
+   *
+   * this.compressOptions = {
+   *  flush: require('zlib').Z_SYNC_FLUSH
+   * }
+   *
+   * @param {Object}
+   * @api public
+   */
+
+  compressOptions: {},
+
+  /**
+   * Test whether to compress the body
+   * based on the content type.
+   * Users should not need to use this.
+   *
+   * @returns {boolean}
+   * @api private
+   */
+
+  get compress(){
+    if (typeof this._compress === 'boolean')
+      return this._compress;
+
+    return this.compressFilter.test(this.get('content-type'));
+  },
+
+  /**
+   * Set ctx.compress as a boolean to override the
+   * content-type filter check.
+   *
+   * this.compress = true;
+   * this.compress = false;
+   *
+   * @param {Boolean} value
+   * @api public
+   */
+
+  set compress(value){
+    if (typeof value !== 'boolean')
+      throw new TypeError('Compress value can only be set as true or false.');
+
+    this._compress = value;
+  },
+
+  /**
+   * Create the compression stream.
+   *
+   * @returns {true || null}
+   * @api private
+   */
+
+  _createCompressionStream: function (body) {
+    if (!this.compress) return;
+
+    this.vary('Accept-Encoding');
+
+    var encodings = new Negotiator(this.req)
+      .preferredEncodings(['gzip', 'deflate', 'identity']);
+    var encoding = encodings[0];
+    if (encoding === 'identity') return;
+
+    if (this.compressThreshold
+      && ~encodings.indexOf('identity')
+      && (typeof body === 'string' || Buffer.isBuffer(body))) {
+      var contentLength = Buffer.isBuffer(body)
+        ? body.length
+        : Buffer.byteLength(body);
+      if (contentLength < this.compressThreshold) return;
+    }
+
+    this.set('Content-Encoding', encoding);
+
+    var stream = encodingMethods[encoding](this.compressOptions)
+      .on('error', this.error.bind(this));
+
+    if (body instanceof Stream) body.pipe(stream);
+    else stream.end(body);
+
+    stream.pipe(this.res);
+
+    return true;
   }
 };
 


### PR DESCRIPTION
was looking at how responses are done, thought it would be much easier to support compression at the core instead of through some middleware. here's a quick prototype. i haven't added tests yet.

the options are exposed on the context as `context.compressOptions`, `context.compressThreshold`, and `context.compressFilter`. i'm not sure how settings will work in koa, but you may want to check the settings instead or in addition to the context.

if you want to merge this, i'll add tests.
