### PR TITLE
Re-enable io.js support on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.11"
+  - iojs
 script: "make test-travis"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-
 SRC = lib/*.js
 
 include node_modules/make-lint/index.mk
+
+BIN = iojs
+
+ifeq ($(findstring io.js, $(shell which node)),)
+	BIN = node
+endif
+
+ifeq (node, $(BIN))
+	FLAGS = --harmony-generators
+endif
 
 TESTS = test/application \
 	test/context/* \
@@ -9,15 +18,15 @@ TESTS = test/application \
 	test/response/*
 
 test:
-	@NODE_ENV=test ./node_modules/.bin/mocha \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/_mocha \
 		--require should \
-		--harmony \
 		$(TESTS) \
 		--bail
 
 test-cov:
-	@NODE_ENV=test node --harmony \
-		node_modules/.bin/istanbul cover \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		-- -u exports \
 		--require should \
@@ -25,8 +34,8 @@ test-cov:
 		--bail
 
 test-travis:
-	@NODE_ENV=test node --harmony \
-		node_modules/.bin/istanbul cover \
+	@NODE_ENV=test $(BIN) $(FLAGS) \
+		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		--report lcovonly \
 		-- -u exports \


### PR DESCRIPTION
On the 3rd of February, the planned roll out on Travis was reverted
and is now rescheduled for a later date. This commit re-enables io.js
support on Travis due the original one been reverted.

For more information on what caused the rollback, check the Travis status page:

http://www.traviscistatus.com/incidents/wpfs5nz0ybks

For a follow up on a possible rescheduled update, see:

http://docs.travis-ci.com/user/build-environment-updates/2015-02-03/

*[WIP]* until io.js support is added back to Travis.