### PR TITLE
upgrade supertest to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "make-lint": "^1.0.1",
     "mocha": "^2.0.1",
     "should": "^3.1.0",
-    "supertest": "~0.15.0",
+    "supertest": "^1.0.1",
     "test-console": "^0.7.1"
   },
   "engines": {

--- a/test/application.js
+++ b/test/application.js
@@ -105,6 +105,7 @@ describe('app.use(fn)', function(){
 
     request(server)
     .get('/')
+    .expect(404)
     .end(function(err){
       if (err) return done(err);
       calls.should.eql([1,2,3,4,5,6]);


### PR DESCRIPTION
Just help to close the #444 in my way, upgrade the `supertest` version and make the test cases be green.

/cc @jonathanong