### PR TITLE
Let errors provide their own status.

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -71,7 +71,7 @@ var proto = module.exports = {
     }
 
     var err = msg instanceof Error ? msg : new Error(msg);
-    err.status = status || 500;
+    err.status = status || err.status || 500;
     err.expose = err.status < 500;
     throw err;
   },


### PR DESCRIPTION
When calling `ctx.throw`, you're allowed to provide an error object and a
status code. The status code is later set as the `status` property of the error
object. If no status code is provided, it defaults to 500. However, this
happens even if the error object already had a `status` property.

This commit allows an error's pre-existing `status` property to be used in
conjunction with `ctx.throw`.

If the status code is below 500, the error message will be exposed to the user
in the HTTP response. It would be nice to have some Error subclasses that
always have the same status code, because then we could just write
`ctx.throw(new WhateverError())`, and define which 4xx error code we want in
the definition of `WhateverError` itself. If, for example, an
`AuthenticationError` is always meant to go along with a 401, then it would be
nice to just have that knowledge in the class definition.
