### PR TITLE
Do not log on expected http errors

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -163,7 +163,7 @@ app.createContext = function(req, res){
 app.onerror = function(err){
   assert(err instanceof Error, 'non-error thrown: ' + err);
 
-  if (404 == err.status) return;
+  if (404 == err.status || err.expose) return;
   if ('test' == this.env) return;
 
   var msg = err.stack || err.toString();


### PR DESCRIPTION
When using `this.assert` and `this.throw`, I don't think it is appropriate to log the http error since it is a completely expected error. For example, 400 client errors (missing username and such) are things I would like the client to know about, but I definitely don't want it to be included in my logs. Checking the `expose` property allows filtering of expected errors, but still maintains error logs for errors that one might be interested in like actual code errors or other 500 errors. 