### PR TITLE
request: complete idempotent methods

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -259,8 +259,8 @@ module.exports = {
    */
 
   get idempotent() {
-    return 'GET' == this.method
-      || 'HEAD' == this.method;
+    var idempotents = ['GET','HEAD','PUT','DELETE','OPTIONS','TRACE'];
+    return idempotents.indexOf(this.method) !== -1;
   },
 
   /**


### PR DESCRIPTION
see rfc2616: http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1.

Intact idempotent HTTP methods should be:
GET, HEAD, PUT, DELETE, OPTIONS and TRACE

And this should work based on [visionmedia/node-methods](https://github.com/visionmedia/node-methods)? I'm not sure but sure that this should be clear at this module.
/cc @koajs
