### PR TITLE
return same object from request.query

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -131,8 +131,6 @@ module.exports = {
 
   get query() {
     var str = this.querystring;
-    if (!str) return {};
-
     var c = this._querycache = this._querycache || {};
     return c[str] || (c[str] = qs.parse(str));
   },

--- a/test/request/query.js
+++ b/test/request/query.js
@@ -7,6 +7,13 @@ describe('ctx.query', function(){
       var ctx = context({ url: '/' });
       ctx.query.should.eql({});
     })
+
+    it('should return the same object each time it\'s accessed', function(done) {
+      var ctx = context({ url: '/' });
+      ctx.query.a = '2';
+      ctx.query.a.should.equal('2');
+      done();
+    });
   })
 
   it('should return a parsed query-string', function(){


### PR DESCRIPTION
Before this change, calling request.query when there was no querystring
resulted in a new object created and returned each time. If the resulting
object was ever changed, accessing request.query would not reflect it and
cause weird bugs.