### PR TITLE
add this.req check at querystring() method

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -154,6 +154,7 @@ module.exports = {
    */
 
   get querystring() {
+    if (!this.req) return '';
     return parse(this.req).query || '';
   },
 


### PR DESCRIPTION
If connection drop by client-side and use post-query logging (for example winston wrapper), then cause a error "Cannot read property 'url' of undefined" at parse() method

This pull request fix a problem