### PR TITLE
make sure helpers return strict string

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -301,9 +301,9 @@ module.exports = {
 
   get charset() {
     var type = this.get('Content-Type');
-    if (!type) return;
+    if (!type) return '';
 
-    return contentType.parse(type).parameters.charset;
+    return contentType.parse(type).parameters.charset || '';
   },
 
   /**
@@ -315,7 +315,7 @@ module.exports = {
 
   get length() {
     var len = this.get('Content-Length');
-    if (null == len) return;
+    if (len == '') return;
     return ~~len;
   },
 
@@ -362,7 +362,7 @@ module.exports = {
    */
 
   get ip() {
-    return this.ips[0] || this.socket.remoteAddress;
+    return this.ips[0] || this.socket.remoteAddress || '';
   },
 
   /**
@@ -546,7 +546,7 @@ module.exports = {
 
   get type() {
     var type = this.get('Content-Type');
-    if (!type) return;
+    if (!type) return '';
     return type.split(';')[0];
   },
 
@@ -577,9 +577,9 @@ module.exports = {
     switch (field = field.toLowerCase()) {
       case 'referer':
       case 'referrer':
-        return req.headers.referrer || req.headers.referer;
+        return req.headers.referrer || req.headers.referer || '';
       default:
-        return req.headers[field];
+        return req.headers[field] || '';
     }
   },
 
@@ -607,6 +607,6 @@ module.exports = {
       method: this.method,
       url: this.url,
       header: this.header
-    }
+    };
   }
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -367,7 +367,7 @@ module.exports = {
 
   get type() {
     var type = this.get('Content-Type');
-    if (!type) return;
+    if (!type) return '';
     return type.split(';')[0];
   },
 
@@ -404,7 +404,7 @@ module.exports = {
    */
 
   get: function(field){
-    return this.header[field.toLowerCase()];
+    return this.header[field.toLowerCase()] || '';
   },
 
   /**
@@ -512,6 +512,6 @@ module.exports = {
       status: this.status,
       message: this.message,
       header: this.header
-    }
+    };
   }
 };

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -4,17 +4,17 @@ var assert = require('assert');
 
 describe('req.charset', function(){
   describe('with no content-type present', function(){
-    it('should return null', function(){
+    it('should return ""', function(){
       var req = request();
-      assert(null == req.charset);
+      assert('' === req.charset);
     })
   })
 
   describe('with charset present', function(){
-    it('should return null', function(){
+    it('should return ""', function(){
       var req = request();
       req.header['content-type'] = 'text/plain';
-      assert(null == req.charset);
+      assert('' === req.charset);
     })
   })
 

--- a/test/request/type.js
+++ b/test/request/type.js
@@ -11,6 +11,6 @@ describe('req.type', function(){
 
   describe('with no host present', function(){
     var req = request();
-    assert(null == req.type);
+    assert('' === req.type);
   })
 })

--- a/test/response/type.js
+++ b/test/response/type.js
@@ -51,10 +51,10 @@ describe('ctx.type=', function(){
 
 describe('ctx.type', function(){
   describe('with no Content-Type', function(){
-    it('should return null', function(){
+    it('should return ""', function(){
       var ctx = context();
       // TODO: this is lame
-      assert(null == ctx.type);
+      assert('' === ctx.type);
     })
   })
 


### PR DESCRIPTION
not sure if this is look good to everyone, but it reduce lots of code like:

```
(this.charset || '').toLowerCase();
(this.get('ua') || '').indexOf('chrome');
(this.type || '').match(/^text/);
```

and this won't break your app if your are using `!this.get('referer')` etc.