### PR TITLE
add a webchat freenode link to irc channel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ $ npm install koa
  - [Guide](docs/guide.md)
  - [FAQ](docs/faq.md)
  - [中文文档](https://github.com/turingou/koa-guide)
- - __#koajs__ on freenode
+ - __[#koajs]__ on freenode
 
 ## Getting started
 
@@ -93,3 +93,4 @@ $ make test
 [coveralls-url]: https://coveralls.io/r/koajs/koa?branch=master
 [gitter-image]: https://badges.gitter.im/Join%20Chat.svg
 [gitter-url]: https://gitter.im/koajs/koa?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[#koajs]: https://webchat.freenode.net/?channels=#koajs


### PR DESCRIPTION
Inspired by my revision here -> https://github.com/elixir-lang/elixir/commit/1932b5243e574bcfff2c4cec2eabc738bc2e43f9

Not everyone uses webchat freenode but it makes a one-click experience for those who do... just like the rest of the links in the section