### PR TITLE
context: delegate etag/last-modified

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -139,10 +139,10 @@ delegate(proto, 'response')
   .access('body')
   .access('length')
   .access('type')
+  .access('lastModified')
+  .access('etag')
   .getter('headerSent')
-  .getter('writable')
-  .setter('lastModified')
-  .setter('etag');
+  .getter('writable');
 
 /**
  * Request delegation.

--- a/lib/response.js
+++ b/lib/response.js
@@ -322,6 +322,17 @@ module.exports = {
   },
 
   /**
+   * Get the ETag of a response.
+   *
+   * @return {String}
+   * @api public
+   */
+
+  get etag() {
+    return this.get('ETag');
+  },
+
+  /**
    * Return the request mime type void of
    * parameters such as "charset".
    *


### PR DESCRIPTION
i think both getting/setting etags and last-modified headers are useful. this PRs just makes it consistent all around
