### PR TITLE
add deprecation warning for ctx.error

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -75,6 +75,7 @@ module.exports = {
    */
 
   error: function(msg, status){
+    console.warn('ctx.error is deprecated, use ctx.throw');
     this.throw(msg, status);
   },
 


### PR DESCRIPTION
Didn't notice the change until now. A warning would be useful
