### PR TITLE
added set() and get() methods for settings in a koa app

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -10,6 +10,7 @@ var context = require('./context');
 var request = require('./request');
 var response = require('./response');
 var Cookies = require('cookies');
+var Keygrip = require('keygrip');
 var accepts = require('accepts');
 var assert = require('assert');
 var http = require('http');
@@ -40,10 +41,12 @@ function Application() {
   this.outputErrors = 'test' != this.env;
   this.subdomainOffset = 2;
   this.poweredBy = true;
+  this.jsonSpaces = 2;
   this.middleware = [];
   this.context = Object.create(context);
   this.request = Object.create(request);
   this.response = Object.create(response);
+  this.settings = {};
 }
 
 /**
@@ -62,10 +65,46 @@ Application.prototype.__proto__ = Emitter.prototype;
  * @api public
  */
 
-app.listen = function(){
+app.listen = function(port){
   debug('listen');
+  //post now is registered in the this.settings of the app so we can access it elsewhere.
+  if (typeof(port) === 'number') {
+    this.set('port', port || this.get('port') || 3000);
+  }
+
   var server = http.createServer(this.callback());
-  return server.listen.apply(server, arguments);
+  return server.listen.apply(server, [this.get('port')].concat(Array.prototype.slice.call(arguments, 1)));
+};
+
+/**
+ *  Adds key value store where we can access stuff in app that may be constants
+ *  example
+ *    var app = koa();
+ *    app.set('port', 3000);
+ *    app.listen(); //no longer have to put port here but you can overide it if desired
+ *    console.log('getting teh port?', app.get('port'));
+ *
+*/
+
+/**
+ *  @param key value
+ *  @return {application} self
+ * 
+ */
+
+app.set = function(key, val) {
+  this.settings[key] = val;
+  return this;
+};
+
+/**
+ *  @param key
+ *  @return value
+ * 
+*/
+
+app.get = function(key) {
+  return this.settings[key];
 };
 
 /**
@@ -103,6 +142,39 @@ app.callback = function(){
     fn.call(ctx, ctx.onerror);
   }
 };
+
+/**
+ * Set signed cookie keys.
+ *
+ * These are passed to [KeyGrip](https://github.com/jed/keygrip),
+ * however you may also pass your own `KeyGrip` instance. For
+ * example the following are acceptable:
+ *
+ *   app.keys = ['im a newer secret', 'i like turtle'];
+ *   app.keys = new KeyGrip(['im a newer secret', 'i like turtle'], 'sha256');
+ *
+ * @param {Array|KeyGrip} keys
+ * @api public
+ */
+
+app.__defineSetter__('keys', function(keys){
+  var ok = Array.isArray(keys) || keys instanceof Keygrip;
+  debug('keys %j', keys);
+  if (!ok) throw new TypeError('app.keys must be an array or Keygrip');
+  if (!(keys instanceof Keygrip)) keys = new Keygrip(keys);
+  this._keys = keys;
+});
+
+/**
+ * Get `Keygrip` instance.
+ *
+ * @return {Keygrip}
+ * @api public
+ */
+
+app.__defineGetter__('keys', function(){
+  return this._keys;
+});
 
 /**
  * Initialize a new context.
@@ -149,8 +221,6 @@ function *respond(next){
 
   yield *next;
 
-  if (false === this.respond) return;
-
   var res = this.res;
   if (res.headersSent || !res.socket.writable) return;
 
@@ -193,7 +263,7 @@ function *respond(next){
   }
 
   // body: json
-  body = JSON.stringify(body);
+  body = JSON.stringify(body, null, this.app.jsonSpaces);
   this.length = Buffer.byteLength(body);
   if (head) return res.end();
   res.end(body);


### PR DESCRIPTION
I wanted to be able to do
app.set('port', 3000);
and access it with 
app.get('port')

The key/value pairs are stored in this.settings to avoid naming conflicts. I also modified the original listen to set the port explicitly so that it can be accessed later. If its good, perhaps we can do the same for the other arguments?
