### PR TITLE
app: listen to `error` on next tick

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -40,7 +40,6 @@ exports = module.exports = Application;
 function Application() {
   if (!(this instanceof Application)) return new Application;
   this.env = process.env.NODE_ENV || 'development';
-  this.on('error', this.onerror);
   this.outputErrors = 'test' != this.env;
   this.subdomainOffset = 2;
   this.poweredBy = true;
@@ -48,6 +47,9 @@ function Application() {
   this.context = Object.create(context);
   this.request = Object.create(request);
   this.response = Object.create(response);
+  setImmediate(function(){
+    this.on('error', this.onerror);
+  }.bind(this));
 }
 
 /**


### PR DESCRIPTION
okay this is a really trivial issue. i'd like a way to "filter" errors from printing to `console.error`. right now, a bunch of `ECONNRESET` errors are being printed to the console because i have a client that frequently `.destroy()`s request. in other words, there are always those errors we don't care about because we can't do anything about.

one way we could do this is to create some sort of `.filterError` method, but more API? no thanks.

my solution is to set the `error` listener on next tick so i can set `.onerror` myself. of course i could do `app.removeListeners('error'); this.on('error', mylistener)`, but meh.
