### PR TITLE
Change request's "ips" regex to match others.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -381,7 +381,7 @@ module.exports = {
     var proxy = this.app.proxy;
     var val = this.get('X-Forwarded-For');
     return proxy && val
-      ? val.split(/ *, */)
+      ? val.split(/\s*,\s*/)
       : [];
   },
 


### PR DESCRIPTION
So I am in this silly quest of cloning the repo, deleting all the code on it and rewriting it again step by step to pass the tests. It is a acceptable way to learn how koa works.

Anyway, I saw that the regex used in `ips` doesn't match the others on the file, so I thought it would be good to change it.