### PR TITLE
remove response.append(), use vary module

### DIFF
--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -243,12 +243,6 @@ this.response.lastModified = new Date();
 this.response.etag = crypto.createHash('md5').update(this.body).digest('hex');
 ```
 
-### res.append(field, val)
-
-  Append `val` to header `field`.
-
 ### res.vary(field)
 
   Vary on `field`.
-
-

--- a/lib/response.js
+++ b/lib/response.js
@@ -12,6 +12,7 @@ var status = require('statuses');
 var destroy = require('dethroy');
 var http = require('http');
 var path = require('path');
+var vary = require('vary');
 var basename = path.basename;
 var extname = path.extname;
 
@@ -201,7 +202,7 @@ module.exports = {
    */
 
   vary: function(field){
-    this.append('Vary', field);
+    vary(this.res, field);
   },
 
   /**
@@ -391,28 +392,6 @@ module.exports = {
 
   remove: function(field){
     this.res.removeHeader(field);
-  },
-
-  /**
-   * Append `val` to header `field`.
-   *
-   * @param {String} field
-   * @param {String} val
-   * @api public
-   */
-
-  append: function(field, val){
-    field = field.toLowerCase();
-    var header = this.header;
-    var list = header[field];
-
-    // not set
-    if (!list) return this.set(field, val);
-
-    // append
-    list = list.split(/ *, */);
-    if (!~list.indexOf(val)) list.push(val);
-    this.set(field, list.join(', '));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "delegates": "0.0.3",
     "dethroy": "~1.0.0",
     "error-inject": "~1.0.0",
+    "vary": "~0.1.0",
     "only": "0.0.2"
   },
   "devDependencies": {

--- a/test/context.js
+++ b/test/context.js
@@ -8,6 +8,7 @@ var koa = require('..');
 exports = module.exports = function(req, res){
   req = req || { headers: {}, socket: new ReadableStream() };
   res = res || { _headers: {} };
+  res.getHeader = function(k){ return res._headers[k.toLowerCase()] };
   res.setHeader = function(k, v){ res._headers[k.toLowerCase()] = v };
   res.removeHeader = function(k, v){ delete res._headers[k.toLowerCase()] };
   return koa().createContext(req, res);


### PR DESCRIPTION
basically, `response.append()` was only really used for `vary()` and it doesn't really have a use-case for other headers. so why not just remove it? now we've got the [vary](https://github.com/expressjs/vary) module.
