### PR TITLE
Use arrow functions where there's benefit

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -117,13 +117,12 @@ app.callback = function(){
   var fn = this.experimental
     ? compose_es7(this.middleware)
     : co.wrap(compose(this.middleware));
-  var self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);
 
-  return function(req, res){
+  return (req, res) => {
     res.statusCode = 404;
-    var ctx = self.createContext(req, res);
+    var ctx = this.createContext(req, res);
     onFinished(res, ctx.onerror);
     fn.call(ctx).then(function () {
       respond.call(ctx);


### PR DESCRIPTION
So... arrow functions _can_ be slower (though not considerably, I don't think), and except cleanness, there's not much reason to use them when there's no .bind, assigning `this` above the fn, or another workaround in place.

As a result, I'm just PR'ing a change to use arrow functions in 1 location where there is benefit because `var self = this;` is meh.