### PR TITLE
Free body stream constraints, check object for a pipe method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -214,8 +214,8 @@ function *respond(next){
     return res.end(body);
   }
 
-  // Stream body
-  if (body instanceof Stream) {
+  // stream body
+  if ('function' == typeof body.pipe) {
     if (!~body.listeners('error').indexOf(this.onerror)) body.on('error', this.onerror);
 
     if (head) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -133,7 +133,7 @@ module.exports = {
     }
 
     // stream
-    if (val instanceof Stream) {
+    if ('function' == typeof val.pipe) {
       if (setType) this.type = 'bin';
       return;
     }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "co-busboy": "git://github.com/cojs/busboy",
     "koa-route": "~1.0.2",
     "swig": "~1.1.0",
-    "co-body": "0.0.1"
+    "co-body": "0.0.1",
+    "pull-stream": "~2.21.0"
   },
   "engines": {
     "node": ">= 0.11.9"

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -2,6 +2,7 @@
 var response = require('../context').response;
 var assert = require('assert');
 var fs = require('fs');
+var pull = require('pull-stream');
 
 describe('res.body=', function(){
   describe('when Content-Type is set', function(){
@@ -75,6 +76,14 @@ describe('res.body=', function(){
       res.body = fs.createReadStream('LICENSE');
       assert('application/octet-stream' == res.header['content-type']);
     })
+  })
+
+  describe('when a duck stream is given', function(){
+    it('should default to an octet stream', function(){
+      var res = response();
+      res.body = pull.values([new Buffer('hello, world!')]);
+      assert('application/octet-stream' == res.header['content-type']);
+    });
   })
 
   describe('when a buffer is given', function(){


### PR DESCRIPTION
This resolves #124, as it enables the use of streams other than Node's core streams.

/cc @jonathanong, @visionmedia
