### PR TITLE
Make `npm test` work with io.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ TESTS = test/application \
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--require should \
-		--harmony-generators \
+		--harmony \
 		$(TESTS) \
 		--bail
 
 test-cov:
-	@NODE_ENV=test node --harmony-generators \
+	@NODE_ENV=test node --harmony \
 		node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		-- -u exports \
@@ -25,7 +25,7 @@ test-cov:
 		--bail
 
 test-travis:
-	@NODE_ENV=test node --harmony-generators \
+	@NODE_ENV=test node --harmony \
 		node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		--report lcovonly \


### PR DESCRIPTION
Hey guys,

I understand that supporting io.js in `.travis.yml ` is a WIP, which surely will make some changes to Makefile, but this commit still makes sense if you need to run `npm test` locally.

However,  the ``` `node -v` == v0* ``` part is ugly. Any better idea? :)

Thanks.