### PR TITLE
remove the 'x-powered-by' in context test since it has been removed

### DIFF
--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -45,7 +45,6 @@ describe('ctx.onerror(err)', function(){
 
       res.headers.should.not.have.property('vary');
       res.headers.should.not.have.property('x-csrf-token');
-      res.headers.should.not.have.property('x-powered-by');
 
       done();
     })


### PR DESCRIPTION
since TJ removed the  `x-powered-by`, there still one test associated with it in context test even it does not influence the others tests.
