### PR TITLE
Readme: add note about `gnode` to the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,10 @@ $ npm install koa
 alias node='node --harmony'
 ```
 
+  Another option, if you would like to use koa with __node 0.10.x__ (the current
+  stable branch), or are tired of typing the `--harmony` flag, is to use
+  [`gnode`](https://github.com/TooTallNate/gnode) to spawn your node instance.
+
 ## Community
 
  - [API](docs/api/index.md) documentation


### PR DESCRIPTION
For people who are stuck on v0.10.x for now, but would still like to use
Koa, then `gnode` is a decent option for allowing that to happen.
