### PR TITLE
bind .onerror to context

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -229,5 +229,6 @@ function createContext() {
     this.req = req;
     this.res = res;
     this.cookies = new Cookies(req, res);
+    this.onerror = this.onerror.bind(this);
   }
 }


### PR DESCRIPTION
so we don't have to do

``` js
stream.on('error', this.onerror.bind(this))
```

every time and just do

``` js
stream.on('error', this.onerror)
```
