### PR TITLE
s/properly/property/

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -106,7 +106,7 @@ throw err;
 
   To bypass Koa's built-in response handling, you may explicitly set `this.respond = false;`. Use this if you want to write to the raw `res` object instead of letting Koa handle the response for you.
 
-  Note that using this is __not__ supported by Koa. This may break intended functionality of Koa middleware and Koa itself. Using this properly is considered a hack and is only a convenience to those wishing to use traditional `fn(req, res)` functions and middleware within Koa.
+  Note that using this is __not__ supported by Koa. This may break intended functionality of Koa middleware and Koa itself. Using this property is considered a hack and is only a convenience to those wishing to use traditional `fn(req, res)` functions and middleware within Koa.
 
 ## Request aliases
 


### PR DESCRIPTION
Though it makes some sense either way, I'm guessing this should read 'property' instead of 'properly.'
