### PR TITLE
allow content type specification on this.throw

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -115,11 +115,13 @@ var proto = module.exports = {
       return;
     }
 
+    var contentType = this.type
+
     // unset all headers
     this.res._headers = {};
 
-    // force text/plain
-    this.type = 'text';
+    // force text/plain if not specified
+    if (!contentType) this.type = 'text';
 
     // ENOENT support
     if ('ENOENT' == err.code) err.status = 404;


### PR DESCRIPTION
This is useful when someone wants to return application/json error messages to clients using this.throw