### PR TITLE
set length on body override

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -163,31 +163,31 @@ module.exports = {
       return;
     }
 
-    // content-type already set
-    if (this.responseHeader['content-type']) return;
+    // set the content-type only if not yet set
+    var setType = !this.responseHeader['content-type'];
 
     // string
     if ('string' == typeof val) {
-      this.type = ~val.indexOf('<') ? 'html' : 'text';
+      if (setType) this.type = ~val.indexOf('<') ? 'html' : 'text';
       this.length = Buffer.byteLength(val);
       return;
     }
 
     // buffer
     if (Buffer.isBuffer(val)) {
-      this.type = 'bin';
+      if (setType) this.type = 'bin';
       this.length = val.length;
       return;
     }
 
     // stream
     if (val instanceof Stream) {
-      this.type = 'bin';
+      if (setType) this.type = 'bin';
       return;
     }
 
     // json
-    this.type = 'json';
+    if (setType) this.type = 'json';
   },
 
   /**

--- a/test/context.js
+++ b/test/context.js
@@ -29,6 +29,13 @@ describe('ctx.body=', function(){
       ctx.body = new Buffer('something');
       assert('image/png' == ctx.responseHeader['content-type']);
     })
+
+    it('should override length', function(){
+      var ctx = context();
+      ctx.type = 'html';
+      ctx.body = 'something';
+      assert.equal(ctx.responseLength, 9);
+    })
   })
 
   describe('when a string is given', function(){
@@ -50,6 +57,21 @@ describe('ctx.body=', function(){
       var ctx = context();
       ctx.body = '<h1>Tobi</h1>';
       assert('text/html; charset=utf-8' == ctx.responseHeader['content-type']);
+    })
+
+    it('should set length', function(){
+      var string = '<h1>Tobi</h1>';
+      var ctx = context();
+      ctx.body = string;
+      assert.equal(ctx.responseLength, Buffer.byteLength(string));
+    })
+
+    it('should set length when body is override', function(){
+      var string = '<h1>Tobi</h1>';
+      var ctx = context();
+      ctx.body = string;
+      ctx.body = string + string;
+      assert.equal(ctx.responseLength, 2 * Buffer.byteLength(string));
     })
   })
 


### PR DESCRIPTION
when you do:

``` js
this.body = 'something';
this.body = 'something longer';
```

then the content-length won't be set. still won't let you change content-type, though.

i actually don't like how the code is written - i'd rather do a big if/else vs all those `return`s
