### PR TITLE
better 404 handling

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -180,7 +180,6 @@ app.onerror = function(err){
  */
 
 function *respond(next){
-  this.status = 200;
   if (this.app.poweredBy) this.set('X-Powered-By', 'koa');
 
   yield *next;
@@ -189,13 +188,9 @@ function *respond(next){
   if (res.headersSent || !res.socket.writable) return;
 
   var body = this.body;
+  var status = this.status = this.status || 404;
   var head = 'HEAD' == this.method;
-  var noContent = ~[204, 205, 304].indexOf(this.status);
-
-  // 404
-  if (null == body && 200 == this.status) {
-    this.status = 404;
-  }
+  var noContent = ~[204, 205, 304].indexOf(status);
 
   // ignore body
   if (noContent) return res.end();
@@ -203,7 +198,7 @@ function *respond(next){
   // status body
   if (null == body) {
     this.type = 'text';
-    body = http.STATUS_CODES[this.status];
+    body = http.STATUS_CODES[status];
   }
 
   // Buffer body

--- a/lib/response.js
+++ b/lib/response.js
@@ -49,7 +49,7 @@ module.exports = {
    */
 
   get statusString() {
-    return http.STATUS_CODES[this.status];
+    return http.STATUS_CODES[this.status || 404];
   },
 
   /**
@@ -60,7 +60,7 @@ module.exports = {
    */
 
   get status() {
-    return this.res.statusCode;
+    return this._status;
   },
 
   /**
@@ -77,9 +77,8 @@ module.exports = {
       val = n;
     }
 
-    this.res.statusCode = val;
-
-    var noContent = 304 == this.status || 204 == this.status;
+    var status = this._status = this.res.statusCode = val;
+    var noContent = 304 == status || 204 == status;
     if (noContent && this.body) this.body = null;
   },
 
@@ -113,6 +112,9 @@ module.exports = {
       this.res.removeHeader('Transfer-Encoding');
       return;
     }
+
+    // set the status
+    this.status = this.status || 200;
 
     // set the content-type only if not yet set
     var setType = !this.header['content-type'];

--- a/test/application.js
+++ b/test/application.js
@@ -119,7 +119,7 @@ describe('app.respond', function(){
       var app = koa();
 
       app.use(function *(){
-        this.status = 200;
+
       })
 
       var server = app.listen();
@@ -226,23 +226,6 @@ describe('app.respond', function(){
         .get('/')
         .expect(400)
         .expect('Bad Request', done);
-      })
-    })
-
-    describe('with status=200', function(){
-      it('should respond with a 404', function(done){
-        var app = koa();
-
-        app.use(function *(){
-          this.status = 200;
-        })
-
-        var server = app.listen();
-
-        request(server)
-        .get('/')
-        .expect(404)
-        .expect('Not Found', done);
       })
     })
 


### PR DESCRIPTION
just realized our current 404 handling is terrible. right now you have to do `if (this.status == 200 && this.body == null)`, which is really annoying and doesn't make sense at all. 

you now either have to set `this.status` or  `this.body`, which will automatically set the status code to `200` if not already set. so now you can just do `if (this.status)` to check whether has been "handled".

this is a backwards compatibility breaking change but IMO makes much more sense. this also drops support for `this.res.statusCode =`, which people shouldn't be doing anyways.

now, a 404 handler will look like this:

``` js
app.use(function* pagenotfound(next){
  yield next;
  if (this.status) return;
  this.status = 404;
  this.body = 'page not found';
})
```

which makes much more sense than the monstrosity we had before.

i just fixed the tests so that it works. i'll add more if you're okay with it.
