### PR TITLE
Fix url.format taking into account path on node@0.11.15

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -117,6 +117,8 @@ module.exports = {
   set path(path) {
     var url = parse(this.req);
     url.pathname = path;
+    url.path = null;
+
     this.url = stringify(url);
   },
 
@@ -167,6 +169,8 @@ module.exports = {
   set querystring(str) {
     var url = parse(this.req);
     url.search = str;
+    url.path = null;
+
     this.url = stringify(url);
   },
 


### PR DESCRIPTION
`node@0.11.15` was released with a patch that adds support for `path` to url.format (https://github.com/joyent/node/commit/d312b6d15c69cf4c438ed7d884e6396c481a57f6). This means that koa 0.15.0 is effectively incompatible with this node version - the next build on travis will fail for sure without a patch like this.

However, this completely broke `npm install` for git+ssh urls and as such has been reverted on io.js, making it work like on `node@0.11.14` again (https://github.com/iojs/io.js/commit/913addbff5481567262c387cef9594f809e4ef83).

I'm not sure if my solution is acceptable, but it is cross-compatible with `node@0.11.14`/`node@0.11.15`/`io.js@1.0.3`.

