### PR TITLE
application: returns 400 when content-range is set in PUT

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -196,6 +196,12 @@ function *respond(next) {
     return res.end();
   }
 
+  // for more semantics, see rfc7231
+  if ('PUT' == this.method && this.request.header['content-range']) {
+    this.status = 400;
+    body = status[this.status];
+  }
+
   // status body
   if (null == body) {
     this.type = 'text';

--- a/test/application.js
+++ b/test/application.js
@@ -271,6 +271,19 @@ describe('app.respond', function(){
     })
   })
 
+  describe('when PUT is used and Content-Range is set', function(){
+    it('should 400', function(done){
+      var app = koa();
+
+      var server = app.listen();
+
+      request(server)
+      .put('/')
+      .set('Content-Range', 'bytes 21010-47021/47022')
+      .expect(400, done);
+    })
+  })
+
   describe('when no middleware are present', function(){
     it('should 404', function(done){
       var app = koa();


### PR DESCRIPTION
see the new HTTP draft: http://tools.ietf.org/html/rfc7231

> An origin server that allows PUT on a given target resource MUST send a 400 (Bad Request) response to a PUT request that contains a Content-Range header field

Range request would be the next huge job for every common http framework IMO, then start from here.
:P
