### PR TITLE
improve set prototype chain performance

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -43,9 +43,9 @@ function Application() {
   this.subdomainOffset = 2;
   this.poweredBy = true;
   this.middleware = [];
-  this.context = Object.create(context);
-  this.request = Object.create(request);
-  this.response = Object.create(response);
+  this.context = { __proto__: context };
+  this.request = { __proto__: request };
+  this.response = { __proto__: response };
 }
 
 /**
@@ -133,9 +133,9 @@ app.callback = function(){
  */
 
 app.createContext = function(req, res){
-  var context = Object.create(this.context);
-  var request = context.request = Object.create(this.request);
-  var response = context.response = Object.create(this.response);
+  var context = { __proto__: this.context };
+  var request = context.request = { __proto__: this.request };
+  var response = context.response = { __proto__: this.response };
   context.app = request.app = response.app = this;
   context.req = request.req = response.req = req;
   context.res = request.res = response.res = res;


### PR DESCRIPTION
On my Mac OS, the benchmark result is:

before:

``` javascript
  1 middleware
  6527.24

  5 middleware
  6170.98

  10 middleware
  6123.54

  15 middleware
  6169.90

  20 middleware
  5985.76

  30 middleware
  5832.96

  50 middleware
  5594.65

  100 middleware
  5148.62
```

after:

``` javascript
  1 middleware
  5683.58

  5 middleware
  5987.54

  10 middleware
  6065.03

  15 middleware
  6042.75

  20 middleware
  6042.96

  30 middleware
  5729.14

  50 middleware
  5659.19

  100 middleware
  5081.91
```
