### PR TITLE
add experimental async function support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ endif
 TESTS = test/application \
 	test/context/* \
 	test/request/* \
-	test/response/*
+	test/response/* \
+	test/experimental/index.js
 
 test:
 	@NODE_ENV=test $(BIN) $(FLAGS) \

--- a/lib/application.js
+++ b/lib/application.js
@@ -4,6 +4,7 @@
 
 var debug = require('debug')('koa:application');
 var Emitter = require('events').EventEmitter;
+var compose_es7 = require('composition');
 var onFinished = require('on-finished');
 var response = require('./response');
 var compose = require('koa-compose');
@@ -94,7 +95,10 @@ app.toJSON = function(){
  */
 
 app.use = function(fn){
-  assert(fn && 'GeneratorFunction' == fn.constructor.name, 'app.use() requires a generator function');
+  if (!this.experimental) {
+    // es7 async functions are allowed
+    assert(fn && 'GeneratorFunction' == fn.constructor.name, 'app.use() requires a generator function');
+  }
   debug('use %s', fn._name || fn.name || '-');
   this.middleware.push(fn);
   return this;
@@ -110,8 +114,9 @@ app.use = function(fn){
 
 app.callback = function(){
   var mw = [respond].concat(this.middleware);
-  var gen = compose(mw);
-  var fn = co.wrap(gen);
+  var fn = this.experimental
+    ? compose_es7(mw)
+    : co.wrap(compose(mw));
   var self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "^1.2.2",
-    "co": "^4.1.0",
+    "co": "^4.4.0",
+    "composition": "^2.1.1",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
     "cookies": "~0.5.0",
@@ -42,6 +43,7 @@
     "vary": "^1.0.0"
   },
   "devDependencies": {
+    "6to5": "^3.6.5",
     "istanbul-harmony": "~0.3.0",
     "make-lint": "^1.0.1",
     "mocha": "^2.0.1",

--- a/test/application.js
+++ b/test/application.js
@@ -104,15 +104,20 @@ describe('app.use(fn)', function(){
     });
   })
 
-  it('should error when a non-generator function is passed', function(done){
+  it('should error when a non-generator function is passed', function(){
     var app = koa();
 
     try {
       app.use(function(){});
     } catch (err) {
       err.message.should.equal('app.use() requires a generator function');
-      done();
     }
+  })
+
+  it('should not error when a non-generator function is passed when .experimental=true', function(){
+    var app = koa();
+    app.experimental = true;
+    app.use(function(){});
   })
 })
 

--- a/test/experimental/async.js
+++ b/test/experimental/async.js
@@ -1,0 +1,23 @@
+
+/**
+ * Separate file primarily because we use `require('6to5/register')`.
+ */
+
+var request = require('supertest');
+var koa = require('../..');
+
+describe('.experimental=true', function () {
+  it('should support async functions', function (done) {
+    var app = koa();
+    app.experimental = true;
+    app.use(async function (next) {
+      var string = await Promise.resolve('asdf');
+      this.body = string;
+    });
+
+    request(app.callback())
+    .get('/')
+    .expect('asdf')
+    .expect(200, done);
+  })
+})

--- a/test/experimental/index.js
+++ b/test/experimental/index.js
@@ -1,0 +1,4 @@
+require('6to5/register')({
+  optional: ['asyncToGenerator']
+});
+require('./async');


### PR DESCRIPTION
requires `regenerator` or `6to5` to actually use. enabled by setting `app.experimental = true`. it's probably going to be a lot slower. if we merge this, i'd like to get feedback on https://github.com/thenables/composition. maybe add a benchmark with it.

closes https://github.com/koajs/koa/issues/339