### PR TITLE
pass context to errors

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -592,12 +591,12 @@ module.exports = {
     // handler and log.
     if (this.headerSent) {
       err.headerSent = true;
-      this.app.emit('error', err);
+      this.app.emit('error', err, this);
       return;
     }
 
     // delegate
-    this.app.emit('error', err);
+    this.app.emit('error', err, this);
 
     // err.status support
     if (err.status) {


### PR DESCRIPTION
errors are kind of useless without the context. not sure if there's a better way to do this (i'm sure there is) since i've never listened to an error event with more than 1 argument.

use case: your logger wants to know the URL or the headers of the request that caused the error.

i edited this github, so the formatting is a little screwed up.
