### PR TITLE
onerror: Retain CORS headers on error

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -121,7 +121,7 @@ var proto = module.exports = {
     var corsHeaders = {};
 
     for (var key in this.res._headers) {
-      if (key.indexOf('Access-Control-') === 0) {
+      if (key.indexOf('access-control-') === 0) {
         corsHeaders[key] = this.res._headers[key];
       }
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -116,8 +116,19 @@ var proto = module.exports = {
       return;
     }
 
-    // unset all headers
-    this.res._headers = {};
+    //Before we can unset all headers, we need
+    //to copy over the CORS headers.
+    var corsHeaders = {};
+
+    for (var key in this.res._headers) {
+      if (key.indexOf('Access-Control-') === 0) {
+        corsHeaders[key] = this.res._headers[key];
+      }
+    }
+
+    // unset all headers except for CORS
+    // headers.
+    this.res._headers = corsHeaders;
 
     // force text/plain
     this.type = 'text';

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -50,6 +50,46 @@ describe('ctx.onerror(err)', function(){
     })
   })
 
+  it('should unset all headers except cors', function(done){
+    var app = koa();
+
+    app.use(function *(next){
+      this.set('Vary', 'Accept-Encoding');
+      this.set('X-CSRF-Token', 'asdf');
+      this.set('Access-Control-Allow-Origin', 'koaisawesome.js');
+      this.set('Access-Control-Expose-Headers', 'something');
+      this.set('Access-Control-Max-Age', '88');
+      this.set('Access-Control-Allow-Credentials', true);
+      this.set('Access-Control-Allow-Methods', 'GET,POST,KOA');
+      this.set('Access-Control-Allow-Headers', 'asdf');
+      this.body = 'response';
+
+      this.throw(418, 'boom');
+    })
+
+    var server = app.listen();
+
+    request(server)
+    .get('/')
+    .expect(418)
+    .expect('Content-Type', 'text/plain; charset=utf-8')
+    .expect('Content-Length', '4')
+    .end(function(err, res){
+      if (err) return done(err);
+
+      res.headers.should.not.have.property('vary');
+      res.headers.should.not.have.property('x-csrf-token');
+      res.headers.should.have.property('access-control-allow-origin');
+      res.headers.should.have.property('access-control-expose-headers');
+      res.headers.should.have.property('access-control-max-age');
+      res.headers.should.have.property('access-control-allow-credentials');
+      res.headers.should.have.property('access-control-allow-methods');
+      res.headers.should.have.property('access-control-allow-headers');
+
+      done();
+    })
+  })
+
   describe('when invalid err.status', function(){
     describe('not number', function(){
       it('should respond 500', function(done){


### PR DESCRIPTION
Fixes #411

* Any errors will now properly pass along CORS headers
* Add unit test for it