### PR TITLE
body: better outputs for object when debugging(development)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -206,7 +206,11 @@ function *respond(next) {
   if (body instanceof Stream) return body.pipe(res);
 
   // body: json
-  body = JSON.stringify(body);
+  if (this.env == 'development')
+    body = JSON.stringify(body, null, 4);
+  else
+    body = JSON.stringify(body);
+  
   this.length = Buffer.byteLength(body);
   res.end(body);
 }


### PR DESCRIPTION
I found a little lame part of this module
Sometimes in my debugging workflow(development env var to be set), I wanna use browser to view my JSON better, in express, I can define that string by myself like `JSON.stringify(obj, null, 4)`, and in koajs, `res.body=` is a true awesome setter that would convert object to JSON like this:

```
{"foo":5,"bar":6}
```

But what we actually expected in debugging time is following in development:

```
{
  "foo": 5,
  "bar": 6
}
```

Then based on this, I think `response` would be more hummable in all browsers when `NODE_ENV` has been set to `development`, this is the easiest way.

/cc @koajs
