### PR TITLE
make sure req.host and req.hostname return strict string

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -212,7 +212,7 @@ module.exports = {
     var proxy = this.app.proxy;
     var host = proxy && this.get('X-Forwarded-Host');
     host = host || this.get('Host');
-    if (!host) return;
+    if (!host) return '';
     return host.split(/\s*,\s*/)[0];
   },
 
@@ -227,7 +227,7 @@ module.exports = {
 
   get hostname() {
     var host = this.host;
-    if (!host) return;
+    if (!host) return '';
     return host.split(':')[0];
   },
 

--- a/test/request/host.js
+++ b/test/request/host.js
@@ -10,9 +10,9 @@ describe('req.host', function(){
   })
 
   describe('with no host present', function(){
-    it('should return null', function(){
+    it('should return ""', function(){
       var req = request();
-      assert(null == req.host);
+      assert.equal(req.host, '');
     })
   })
 

--- a/test/request/hostname.js
+++ b/test/request/hostname.js
@@ -10,9 +10,9 @@ describe('req.hostname', function(){
   })
 
   describe('with no host present', function(){
-    it('should return null', function(){
+    it('should return ""', function(){
       var req = request();
-      assert(null == req.hostname);
+      assert.equal(req.hostname, '');
     })
   })
 


### PR DESCRIPTION
It will more convenient to use `this.host` as a strict string, like `this.host.split('.')`.

Otherwise we need to detect `this.host` is string or undefined first.

```js
if (typeof this.host === 'string') {
  // dosomething ...
} else {

}
```