### PR TITLE
Fix typo in test

### DIFF
--- a/test/request/ip.js
+++ b/test/request/ip.js
@@ -13,7 +13,7 @@ describe('req.ip', function(){
   })
 
   describe('with no req.ips present', function(){
-    it('should return req.socket.removeAddress', function(){
+    it('should return req.socket.remoteAddress', function(){
       var req = request();
       req.socket.remoteAddress = '127.0.0.2';
       req.ip.should.equal('127.0.0.2');


### PR DESCRIPTION
Fixes a minor typo in test/request/ip.js (`remoteAddress` instead of `removeAddress`).