### PR TITLE
no need to assign error in catch{}-able test

### DIFF
--- a/test/application.js
+++ b/test/application.js
@@ -940,7 +940,6 @@ describe('app.respond', function(){
           yield next;
           this.body = 'Hello';
         } catch (err) {
-          error = err;
           this.body = 'Got error';
         }
       });


### PR DESCRIPTION
in reference to https://github.com/koajs/koa/pull/485#issuecomment-146035374 @tj 