### PR TITLE
use closure instead of .bind()

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -140,7 +140,10 @@ app.createContext = function(req, res){
   request.ctx = response.ctx = context;
   request.response = response;
   response.request = request;
-  context.onerror = context.onerror.bind(context);
+  var onerror = context.onerror;
+  context.onerror = function(err){
+    onerror.call(context, err);
+  };
   context.originalUrl = request.originalUrl = req.url;
   context.cookies = new Cookies(req, res, this.keys);
   context.accept = request.accept = accepts(req);

--- a/lib/response.js
+++ b/lib/response.js
@@ -127,7 +127,9 @@ module.exports = {
 
     // stream
     if ('function' == typeof val.pipe) {
-      onfinish(this, destroy.bind(null, val));
+      onfinish(this, function(){
+        destroy(val);
+      });
       ensureErrorHandler(val, this.ctx.onerror);
 
       // overwriting


### PR DESCRIPTION
i've run the benchmark several times in my laptop. there is a slightly performance improve.

node v0.11.12.(test on 0.11.13, bind is slower than closure as well)
before

```
  1 middleware
  9361.78

  5 middleware
  9277.84

  10 middleware
  9166.20

  15 middleware
  8954.21

  20 middleware
  8771.13

  30 middleware
  8590.82

  50 middleware
  8118.87

  100 middleware
  7134.31
```

after

```
  1 middleware
  9690.68

  5 middleware
  9637.66

  10 middleware
  9449.17

  15 middleware
  9285.14

  20 middleware
  8922.27

  30 middleware
  8755.52

  50 middleware
  8418.54

  100 middleware
  7242.11
```
