### PR TITLE
onerror: check existence of error

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -644,6 +644,11 @@ module.exports = {
    */
 
   onerror: function(err){
+    // don't do anything if there is no error.
+    // this allows you to pass `this.onerror`
+    // to node-style callbacks.
+    if (!err) return;
+
     // nothing we can do here other
     // than delegate to the app-level
     // handler and log.


### PR DESCRIPTION
so you can pass `.onerror` to node-style callbacks.

``` js
function* () {
  doSomethingAsync(this.onerror.bind(this))
  yield next
})
```

another option is to make sure it's `instanceof Error`
