### PR TITLE
benchmark: use generator delegation

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -10,14 +10,14 @@ console.log('  %s middleware', n);
 
 while (n--) {
   app.use(function *(next){
-    yield next;
+    yield *next;
   });
 }
 
 var body = new Buffer('Hello World');
 
 app.use(function *(next){
-  yield next;
+  yield *next;
   this.body = body;
 });
 


### PR DESCRIPTION
not like it matters, but i always end up adding the stars when benching. up to you if you want to add it to the benchmark. still agree that examples should not include any `*`s
