### PR TITLE
Add io.js to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: node_js
 node_js:
   - "0.11"
+env:
+  global:
+    - IOJS_VERSION="v1.0.4"
+  matrix:
+    - BIN="iojs" FLAGS=""
+    - BIN="node" FLAGS="--harmony-generators"
+before_install:
+  - "[ $BIN != 'iojs' ] || (wget https://iojs.org/dist/${IOJS_VERSION}/iojs-${IOJS_VERSION}-linux-x64.tar.xz && sudo tar xJf iojs-${IOJS_VERSION}-linux-x64.tar.xz -C /opt && rm iojs-${IOJS_VERSION}-linux-x64.tar.xz)"
+  - "[ $BIN != 'iojs' ] || (sudo ln -s /opt/iojs-${IOJS_VERSION}-linux-x64/bin/iojs /usr/local/bin/iojs && sudo chmod +x /usr/local/bin/iojs)"
 script: "make test-travis"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,25 @@ SRC = lib/*.js
 
 include node_modules/make-lint/index.mk
 
+BIN ?= node
+
+FLAGS ?= --harmony-generators
+
 TESTS = test/application \
 	test/context/* \
 	test/request/* \
 	test/response/*
 
 test:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/_mocha \
 		--require should \
-		--harmony-generators \
 		$(TESTS) \
 		--bail
 
 test-cov:
-	@NODE_ENV=test node --harmony-generators \
-		node_modules/.bin/istanbul cover \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		-- -u exports \
 		--require should \
@@ -25,8 +29,8 @@ test-cov:
 		--bail
 
 test-travis:
-	@NODE_ENV=test node --harmony-generators \
-		node_modules/.bin/istanbul cover \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		--report lcovonly \
 		-- -u exports \


### PR DESCRIPTION
Needed to make it easier to test against different versions of node/io.js binaries locally and took the chance to add interim support for travis as well. 
