### PR TITLE
Improve html content sniffing

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -478,8 +478,19 @@ function escape(html) {
  *
  * @param {String} val
  * @return {Boolean}
+ * @api private
  */
 
 function isHtml(val) {
-  return ~val.indexOf('<')
+  // <!doctype html>             => true
+  // <!-- comments -->           => true
+  // <h1>Hello world!            => true
+  // < h2 >                      => false
+  // <3 u                        => false
+  // <------>                    => false
+  // a<b and a>c                 => false 
+  // Hello<br>world!             => false (rare case)
+
+  // Test whether it start with an html-like tag, doctype or comment.
+  return /^\s*<[a-z!]/i.test(val);
 }


### PR DESCRIPTION
Check existence of the `<` character seems too loose. I think most html outputs should start with a doctype, tag or comment.
