### PR TITLE
fix doc, getter of type is delegated to request

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -126,6 +126,7 @@ throw err;
   - `ctx.querystring`
   - `ctx.querystring=`
   - `ctx.length`
+  - `ctx.type`
   - `ctx.host`
   - `ctx.host=`
   - `ctx.fresh`
@@ -152,7 +153,6 @@ throw err;
   - `ctx.status`
   - `ctx.status=`
   - `ctx.length=`
-  - `ctx.type`
   - `ctx.type=`
   - `ctx.headerSent`
   - `ctx.redirect()`


### PR DESCRIPTION
Same kind of confusing thing as #215 mentioned, user have to remember that getters and setters of the `length` and `type` property are different.
