### PR TITLE
make res.charset also work before res.type

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -25,7 +25,8 @@ module.exports = {
    */
 
   set charset(val) {
-    this.set('Content-Type', this.type + '; charset=' + val);
+    this._charset = val;
+    this.type && this.set('Content-Type', this.type + '; charset=' + val);
   },
 
   /**
@@ -290,7 +291,10 @@ module.exports = {
     if (!~type.indexOf('/')) {
       type = mime.lookup(type);
       var cs = mime.charsets.lookup(type);
-      if (cs) type += '; charset=' + cs.toLowerCase();
+      cs = this._charset ? this._charset : (cs && cs.toLowerCase());
+      if (cs) type += '; charset=' + cs;
+    } else if (this._charset && !~type.indexOf(';')) {
+      type += '; charset=' + this._charset;
     }
 
     this.set('Content-Type', type);

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -30,6 +30,19 @@ describe('res.body=', function(){
       res.body = 'something';
       res.length.should.equal(9);
     })
+
+    describe('when charset is set', function (){
+      it('should not override charset', function (){
+        var res = response();
+        res.charset = 'gbk';
+
+        res.body = '<em>hey</em>';
+        assert('text/html; charset=gbk' == res.header['content-type']);
+
+        res.body = {foo: 'bar'};
+        assert('application/json; charset=gbk' == res.header['content-type']);
+      })
+    })
   })
 
   describe('when a string is given', function(){

--- a/test/response/charset.js
+++ b/test/response/charset.js
@@ -20,6 +20,21 @@ describe('ctx.charset=', function(){
       ctx.response.get('Content-Type').should.equal('text/plain; charset=utf8');
     })
   })
+
+  describe('before ctx.=type', function(){
+    it('should set it', function (){
+      var ctx = context();
+      ctx.charset = 'hey';
+      ctx.type = 'text/html';
+      ctx.response.get('Content-Type').should.equal('text/html; charset=hey');
+    })
+    it('should set by type', function (){
+      var ctx = context();
+      ctx.charset = 'hey';
+      ctx.type='text/html; charset=utf8';
+      ctx.response.get('Content-Type').should.equal('text/html; charset=utf8');
+    })
+  })
 })
 
 describe('ctx.charset', function(){


### PR DESCRIPTION
provide more friendly usage for res.charset
not longer need to put res.charset after res.type

```
res.charset = 'gbk';
res.type = 'text/html';

res.charset = 'gbk';
res.body = '<html></html>';

res.charset = 'gbk';
res.body = {foo: 'bar'}
```
