### PR TITLE
hack inspect, display all the apis

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -71,6 +71,17 @@ app.listen = function(){
 };
 
 /**
+ * Inspect implementation.
+ *
+ * @return {Object}
+ * @api public
+ */
+
+app.inspect = function(){
+  return this.toJSON();
+};
+
+/**
  * Return JSON representation.
  *
  * @return {Object}

--- a/lib/context.js
+++ b/lib/context.js
@@ -5,6 +5,7 @@
 
 var debug = require('debug')('koa:context');
 var delegate = require('delegates');
+var show = require('show-methods');
 var http = require('http');
 
 /**
@@ -22,8 +23,9 @@ var proto = module.exports = {
 
   inspect: function(){
     return {
-      request: this.request,
-      response: this.response
+      request: this.request.toJSON(),
+      response: this.response.toJSON(),
+      apis: show(this)
     }
   },
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,6 +8,7 @@ var qs = require('querystring');
 var typeis = require('type-is');
 var fresh = require('fresh');
 var url = require('url');
+var show = require('show-methods');
 var parse = url.parse;
 var stringify = url.format;
 
@@ -578,7 +579,9 @@ module.exports = {
 
   inspect: function(){
     if (!this.req) return;
-    return this.toJSON();
+    var o = this.toJSON();
+    o.apis = show(this);
+    return o;
   },
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -9,6 +9,7 @@ var status = require('statuses');
 var http = require('http');
 var path = require('path');
 var mime = require('mime');
+var show = require('show-methods');
 var basename = path.basename;
 var extname = path.extname;
 
@@ -431,6 +432,7 @@ module.exports = {
     if (!this.res) return;
     var o = this.toJSON();
     o.body = this.body;
+    o.apis = show(this);
     return o;
   },
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "koa-compose": "~2.2.0",
     "cookies": "~0.4.0",
     "delegates": "0.0.3",
-    "only": "0.0.2"
+    "only": "0.0.2",
+    "show-methods": "0.0.2"
   },
   "devDependencies": {
     "should": "^3.1.0",

--- a/test/context.js
+++ b/test/context.js
@@ -5,7 +5,7 @@ var response = require('../lib/response');
 var koa = require('..');
 
 exports = module.exports = function(req, res){
-  req = req || { headers: {} };
+  req = req || { headers: {}, socket: {} };
   res = res || { _headers: {} };
   res.setHeader = function(k, v){ res._headers[k.toLowerCase()] = v };
   res.removeHeader = function(k, v){ delete res._headers[k.toLowerCase()] };

--- a/test/context/inspect.js
+++ b/test/context/inspect.js
@@ -1,0 +1,17 @@
+
+var util = require('util');
+var context = require('../context');
+
+describe('ctx.inspect()', function(){
+  it('should work', function(){
+    var ctx = context();
+
+    ctx.req.method = 'POST';
+    ctx.req.url = '/items';
+    ctx.req.headers['content-type'] = 'text/plain';
+    ctx.status = 200;
+    ctx.body = '<p>Hey</p>';
+
+    util.inspect(ctx).should.be.String;
+  })
+})

--- a/test/request/inspect.js
+++ b/test/request/inspect.js
@@ -1,0 +1,17 @@
+
+var util = require('util');
+var context = require('../context');
+
+describe('request.inspect()', function(){
+  it('should work', function(){
+    var ctx = context();
+
+    ctx.req.method = 'POST';
+    ctx.req.url = '/items';
+    ctx.req.headers['content-type'] = 'text/plain';
+    ctx.status = 200;
+    ctx.body = '<p>Hey</p>';
+
+    util.inspect(ctx.request).should.be.String;
+  })
+})

--- a/test/response/inspect.js
+++ b/test/response/inspect.js
@@ -1,0 +1,17 @@
+
+var util = require('util');
+var context = require('../context');
+
+describe('response.inspect()', function(){
+  it('should work', function(){
+    var ctx = context();
+
+    ctx.req.method = 'POST';
+    ctx.req.url = '/items';
+    ctx.req.headers['content-type'] = 'text/plain';
+    ctx.status = 200;
+    ctx.body = '<p>Hey</p>';
+
+    util.inspect(ctx.response).should.be.String;
+  })
+})


### PR DESCRIPTION
use [show-methods](https://github.com/dead-horse/show-methods) to list all the methods, accesses, getters and setters of ctx, ctx.request, ctx.response. 

related to #245, it is a little weird to list in `console.log`, but seems no easy way to do this now.
 a koa executable is awesome, but I think most people probably won't use it? 
and the `console.log` can also list all the methods that other middlewares add to `ctx`
