### PR TITLE
Onerror status

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -75,7 +75,7 @@ var proto = module.exports = {
 
     var err = msg instanceof Error ? msg : new Error(msg);
     err.status = status || err.status || 500;
-    err.expose = err.status < 500;
+    err.expose = 'number' == typeof err.status && http.STATUS_CODES[err.status] && err.status < 500;
     throw err;
   },
 

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -50,6 +50,7 @@ describe('ctx.onerror(err)', function(){
       done();
     })
   })
+
   describe('when invalid err.status', function(){
     describe('not number', function(){
       it('should respond 500', function(done){
@@ -59,7 +60,7 @@ describe('ctx.onerror(err)', function(){
           this.body = 'something else';
           var err = new Error('some error');
           err.status = 'notnumber';
-          this.throw(err);
+          throw err;
         })
 
         var server = app.listen();
@@ -80,7 +81,7 @@ describe('ctx.onerror(err)', function(){
           this.body = 'something else';
           var err = new Error('some error');
           err.status = 9999;
-          this.throw(err);
+          throw err;
         })
 
         var server = app.listen();

--- a/test/context/throw.js
+++ b/test/context/throw.js
@@ -10,7 +10,7 @@ describe('ctx.throw(msg)', function(){
       ctx.throw('boom');
     } catch (err) {
       assert(500 == err.status);
-      assert(false === err.expose);
+      assert(!err.expose);
       done();
     }
   })
@@ -26,6 +26,7 @@ describe('ctx.throw(err)', function(){
     } catch (err) {
       assert(500 == err.status);
       assert('test' == err.message);
+      assert(!err.expose);
       done();
     }
   })
@@ -41,6 +42,7 @@ describe('ctx.throw(err, status)', function(){
     } catch (err) {
       assert(422 == err.status);
       assert('test' == err.message);
+      assert(true === err.expose);
       done();
     }
   })
@@ -56,6 +58,7 @@ describe('ctx.throw(status, err)', function(){
     } catch (err) {
       assert(422 == err.status);
       assert('test' == err.message);
+      assert(true === err.expose);
       done();
     }
   })
@@ -70,6 +73,7 @@ describe('ctx.throw(msg, status)', function(){
     } catch (err) {
       assert('name required' == err.message);
       assert(400 == err.status);
+      assert(true === err.expose);
       done();
     }
   })
@@ -84,6 +88,7 @@ describe('ctx.throw(status, msg)', function(){
     } catch (err) {
       assert('name required' == err.message);
       assert(400 == err.status);
+      assert(true === err.expose);
       done();
     }
   })
@@ -98,7 +103,24 @@ describe('ctx.throw(status)', function(){
     } catch (err) {
       assert('Bad Request' == err.message);
       assert(400 == err.status);
+      assert(true === err.expose);
       done();
     }
+  })
+
+  describe('when not valid status', function(){
+    it('should not expose', function(done){
+      var ctx = context();
+
+      try {
+        var err = new Error('some error');
+        err.status = -1;
+        ctx.throw(err);
+      } catch(err) {
+        assert('some error' == err.message);
+        assert(!err.expose);
+        done();
+      }
+    })
   })
 })


### PR DESCRIPTION
```
var err = new Error('msg');
err.status = -1;

throw err;
```

`ctx.onerror` call `response.status = err.status`, lead to `uncaughtException`.

```
var err = new Error('msg');
err.message = -1;

this.throw(err);
```

will set `err.expose = true`.
