### PR TITLE
remove anti pattern

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -174,7 +174,7 @@ app.onerror = function(err){
 };
 
 /**
- * Response middleware.
+ * Response helper.
  */
 
 function respond() {

--- a/lib/application.js
+++ b/lib/application.js
@@ -125,7 +125,7 @@ app.callback = function(){
     var ctx = self.createContext(req, res);
     onFinished(res, ctx.onerror);
     fn.call(ctx).then(function () {
-      respond.call(ctx)
+      respond.call(ctx);
     }).catch(ctx.onerror);
   }
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -113,10 +113,9 @@ app.use = function(fn){
  */
 
 app.callback = function(){
-  var mw = [respond].concat(this.middleware);
   var fn = this.experimental
-    ? compose_es7(mw)
-    : co.wrap(compose(mw));
+    ? compose_es7(this.middleware)
+    : co.wrap(compose(this.middleware));
   var self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);
@@ -125,7 +124,9 @@ app.callback = function(){
     res.statusCode = 404;
     var ctx = self.createContext(req, res);
     onFinished(res, ctx.onerror);
-    fn.call(ctx).catch(ctx.onerror);
+    fn.call(ctx).then(function () {
+      respond.call(ctx)
+    }).catch(ctx.onerror);
   }
 };
 
@@ -176,9 +177,7 @@ app.onerror = function(err){
  * Response middleware.
  */
 
-function *respond(next) {
-  yield *next;
-
+function respond() {
   // allow bypassing koa
   if (false === this.respond) return;
 


### PR DESCRIPTION
remove `yield* next` in lib/application, which caused annoy `A promise
was converted into a generator …` message.

benchmark result:
* when bench with native Promise, it has no impact for both stable and
experimental ones.
* when bench with Bluebird, it’s about 5-10% faster than original for
both stable and experimental ones.