### PR TITLE
add: ctx.locals as a recommended namespace for passing information to the frontend

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -50,6 +50,14 @@ app.use(function *(){
 
   A koa `Response` object.
 
+### ctx.state
+
+  The recommended namespace for passing information through middleware and to your frontend views.
+
+```js
+this.state.user = yield User.find(id);
+```
+
 ### ctx.app
 
   Application instance reference.

--- a/lib/application.js
+++ b/lib/application.js
@@ -146,6 +146,7 @@ app.createContext = function(req, res){
   context.originalUrl = request.originalUrl = req.url;
   context.cookies = new Cookies(req, res, this.keys);
   context.accept = request.accept = accepts(req);
+  context.state = {};
   return context;
 };
 

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -1,0 +1,21 @@
+
+var request = require('supertest');
+var assert = require('assert');
+var koa = require('../..');
+
+describe('ctx.state', function() {
+  it('should provide a ctx.state namespace', function(done) {
+    var app = koa();
+
+    app.use(function *() {
+      assert.deepEqual(this.state, {});
+    });
+
+    var server = app.listen();
+
+    request(server)
+    .get('/')
+    .expect(404)
+    .end(done);
+  })
+})


### PR DESCRIPTION
Just throwing this PR out there. It was discussed in: https://github.com/koajs/koa/issues/338.

Basically this gives you a namespace to attach to that you don't have to worry about this object being undefined. Alternatively, you could always add: 

``` js
app.use(function *(next) {
  this.locals = this.locals || {};
  yield next;
});
```

at the top of your stack. I feel like this is common enough use-case that it should be added to core, but open to your thoughts.
