### PR TITLE
Update keygrip dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "negotiator": "~0.3.0",
     "koa-compose": "~2.0.0",
     "cookies": "~0.3.7",
-    "keygrip": "~0.2.4"
+    "keygrip": "~1.0.0"
   },
   "devDependencies": {
     "bytes": "~0.2.1",


### PR DESCRIPTION
The 0.2.4 version of keygrip was problematic for Windows installations, due to the generation of a default secret (jed/keygrip#11). Since generating default keys wasn't a well advised API to begin with, we removed it. The major version was bumped to reflect the breaking change.
