### PR TITLE
Es2015 classes - Tracking PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "1"
-  - "2"
-  - "3"
   - "4"
 sudo: false
 script: "make test-travis"

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,6 @@ SRC = lib/*.js
 
 include node_modules/make-lint/index.mk
 
-BIN = iojs
-
-ifeq ($(findstring io.js, $(shell which node)),)
-	BIN = node
-endif
-
-ifeq (node, $(BIN))
-	FLAGS = --harmony
-endif
-
 REQUIRED = --require should --require should-http
 
 TESTS = test/application \
@@ -21,14 +11,14 @@ TESTS = test/application \
 	test/experimental/index.js
 
 test:
-	@NODE_ENV=test $(BIN) $(FLAGS) \
+	@NODE_ENV=test node \
 		./node_modules/.bin/_mocha \
 		$(REQUIRED) \
 		$(TESTS) \
 		--bail
 
 test-cov:
-	@NODE_ENV=test $(BIN) $(FLAGS) \
+	@NODE_ENV=test node \
 		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		-- -u exports \
@@ -37,7 +27,7 @@ test-cov:
 		--bail
 
 test-travis:
-	@NODE_ENV=test $(BIN) $(FLAGS) \
+	@NODE_ENV=test node \
 		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		--report lcovonly \

--- a/Readme.md
+++ b/Readme.md
@@ -47,8 +47,8 @@ $ npm install koa
 ## Example
 
 ```js
-const koa = require('koa');
-const app = koa();
+const Koa = require('koa');
+const app = new Koa();
 
 // logger
 

--- a/Readme.md
+++ b/Readme.md
@@ -47,15 +47,15 @@ $ npm install koa
 ## Example
 
 ```js
-var koa = require('koa');
-var app = koa();
+const koa = require('koa');
+const app = koa();
 
 // logger
 
 app.use(function *(next){
-  var start = new Date;
+  const start = new Date;
   yield next;
-  var ms = new Date - start;
+  const ms = new Date - start;
   console.log('%s %s - %s', this.method, this.url, ms);
 });
 

--- a/benchmarks/experimental/async.js
+++ b/benchmarks/experimental/async.js
@@ -8,7 +8,7 @@ app.experimental = true;
 // number of middleware
 
 const n = parseInt(process.env.MW || '1', 10);
-console.log('  %s async middleware', n);
+console.log(`  ${n} async middleware`);
 
 while (n--) {
   app.use(async function (next){

--- a/benchmarks/experimental/async.js
+++ b/benchmarks/experimental/async.js
@@ -1,13 +1,13 @@
 
-var http = require('http');
-var koa = require('../..');
-var app = koa();
+const http = require('http');
+const koa = require('../..');
+const app = koa();
 
 app.experimental = true;
 
 // number of middleware
 
-var n = parseInt(process.env.MW || '1', 10);
+const n = parseInt(process.env.MW || '1', 10);
 console.log('  %s async middleware', n);
 
 while (n--) {
@@ -16,7 +16,7 @@ while (n--) {
   });
 }
 
-var body = new Buffer('Hello World');
+const body = new Buffer('Hello World');
 
 app.use(async function (next){
   await next;

--- a/benchmarks/experimental/async.js
+++ b/benchmarks/experimental/async.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const http = require('http');
 const koa = require('../..');
 const app = koa();

--- a/benchmarks/experimental/async.js
+++ b/benchmarks/experimental/async.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const http = require('http');
-const koa = require('../..');
-const app = koa();
+const Koa = require('../..');
+const app = new Koa();
 
 app.experimental = true;
 

--- a/benchmarks/experimental/index.js
+++ b/benchmarks/experimental/index.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 // support async await by babel
 require('babel/register')({
   optional: ['asyncToGenerator']

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const http = require('http');
-const koa = require('..');
-const app = koa();
+const Koa = require('..');
+const app = new Koa();
 
 // number of middleware
 

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -6,7 +6,7 @@ const app = koa();
 // number of middleware
 
 const n = parseInt(process.env.MW || '1', 10);
-console.log('  %s middleware', n);
+console.log(`  ${n} middleware`);
 
 while (n--) {
   app.use(function *(next){

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const http = require('http');
 const koa = require('..');
 const app = koa();

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -1,11 +1,11 @@
 
-var http = require('http');
-var koa = require('..');
-var app = koa();
+const http = require('http');
+const koa = require('..');
+const app = koa();
 
 // number of middleware
 
-var n = parseInt(process.env.MW || '1', 10);
+const n = parseInt(process.env.MW || '1', 10);
 console.log('  %s middleware', n);
 
 while (n--) {
@@ -14,7 +14,7 @@ while (n--) {
   });
 }
 
-var body = new Buffer('Hello World');
+const body = new Buffer('Hello World');
 
 app.use(function *(next){
   yield *next;

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,3 +1,6 @@
+
+'use strict';
+
 #!/usr/bin/env bash
 
 echo

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/application.js
+++ b/lib/application.js
@@ -37,7 +37,6 @@ class Application extends Emitter {
 
   constructor() {
     super();
-    if (!(this instanceof Application)) return new Application;
     this.env = process.env.NODE_ENV || 'development';
     this.subdomainOffset = 2;
     this.middleware = [];

--- a/lib/application.js
+++ b/lib/application.js
@@ -117,13 +117,12 @@ app.callback = function(){
   const fn = this.experimental
     ? compose_es7(this.middleware)
     : co.wrap(compose(this.middleware));
-  const self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);
 
-  return function(req, res){
+  return (req, res) => {
     res.statusCode = 404;
-    const ctx = self.createContext(req, res);
+    const ctx = this.createContext(req, res);
     onFinished(res, ctx.onerror);
     fn.call(ctx).then(function () {
       respond.call(ctx);

--- a/lib/application.js
+++ b/lib/application.js
@@ -27,7 +27,7 @@ const co = require('co');
  * Application prototype.
  */
 
-class Application {
+class Application extends Emitter {
 
   /**
    * Initialize a new `Application`.
@@ -36,6 +36,7 @@ class Application {
    */
 
   constructor() {
+    super();
     if (!(this instanceof Application)) return new Application;
     this.env = process.env.NODE_ENV || 'development';
     this.subdomainOffset = 2;
@@ -160,7 +161,7 @@ class Application {
    * @param {Error} err
    * @api private
    */
-  
+
   onerror(err) {
     assert(err instanceof Error, `non-error thrown: ${err}`);
 
@@ -178,10 +179,10 @@ class Application {
 }
 
 /**
- * Inherit from `Emitter.prototype`.
+ * Expose `Application`.
  */
 
-Object.setPrototypeOf(Application.prototype, Emitter.prototype);
+exports = module.exports = Application;
 
 /**
  * Response helper.
@@ -227,9 +228,3 @@ function respond() {
   this.length = Buffer.byteLength(body);
   res.end(body);
 }
-
-/**
- * Expose `Application`.
- */
-
-exports = module.exports = Application;

--- a/lib/application.js
+++ b/lib/application.js
@@ -27,28 +27,154 @@ const co = require('co');
  * Application prototype.
  */
 
-const app = Application.prototype;
+class Application {
 
-/**
- * Expose `Application`.
- */
+  /**
+   * Initialize a new `Application`.
+   *
+   * @api public
+   */
 
-exports = module.exports = Application;
+  constructor() {
+    if (!(this instanceof Application)) return new Application;
+    this.env = process.env.NODE_ENV || 'development';
+    this.subdomainOffset = 2;
+    this.middleware = [];
+    this.context = Object.create(context);
+    this.request = Object.create(request);
+    this.response = Object.create(response);
+  }
 
-/**
- * Initialize a new `Application`.
- *
- * @api public
- */
+  /**
+   * Shorthand for:
+   *
+   *    http.createServer(app.callback()).listen(...)
+   *
+   * @param {Mixed} ...
+   * @return {Server}
+   * @api public
+   */
 
-function Application() {
-  if (!(this instanceof Application)) return new Application;
-  this.env = process.env.NODE_ENV || 'development';
-  this.subdomainOffset = 2;
-  this.middleware = [];
-  this.context = Object.create(context);
-  this.request = Object.create(request);
-  this.response = Object.create(response);
+  listen() {
+    debug('listen');
+    const server = http.createServer(this.callback());
+    return server.listen.apply(server, arguments);
+  }
+
+  /**
+   * Return JSON representation.
+   * We only bother showing settings.
+   *
+   * @return {Object}
+   * @api public
+   */
+
+  toJSON() {
+    return only(this, [
+      'subdomainOffset',
+      'env'
+    ]);
+  }
+
+  /**
+   * Alias of toJSON().
+   *
+   * @return {Object}
+   * @api public
+   */
+
+  inspect() {
+    return this.toJSON();
+  }
+
+  /**
+   * Use the given middleware `fn`.
+   *
+   * @param {GeneratorFunction} fn
+   * @return {Application} self
+   * @api public
+   */
+
+  use(fn) {
+    if (!this.experimental) {
+      // es7 async functions are allowed
+      assert(fn && 'GeneratorFunction' == fn.constructor.name, 'app.use() requires a generator function');
+    }
+    debug('use %s', fn._name || fn.name || '-');
+    this.middleware.push(fn);
+    return this;
+  }
+
+  /**
+   * Return a request handler callback
+   * for node's native http server.
+   *
+   * @return {Function}
+   * @api public
+   */
+
+  callback() {
+    const fn = this.experimental
+     ? compose_es7(this.middleware)
+     : co.wrap(compose(this.middleware));
+
+    if (!this.listeners('error').length) this.on('error', this.onerror);
+
+    return (req, res) => {
+     res.statusCode = 404;
+     const ctx = this.createContext(req, res);
+     onFinished(res, ctx.onerror);
+     fn.call(ctx).then(function () {
+       respond.call(ctx);
+     }).catch(ctx.onerror);
+    }
+  }
+
+  /**
+  * Initialize a new context.
+  *
+  * @api private
+  */
+
+  createContext(req, res) {
+    const context = Object.create(this.context);
+    const request = context.request = Object.create(this.request);
+    const response = context.response = Object.create(this.response);
+    context.app = request.app = response.app = this;
+    context.req = request.req = response.req = req;
+    context.res = request.res = response.res = res;
+    request.ctx = response.ctx = context;
+    request.response = response;
+    response.request = request;
+    context.onerror = context.onerror.bind(context);
+    context.originalUrl = request.originalUrl = req.url;
+    context.cookies = new Cookies(req, res, this.keys);
+    context.accept = request.accept = accepts(req);
+    context.state = {};
+    return context;
+  }
+
+  /**
+   * Default error handler.
+   *
+   * @param {Error} err
+   * @api private
+   */
+  
+  onerror(err) {
+    assert(err instanceof Error, `non-error thrown: ${err}`);
+
+    if (404 == err.status || err.expose) return;
+    if (this.silent) return;
+    // DEPRECATE env-specific logging in v2
+    if ('test' == this.env) return;
+
+    const msg = err.stack || err.toString();
+    console.error();
+    console.error(msg.replace(/^/gm, '  '));
+    console.error();
+  }
+
 }
 
 /**
@@ -56,126 +182,6 @@ function Application() {
  */
 
 Object.setPrototypeOf(Application.prototype, Emitter.prototype);
-
-/**
- * Shorthand for:
- *
- *    http.createServer(app.callback()).listen(...)
- *
- * @param {Mixed} ...
- * @return {Server}
- * @api public
- */
-
-app.listen = function(){
-  debug('listen');
-  const server = http.createServer(this.callback());
-  return server.listen.apply(server, arguments);
-};
-
-/**
- * Return JSON representation.
- * We only bother showing settings.
- *
- * @return {Object}
- * @api public
- */
-
-app.inspect =
-app.toJSON = function(){
-  return only(this, [
-    'subdomainOffset',
-    'env'
-  ]);
-};
-
-/**
- * Use the given middleware `fn`.
- *
- * @param {GeneratorFunction} fn
- * @return {Application} self
- * @api public
- */
-
-app.use = function(fn){
-  if (!this.experimental) {
-    // es7 async functions are allowed
-    assert(fn && 'GeneratorFunction' == fn.constructor.name, 'app.use() requires a generator function');
-  }
-  debug('use %s', fn._name || fn.name || '-');
-  this.middleware.push(fn);
-  return this;
-};
-
-/**
- * Return a request handler callback
- * for node's native http server.
- *
- * @return {Function}
- * @api public
- */
-
-app.callback = function(){
-  const fn = this.experimental
-    ? compose_es7(this.middleware)
-    : co.wrap(compose(this.middleware));
-
-  if (!this.listeners('error').length) this.on('error', this.onerror);
-
-  return (req, res) => {
-    res.statusCode = 404;
-    const ctx = this.createContext(req, res);
-    onFinished(res, ctx.onerror);
-    fn.call(ctx).then(function () {
-      respond.call(ctx);
-    }).catch(ctx.onerror);
-  }
-};
-
-/**
- * Initialize a new context.
- *
- * @api private
- */
-
-app.createContext = function(req, res){
-  const context = Object.create(this.context);
-  const request = context.request = Object.create(this.request);
-  const response = context.response = Object.create(this.response);
-  context.app = request.app = response.app = this;
-  context.req = request.req = response.req = req;
-  context.res = request.res = response.res = res;
-  request.ctx = response.ctx = context;
-  request.response = response;
-  response.request = request;
-  context.onerror = context.onerror.bind(context);
-  context.originalUrl = request.originalUrl = req.url;
-  context.cookies = new Cookies(req, res, this.keys);
-  context.accept = request.accept = accepts(req);
-  context.state = {};
-  return context;
-};
-
-/**
- * Default error handler.
- *
- * @param {Error} err
- * @api private
- */
-
-app.onerror = function(err){
-  assert(err instanceof Error, `non-error thrown: ${err}`);
-
-  if (404 == err.status || err.expose) return;
-  if (this.silent) return;
-  // DEPRECATE env-specific logging in v2
-  if ('test' == this.env) return;
-
-  const msg = err.stack || err.toString();
-  console.error();
-  console.error(msg.replace(/^/gm, '  '));
-  console.error();
-};
 
 /**
  * Response helper.
@@ -221,3 +227,9 @@ function respond() {
   this.length = Buffer.byteLength(body);
   res.end(body);
 }
+
+/**
+ * Expose `Application`.
+ */
+
+exports = module.exports = Application;

--- a/lib/application.js
+++ b/lib/application.js
@@ -163,7 +163,7 @@ app.createContext = function(req, res){
  */
 
 app.onerror = function(err){
-  assert(err instanceof Error, 'non-error thrown: ' + err);
+  assert(err instanceof Error, `non-error thrown: ${err}`);
 
   if (404 == err.status || err.expose) return;
   if (this.silent) return;

--- a/lib/application.js
+++ b/lib/application.js
@@ -3,29 +3,29 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('koa:application');
-var Emitter = require('events').EventEmitter;
-var compose_es7 = require('composition');
-var onFinished = require('on-finished');
-var response = require('./response');
-var compose = require('koa-compose');
-var isJSON = require('koa-is-json');
-var context = require('./context');
-var request = require('./request');
-var statuses = require('statuses');
-var Cookies = require('cookies');
-var accepts = require('accepts');
-var assert = require('assert');
-var Stream = require('stream');
-var http = require('http');
-var only = require('only');
-var co = require('co');
+const debug = require('debug')('koa:application');
+const Emitter = require('events').EventEmitter;
+const compose_es7 = require('composition');
+const onFinished = require('on-finished');
+const response = require('./response');
+const compose = require('koa-compose');
+const isJSON = require('koa-is-json');
+const context = require('./context');
+const request = require('./request');
+const statuses = require('statuses');
+const Cookies = require('cookies');
+const accepts = require('accepts');
+const assert = require('assert');
+const Stream = require('stream');
+const http = require('http');
+const only = require('only');
+const co = require('co');
 
 /**
  * Application prototype.
  */
 
-var app = Application.prototype;
+const app = Application.prototype;
 
 /**
  * Expose `Application`.
@@ -67,7 +67,7 @@ Object.setPrototypeOf(Application.prototype, Emitter.prototype);
 
 app.listen = function(){
   debug('listen');
-  var server = http.createServer(this.callback());
+  const server = http.createServer(this.callback());
   return server.listen.apply(server, arguments);
 };
 
@@ -114,16 +114,16 @@ app.use = function(fn){
  */
 
 app.callback = function(){
-  var fn = this.experimental
+  const fn = this.experimental
     ? compose_es7(this.middleware)
     : co.wrap(compose(this.middleware));
-  var self = this;
+  const self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);
 
   return function(req, res){
     res.statusCode = 404;
-    var ctx = self.createContext(req, res);
+    const ctx = self.createContext(req, res);
     onFinished(res, ctx.onerror);
     fn.call(ctx).then(function () {
       respond.call(ctx);
@@ -138,9 +138,9 @@ app.callback = function(){
  */
 
 app.createContext = function(req, res){
-  var context = Object.create(this.context);
-  var request = context.request = Object.create(this.request);
-  var response = context.response = Object.create(this.response);
+  const context = Object.create(this.context);
+  const request = context.request = Object.create(this.request);
+  const response = context.response = Object.create(this.response);
   context.app = request.app = response.app = this;
   context.req = request.req = response.req = req;
   context.res = request.res = response.res = res;
@@ -170,7 +170,7 @@ app.onerror = function(err){
   // DEPRECATE env-specific logging in v2
   if ('test' == this.env) return;
 
-  var msg = err.stack || err.toString();
+  const msg = err.stack || err.toString();
   console.error();
   console.error(msg.replace(/^/gm, '  '));
   console.error();
@@ -184,11 +184,11 @@ function respond() {
   // allow bypassing koa
   if (false === this.respond) return;
 
-  var res = this.res;
+  const res = this.res;
   if (res.headersSent || !this.writable) return;
 
   var body = this.body;
-  var code = this.status;
+  const code = this.status;
 
   // ignore body
   if (statuses.empty[code]) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/context.js
+++ b/lib/context.js
@@ -3,16 +3,16 @@
  * Module dependencies.
  */
 
-var createError = require('http-errors');
-var httpAssert = require('http-assert');
-var delegate = require('delegates');
-var statuses = require('statuses');
+const createError = require('http-errors');
+const httpAssert = require('http-assert');
+const delegate = require('delegates');
+const statuses = require('statuses');
 
 /**
  * Context prototype.
  */
 
-var proto = module.exports = {
+const proto = module.exports = {
 
   /**
    * util.inspect() implementation, which
@@ -128,8 +128,8 @@ var proto = module.exports = {
     if ('number' != typeof err.status || !statuses[err.status]) err.status = 500;
 
     // respond
-    var code = statuses[err.status];
-    var msg = err.expose ? err.message : code;
+    const code = statuses[err.status];
+    const msg = err.expose ? err.message : code;
     this.status = err.status;
     this.length = Buffer.byteLength(msg);
     this.res.end(msg);

--- a/lib/context.js
+++ b/lib/context.js
@@ -102,7 +102,7 @@ const proto = module.exports = {
     // to node-style callbacks.
     if (null == err) return;
 
-    if (!(err instanceof Error)) err = new Error('non-error thrown: ' + err);
+    if (!(err instanceof Error)) err = new Error(`non-error thrown: ${err}`);
 
     // delegate
     this.app.emit('error', err, this);

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/request.js
+++ b/lib/request.js
@@ -67,7 +67,7 @@ module.exports = {
    */
 
   get origin() {
-    return this.protocol + '://' + this.host;
+    return `${this.protocol}://${this.host}`;
   },
 
   /**
@@ -194,7 +194,7 @@ module.exports = {
 
   get search() {
     if (!this.querystring) return '';
-    return '?' + this.querystring;
+    return `?${this.querystring}`;
   },
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,12 +3,12 @@
  * Module dependencies.
  */
 
-var contentType = require('content-type');
-var stringify = require('url').format;
-var parse = require('parseurl');
-var qs = require('querystring');
-var typeis = require('type-is');
-var fresh = require('fresh');
+const contentType = require('content-type');
+const stringify = require('url').format;
+const parse = require('parseurl');
+const qs = require('querystring');
+const typeis = require('type-is');
+const fresh = require('fresh');
 
 /**
  * Prototype.
@@ -126,7 +126,7 @@ module.exports = {
    */
 
   set path(path) {
-    var url = parse(this.req);
+    const url = parse(this.req);
     url.pathname = path;
     url.path = null;
 
@@ -141,8 +141,8 @@ module.exports = {
    */
 
   get query() {
-    var str = this.querystring;
-    var c = this._querycache = this._querycache || {};
+    const str = this.querystring;
+    const c = this._querycache = this._querycache || {};
     return c[str] || (c[str] = qs.parse(str));
   },
 
@@ -177,7 +177,7 @@ module.exports = {
    */
 
   set querystring(str) {
-    var url = parse(this.req);
+    const url = parse(this.req);
     url.search = str;
     url.path = null;
 
@@ -219,7 +219,7 @@ module.exports = {
    */
 
   get host() {
-    var proxy = this.app.proxy;
+    const proxy = this.app.proxy;
     var host = proxy && this.get('X-Forwarded-Host');
     host = host || this.get('Host');
     if (!host) return '';
@@ -236,7 +236,7 @@ module.exports = {
    */
 
   get hostname() {
-    var host = this.host;
+    const host = this.host;
     if (!host) return '';
     return host.split(':')[0];
   },
@@ -251,8 +251,8 @@ module.exports = {
    */
 
   get fresh() {
-    var method = this.method;
-    var s = this.ctx.status;
+    const method = this.method;
+    const s = this.ctx.status;
 
     // GET or HEAD for weak freshness validation only
     if ('GET' != method && 'HEAD' != method) return false;
@@ -286,7 +286,7 @@ module.exports = {
    */
 
   get idempotent() {
-    var methods = ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'];
+    const methods = ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'];
     return !!~methods.indexOf(this.method);
   },
 
@@ -310,7 +310,7 @@ module.exports = {
    */
 
   get charset() {
-    var type = this.get('Content-Type');
+    const type = this.get('Content-Type');
     if (!type) return '';
 
     return contentType.parse(type).parameters.charset || '';
@@ -324,7 +324,7 @@ module.exports = {
    */
 
   get length() {
-    var len = this.get('Content-Length');
+    const len = this.get('Content-Length');
     if (len == '') return;
     return ~~len;
   },
@@ -342,10 +342,10 @@ module.exports = {
    */
 
   get protocol() {
-    var proxy = this.app.proxy;
+    const proxy = this.app.proxy;
     if (this.socket.encrypted) return 'https';
     if (!proxy) return 'http';
-    var proto = this.get('X-Forwarded-Proto') || 'http';
+    const proto = this.get('X-Forwarded-Proto') || 'http';
     return proto.split(/\s*,\s*/)[0];
   },
 
@@ -388,8 +388,8 @@ module.exports = {
    */
 
   get ips() {
-    var proxy = this.app.proxy;
-    var val = this.get('X-Forwarded-For');
+    const proxy = this.app.proxy;
+    const val = this.get('X-Forwarded-For');
     return proxy && val
       ? val.split(/\s*,\s*/)
       : [];
@@ -411,7 +411,7 @@ module.exports = {
    */
 
   get subdomains() {
-    var offset = this.app.subdomainOffset;
+    const offset = this.app.subdomainOffset;
     return (this.host || '')
       .split('.')
       .reverse()
@@ -555,7 +555,7 @@ module.exports = {
    */
 
   get type() {
-    var type = this.get('Content-Type');
+    const type = this.get('Content-Type');
     if (!type) return '';
     return type.split(';')[0];
   },
@@ -583,7 +583,7 @@ module.exports = {
    */
 
   get: function(field){
-    var req = this.req;
+    const req = this.req;
     switch (field = field.toLowerCase()) {
       case 'referer':
       case 'referrer':

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 /**
  * Module dependencies.
  */

--- a/lib/response.js
+++ b/lib/response.js
@@ -78,7 +78,7 @@ module.exports = {
 
   set status(code) {
     assert('number' == typeof code, 'status code must be a number');
-    assert(statuses[code], 'invalid status code: ' + code);
+    assert(statuses[code], `invalid status code: ${code}`);
     this._explicitStatus = true;
     this.res.statusCode = code;
     this.res.statusMessage = statuses[code];
@@ -261,13 +261,13 @@ module.exports = {
     if (this.ctx.accepts('html')) {
       url = escape(url);
       this.type = 'text/html; charset=utf-8';
-      this.body = 'Redirecting to <a href="' + url + '">' + url + '</a>.';
+      this.body = `Redirecting to <a href="${url}">${url}</a>.`;
       return;
     }
 
     // text
     this.type = 'text/plain; charset=utf-8';
-    this.body = 'Redirecting to ' + url + '.';
+    this.body = `Redirecting to ${url}.`;
   },
 
   /**
@@ -342,7 +342,7 @@ module.exports = {
    */
 
   set etag(val) {
-    if (!/^(W\/)?"/.test(val)) val = '"' + val + '"';
+    if (!/^(W\/)?"/.test(val)) val = `"${val}"`;
     this.set('ETag', val);
   },
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -3,19 +3,19 @@
  * Module dependencies.
  */
 
-var contentDisposition = require('content-disposition');
-var ensureErrorHandler = require('error-inject');
-var getType = require('mime-types').contentType;
-var onFinish = require('on-finished');
-var isJSON = require('koa-is-json');
-var escape = require('escape-html');
-var typeis = require('type-is').is;
-var statuses = require('statuses');
-var destroy = require('destroy');
-var assert = require('assert');
-var path = require('path');
-var vary = require('vary');
-var extname = path.extname;
+const contentDisposition = require('content-disposition');
+const ensureErrorHandler = require('error-inject');
+const getType = require('mime-types').contentType;
+const onFinish = require('on-finished');
+const isJSON = require('koa-is-json');
+const escape = require('escape-html');
+const typeis = require('type-is').is;
+const statuses = require('statuses');
+const destroy = require('destroy');
+const assert = require('assert');
+const path = require('path');
+const vary = require('vary');
+const extname = path.extname;
 
 /**
  * Prototype.
@@ -126,7 +126,7 @@ module.exports = {
    */
 
   set body(val) {
-    var original = this._body;
+    const original = this._body;
     this._body = val;
 
     // no content
@@ -142,7 +142,7 @@ module.exports = {
     if (!this._explicitStatus) this.status = 200;
 
     // set the content-type only if not yet set
-    var setType = !this.header['content-type'];
+    const setType = !this.header['content-type'];
 
     // string
     if ('string' == typeof val) {
@@ -194,8 +194,8 @@ module.exports = {
    */
 
   get length() {
-    var len = this.header['content-length'];
-    var body = this.body;
+    const len = this.header['content-length'];
+    const body = this.body;
 
     if (null == len) {
       if (!body) return;
@@ -325,7 +325,7 @@ module.exports = {
    */
 
   get lastModified() {
-    var date = this.get('last-modified');
+    const date = this.get('last-modified');
     if (date) return new Date(date);
   },
 
@@ -366,7 +366,7 @@ module.exports = {
    */
 
   get type() {
-    var type = this.get('Content-Type');
+    const type = this.get('Content-Type');
     if (!type) return '';
     return type.split(';')[0];
   },
@@ -381,7 +381,7 @@ module.exports = {
    */
 
   is: function(types){
-    var type = this.type;
+    const type = this.type;
     if (!types) return type || false;
     if (!Array.isArray(types)) types = [].slice.call(arguments);
     return typeis(type, types);
@@ -449,7 +449,7 @@ module.exports = {
    */
 
   append: function(field, val){
-    var prev = this.get(field);
+    const prev = this.get(field);
 
     if (prev) {
       val = Array.isArray(prev)
@@ -481,7 +481,7 @@ module.exports = {
    */
 
   get writable() {
-    var socket = this.res.socket;
+    const socket = this.res.socket;
     if (!socket) return false;
     return socket.writable;
   },
@@ -495,7 +495,7 @@ module.exports = {
 
   inspect: function(){
     if (!this.res) return;
-    var o = this.toJSON();
+    const o = this.toJSON();
     o.body = this.body;
     return o;
   },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "test-console": "^0.7.1"
   },
   "engines": {
-    "node": ">= 0.12.0",
-    "iojs": ">= 1.0.0"
+    "node": ">= 4"
   },
   "files": [
     "lib"

--- a/test/application.js
+++ b/test/application.js
@@ -6,13 +6,13 @@ const request = require('supertest');
 const statuses = require('statuses');
 const assert = require('assert');
 const http = require('http');
-const koa = require('..');
+const Koa = require('..');
 const fs = require('fs');
 const AssertionError = assert.AssertionError;
 
 describe('app', function(){
   it('should handle socket errors', function(done){
-    const app = koa();
+    const app = new Koa();
 
     app.use(function *(next){
       // triggers this.socket.writable == false
@@ -30,7 +30,7 @@ describe('app', function(){
   })
 
   it('should not .writeHead when !socket.writable', function(done){
-    const app = koa();
+    const app = new Koa();
 
     app.use(function *(next){
       // set .writable to false
@@ -54,7 +54,7 @@ describe('app', function(){
   it('should set development env when NODE_ENV missing', function(){
     const NODE_ENV = process.env.NODE_ENV;
     process.env.NODE_ENV = '';
-    const app = koa();
+    const app = new Koa();
     process.env.NODE_ENV = NODE_ENV;
     assert.equal(app.env, 'development');
   })
@@ -62,7 +62,7 @@ describe('app', function(){
 
 describe('app.toJSON()', function(){
   it('should work', function(){
-    const app = koa();
+    const app = new Koa();
     const obj = app.toJSON();
 
     obj.should.eql({
@@ -74,7 +74,7 @@ describe('app.toJSON()', function(){
 
 describe('app.inspect()', function(){
   it('should work', function(){
-    const app = koa();
+    const app = new Koa();
     const util = require('util');
     const str = util.inspect(app);
   })
@@ -82,7 +82,7 @@ describe('app.inspect()', function(){
 
 describe('app.use(fn)', function(){
   it('should compose middleware', function(done){
-    const app = koa();
+    const app = new Koa();
     const calls = [];
 
     app.use(function *(next){
@@ -116,7 +116,7 @@ describe('app.use(fn)', function(){
   })
 
   it('should error when a non-generator function is passed', function(){
-    const app = koa();
+    const app = new Koa();
 
     try {
       app.use(function(){});
@@ -126,7 +126,7 @@ describe('app.use(fn)', function(){
   })
 
   it('should not error when a non-generator function is passed when .experimental=true', function(){
-    const app = koa();
+    const app = new Koa();
     app.experimental = true;
     app.use(function(){});
   })
@@ -134,7 +134,7 @@ describe('app.use(fn)', function(){
 
 describe('app.onerror(err)', function(){
   it('should throw an error if a non-error is given', function(done){
-    const app = koa();
+    const app = new Koa();
 
     try {
       app.onerror('foo');
@@ -149,7 +149,7 @@ describe('app.onerror(err)', function(){
   })
 
   it('should do nothing if status is 404', function(done){
-    const app = koa();
+    const app = new Koa();
     const err = new Error();
 
     err.status = 404;
@@ -164,7 +164,7 @@ describe('app.onerror(err)', function(){
   })
 
   it('should do nothing if .silent', function(done){
-    var app = koa();
+    var app = new Koa();
     app.silent = true;
     var err = new Error();
 
@@ -178,7 +178,7 @@ describe('app.onerror(err)', function(){
   })
 
   it('should log the error to stderr', function(done){
-    const app = koa();
+    const app = new Koa();
     app.env = 'dev';
 
     const err = new Error();
@@ -194,7 +194,7 @@ describe('app.onerror(err)', function(){
   })
 
   it('should use err.toString() instad of err.stack', function(done){
-    const app = koa();
+    const app = new Koa();
     app.env = 'dev';
 
     const err = new Error('mock stack null');
@@ -213,7 +213,7 @@ describe('app.onerror(err)', function(){
 describe('app.respond', function(){
   describe('when this.respond === false', function(){
     it('should bypass app.respond', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = 'Hello';
@@ -239,7 +239,7 @@ describe('app.respond', function(){
 
   describe('when HEAD is used', function(){
     it('should not respond with the body', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = 'Hello';
@@ -260,7 +260,7 @@ describe('app.respond', function(){
     })
 
     it('should keep json headers', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = { hello: 'world' };
@@ -281,7 +281,7 @@ describe('app.respond', function(){
     })
 
     it('should keep string headers', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = 'hello world';
@@ -302,7 +302,7 @@ describe('app.respond', function(){
     })
 
     it('should keep buffer headers', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = new Buffer('hello world');
@@ -323,7 +323,7 @@ describe('app.respond', function(){
     })
 
     it('should respond with a 404 if no body was set', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
 
@@ -337,7 +337,7 @@ describe('app.respond', function(){
     })
 
     it('should respond with a 200 if body = ""', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = '';
@@ -351,7 +351,7 @@ describe('app.respond', function(){
     })
 
     it('should not overwrite the content-type', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 200;
@@ -369,7 +369,7 @@ describe('app.respond', function(){
 
   describe('when no middleware are present', function(){
     it('should 404', function(done){
-      const app = koa();
+      const app = new Koa();
 
       const server = app.listen();
 
@@ -381,7 +381,7 @@ describe('app.respond', function(){
 
   describe('when res has already been written to', function(){
     it('should not cause an app error', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(next){
         const res = this.res;
@@ -412,7 +412,7 @@ describe('app.respond', function(){
     })
 
     it('should send the right body', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(next){
         const res = this.res;
@@ -436,7 +436,7 @@ describe('app.respond', function(){
   describe('when .body is missing', function(){
     describe('with status=400', function(){
       it('should respond with the associated status message', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.status = 400;
@@ -454,7 +454,7 @@ describe('app.respond', function(){
 
     describe('with status=204', function(){
       it('should respond without a body', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.status = 204;
@@ -477,7 +477,7 @@ describe('app.respond', function(){
 
     describe('with status=205', function(){
       it('should respond without a body', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.status = 205;
@@ -500,7 +500,7 @@ describe('app.respond', function(){
 
     describe('with status=304', function(){
       it('should respond without a body', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.status = 304;
@@ -523,7 +523,7 @@ describe('app.respond', function(){
 
     describe('with custom status=700', function(){
       it('should respond with the associated status message', function (done){
-        const app = koa();
+        const app = new Koa();
         statuses['700'] = 'custom status';
 
         app.use(function *(){
@@ -546,7 +546,7 @@ describe('app.respond', function(){
 
     describe('with custom statusMessage=ok', function(){
       it('should respond with the custom status message', function (done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.status = 200;
@@ -569,7 +569,7 @@ describe('app.respond', function(){
 
     describe('with custom status without message', function (){
       it('should respond with the status code number', function (done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           this.res.statusCode = 701;
@@ -587,7 +587,7 @@ describe('app.respond', function(){
 
   describe('when .body is a null', function(){
     it('should respond 204 by default', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = null;
@@ -608,7 +608,7 @@ describe('app.respond', function(){
     })
 
     it('should respond 204 with status=200', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 200;
@@ -630,7 +630,7 @@ describe('app.respond', function(){
     })
 
     it('should respond 205 with status=205', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 205;
@@ -652,7 +652,7 @@ describe('app.respond', function(){
     })
 
     it('should respond 304 with status=304', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 304;
@@ -676,7 +676,7 @@ describe('app.respond', function(){
 
   describe('when .body is a string', function(){
     it('should respond', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = 'Hello';
@@ -692,7 +692,7 @@ describe('app.respond', function(){
 
   describe('when .body is a Buffer', function(){
     it('should respond', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = new Buffer('Hello');
@@ -708,7 +708,7 @@ describe('app.respond', function(){
 
   describe('when .body is a Stream', function(){
     it('should respond', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = fs.createReadStream('package.json');
@@ -730,7 +730,7 @@ describe('app.respond', function(){
     })
 
     it('should strip content-length when overwriting', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = 'hello';
@@ -753,7 +753,7 @@ describe('app.respond', function(){
     })
 
     it('should keep content-length if not overwritten', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.length = fs.readFileSync('package.json').length;
@@ -776,7 +776,7 @@ describe('app.respond', function(){
     })
 
     it('should keep content-length if overwritten with the same stream', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.length = fs.readFileSync('package.json').length;
@@ -801,7 +801,7 @@ describe('app.respond', function(){
     })
 
     it('should handle errors', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.set('Content-Type', 'application/json; charset=utf-8');
@@ -818,7 +818,7 @@ describe('app.respond', function(){
     })
 
     it('should handle errors when no content status', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 204;
@@ -834,7 +834,7 @@ describe('app.respond', function(){
 
 
     it('should handle all intermediate stream body errors', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = fs.createReadStream('does not exist');
@@ -852,7 +852,7 @@ describe('app.respond', function(){
 
   describe('when .body is an Object', function(){
     it('should respond with json', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.body = { hello: 'world' };
@@ -869,7 +869,7 @@ describe('app.respond', function(){
 
   describe('when an error occurs', function(){
     it('should emit "error" on the app', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         throw new Error('boom');
@@ -887,7 +887,7 @@ describe('app.respond', function(){
 
     describe('with an .expose property', function(){
       it('should expose the message', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           const err = new Error('sorry!');
@@ -905,7 +905,7 @@ describe('app.respond', function(){
 
     describe('with a .status property', function(){
       it('should respond with .status', function(done){
-        const app = koa();
+        const app = new Koa();
 
         app.use(function *(){
           const err = new Error('s3 explodes');
@@ -921,7 +921,7 @@ describe('app.respond', function(){
     })
 
     it('should respond with 500', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         throw new Error('boom!');
@@ -936,7 +936,7 @@ describe('app.respond', function(){
     })
 
     it('should be catchable', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(next){
         try {
@@ -963,7 +963,7 @@ describe('app.respond', function(){
 
   describe('when status and body property', function(){
     it('should 200', function(done){
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 304;
@@ -980,7 +980,7 @@ describe('app.respond', function(){
     })
 
     it('should 204', function(done) {
-      const app = koa();
+      const app = new Koa();
 
       app.use(function *(){
         this.status = 200;
@@ -1003,9 +1003,9 @@ describe('app.respond', function(){
 })
 
 describe('app.context', function(){
-  const app1 = koa();
+  const app1 = new Koa();
   app1.context.msg = 'hello';
-  const app2 = koa();
+  const app2 = new Koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){
@@ -1031,9 +1031,9 @@ describe('app.context', function(){
 })
 
 describe('app.request', function(){
-  const app1 = koa();
+  const app1 = new Koa();
   app1.request.message = 'hello';
-  const app2 = koa();
+  const app2 = new Koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){
@@ -1059,9 +1059,9 @@ describe('app.request', function(){
 })
 
 describe('app.response', function(){
-  const app1 = koa();
+  const app1 = new Koa();
   app1.response.msg = 'hello';
-  const app2 = koa();
+  const app2 = new Koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){

--- a/test/application.js
+++ b/test/application.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const stderr = require('test-console').stderr;
 const request = require('supertest');
 const statuses = require('statuses');

--- a/test/application.js
+++ b/test/application.js
@@ -1,16 +1,16 @@
 
-var stderr = require('test-console').stderr;
-var request = require('supertest');
-var statuses = require('statuses');
-var assert = require('assert');
-var http = require('http');
-var koa = require('..');
-var fs = require('fs');
-var AssertionError = assert.AssertionError;
+const stderr = require('test-console').stderr;
+const request = require('supertest');
+const statuses = require('statuses');
+const assert = require('assert');
+const http = require('http');
+const koa = require('..');
+const fs = require('fs');
+const AssertionError = assert.AssertionError;
 
 describe('app', function(){
   it('should handle socket errors', function(done){
-    var app = koa();
+    const app = koa();
 
     app.use(function *(next){
       // triggers this.socket.writable == false
@@ -28,7 +28,7 @@ describe('app', function(){
   })
 
   it('should not .writeHead when !socket.writable', function(done){
-    var app = koa();
+    const app = koa();
 
     app.use(function *(next){
       // set .writable to false
@@ -50,9 +50,9 @@ describe('app', function(){
   })
 
   it('should set development env when NODE_ENV missing', function(){
-    var NODE_ENV = process.env.NODE_ENV;
+    const NODE_ENV = process.env.NODE_ENV;
     process.env.NODE_ENV = '';
-    var app = koa();
+    const app = koa();
     process.env.NODE_ENV = NODE_ENV;
     assert.equal(app.env, 'development');
   })
@@ -60,8 +60,8 @@ describe('app', function(){
 
 describe('app.toJSON()', function(){
   it('should work', function(){
-    var app = koa();
-    var obj = app.toJSON();
+    const app = koa();
+    const obj = app.toJSON();
 
     obj.should.eql({
       subdomainOffset: 2,
@@ -72,16 +72,16 @@ describe('app.toJSON()', function(){
 
 describe('app.inspect()', function(){
   it('should work', function(){
-    var app = koa();
-    var util = require('util');
-    var str = util.inspect(app);
+    const app = koa();
+    const util = require('util');
+    const str = util.inspect(app);
   })
 })
 
 describe('app.use(fn)', function(){
   it('should compose middleware', function(done){
-    var app = koa();
-    var calls = [];
+    const app = koa();
+    const calls = [];
 
     app.use(function *(next){
       calls.push(1);
@@ -101,7 +101,7 @@ describe('app.use(fn)', function(){
       calls.push(4);
     });
 
-    var server = app.listen();
+    const server = app.listen();
 
     request(server)
     .get('/')
@@ -114,7 +114,7 @@ describe('app.use(fn)', function(){
   })
 
   it('should error when a non-generator function is passed', function(){
-    var app = koa();
+    const app = koa();
 
     try {
       app.use(function(){});
@@ -124,7 +124,7 @@ describe('app.use(fn)', function(){
   })
 
   it('should not error when a non-generator function is passed when .experimental=true', function(){
-    var app = koa();
+    const app = koa();
     app.experimental = true;
     app.use(function(){});
   })
@@ -132,7 +132,7 @@ describe('app.use(fn)', function(){
 
 describe('app.onerror(err)', function(){
   it('should throw an error if a non-error is given', function(done){
-    var app = koa();
+    const app = koa();
 
     try {
       app.onerror('foo');
@@ -147,12 +147,12 @@ describe('app.onerror(err)', function(){
   })
 
   it('should do nothing if status is 404', function(done){
-    var app = koa();
-    var err = new Error();
+    const app = koa();
+    const err = new Error();
 
     err.status = 404;
 
-    var output = stderr.inspectSync(function() {
+    const output = stderr.inspectSync(function() {
       app.onerror(err);
     });
 
@@ -166,7 +166,7 @@ describe('app.onerror(err)', function(){
     app.silent = true;
     var err = new Error();
 
-    var output = stderr.inspectSync(function() {
+    const output = stderr.inspectSync(function() {
       app.onerror(err);
     });
 
@@ -176,13 +176,13 @@ describe('app.onerror(err)', function(){
   })
 
   it('should log the error to stderr', function(done){
-    var app = koa();
+    const app = koa();
     app.env = 'dev';
 
-    var err = new Error();
+    const err = new Error();
     err.stack = 'Foo';
 
-    var output = stderr.inspectSync(function() {
+    const output = stderr.inspectSync(function() {
       app.onerror(err);
     });
 
@@ -192,13 +192,13 @@ describe('app.onerror(err)', function(){
   })
 
   it('should use err.toString() instad of err.stack', function(done){
-    var app = koa();
+    const app = koa();
     app.env = 'dev';
 
-    var err = new Error('mock stack null');
+    const err = new Error('mock stack null');
     err.stack = null;
 
-    var output = stderr.inspectSync(function() {
+    const output = stderr.inspectSync(function() {
       app.onerror(err);
     });
 
@@ -211,13 +211,13 @@ describe('app.onerror(err)', function(){
 describe('app.respond', function(){
   describe('when this.respond === false', function(){
     it('should bypass app.respond', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = 'Hello';
         this.respond = false;
 
-        var res = this.res;
+        const res = this.res;
         res.statusCode = 200;
         setImmediate(function(){
           res.setHeader('Content-Type', 'text/plain');
@@ -225,7 +225,7 @@ describe('app.respond', function(){
         })
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -237,13 +237,13 @@ describe('app.respond', function(){
 
   describe('when HEAD is used', function(){
     it('should not respond with the body', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = 'Hello';
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -258,13 +258,13 @@ describe('app.respond', function(){
     })
 
     it('should keep json headers', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = { hello: 'world' };
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -279,13 +279,13 @@ describe('app.respond', function(){
     })
 
     it('should keep string headers', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = 'hello world';
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -300,13 +300,13 @@ describe('app.respond', function(){
     })
 
     it('should keep buffer headers', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = new Buffer('hello world');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -321,13 +321,13 @@ describe('app.respond', function(){
     })
 
     it('should respond with a 404 if no body was set', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
 
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -335,13 +335,13 @@ describe('app.respond', function(){
     })
 
     it('should respond with a 200 if body = ""', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = '';
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -349,14 +349,14 @@ describe('app.respond', function(){
     })
 
     it('should not overwrite the content-type', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 200;
         this.type = 'application/javascript';
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .head('/')
@@ -367,9 +367,9 @@ describe('app.respond', function(){
 
   describe('when no middleware are present', function(){
     it('should 404', function(done){
-      var app = koa();
+      const app = koa();
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -379,10 +379,10 @@ describe('app.respond', function(){
 
   describe('when res has already been written to', function(){
     it('should not cause an app error', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(next){
-        var res = this.res;
+        const res = this.res;
         this.status = 200;
         res.setHeader("Content-Type", "text/html")
         res.write('Hello');
@@ -391,13 +391,13 @@ describe('app.respond', function(){
         }, 0);
       });
 
-      var errorCaught = false;
+      const errorCaught = false;
 
       app.on('error', function(err){
         errorCaught = err;
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -410,10 +410,10 @@ describe('app.respond', function(){
     })
 
     it('should send the right body', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(next){
-        var res = this.res;
+        const res = this.res;
         this.status = 200;
         res.setHeader("Content-Type", "text/html")
         res.write('Hello');
@@ -422,7 +422,7 @@ describe('app.respond', function(){
         }, 0);
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -434,13 +434,13 @@ describe('app.respond', function(){
   describe('when .body is missing', function(){
     describe('with status=400', function(){
       it('should respond with the associated status message', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.status = 400;
         });
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -452,13 +452,13 @@ describe('app.respond', function(){
 
     describe('with status=204', function(){
       it('should respond without a body', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.status = 204;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -475,13 +475,13 @@ describe('app.respond', function(){
 
     describe('with status=205', function(){
       it('should respond without a body', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.status = 205;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -498,13 +498,13 @@ describe('app.respond', function(){
 
     describe('with status=304', function(){
       it('should respond without a body', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.status = 304;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -521,14 +521,14 @@ describe('app.respond', function(){
 
     describe('with custom status=700', function(){
       it('should respond with the associated status message', function (done){
-        var app = koa();
+        const app = koa();
         statuses['700'] = 'custom status';
 
         app.use(function *(){
           this.status = 700;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -544,14 +544,14 @@ describe('app.respond', function(){
 
     describe('with custom statusMessage=ok', function(){
       it('should respond with the custom status message', function (done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.status = 200;
           this.message = 'ok';
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -567,13 +567,13 @@ describe('app.respond', function(){
 
     describe('with custom status without message', function (){
       it('should respond with the status code number', function (done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
           this.res.statusCode = 701;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -585,13 +585,13 @@ describe('app.respond', function(){
 
   describe('when .body is a null', function(){
     it('should respond 204 by default', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = null;
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -606,14 +606,14 @@ describe('app.respond', function(){
     })
 
     it('should respond 204 with status=200', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 200;
         this.body = null;
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -628,14 +628,14 @@ describe('app.respond', function(){
     })
 
     it('should respond 205 with status=205', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 205;
         this.body = null;
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -650,14 +650,14 @@ describe('app.respond', function(){
     })
 
     it('should respond 304 with status=304', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 304;
         this.body = null;
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -674,13 +674,13 @@ describe('app.respond', function(){
 
   describe('when .body is a string', function(){
     it('should respond', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = 'Hello';
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -690,13 +690,13 @@ describe('app.respond', function(){
 
   describe('when .body is a Buffer', function(){
     it('should respond', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = new Buffer('Hello');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -706,21 +706,21 @@ describe('app.respond', function(){
 
   describe('when .body is a Stream', function(){
     it('should respond', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = fs.createReadStream('package.json');
         this.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
       .expect('Content-Type', 'application/json; charset=utf-8')
       .end(function(err, res){
         if (err) return done(err);
-        var pkg = require('../package');
+        const pkg = require('../package');
         res.should.not.have.header('Content-Length');
         res.body.should.eql(pkg);
         done();
@@ -728,7 +728,7 @@ describe('app.respond', function(){
     })
 
     it('should strip content-length when overwriting', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = 'hello';
@@ -736,14 +736,14 @@ describe('app.respond', function(){
         this.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
       .expect('Content-Type', 'application/json; charset=utf-8')
       .end(function(err, res){
         if (err) return done(err);
-        var pkg = require('../package');
+        const pkg = require('../package');
         res.should.not.have.header('Content-Length');
         res.body.should.eql(pkg);
         done();
@@ -751,7 +751,7 @@ describe('app.respond', function(){
     })
 
     it('should keep content-length if not overwritten', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.length = fs.readFileSync('package.json').length;
@@ -759,14 +759,14 @@ describe('app.respond', function(){
         this.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
       .expect('Content-Type', 'application/json; charset=utf-8')
       .end(function(err, res){
         if (err) return done(err);
-        var pkg = require('../package');
+        const pkg = require('../package');
         res.should.have.header('Content-Length');
         res.body.should.eql(pkg);
         done();
@@ -774,24 +774,24 @@ describe('app.respond', function(){
     })
 
     it('should keep content-length if overwritten with the same stream', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.length = fs.readFileSync('package.json').length;
-        var stream = fs.createReadStream('package.json');
+        const stream = fs.createReadStream('package.json');
         this.body = stream;
         this.body = stream;
         this.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
       .expect('Content-Type', 'application/json; charset=utf-8')
       .end(function(err, res){
         if (err) return done(err);
-        var pkg = require('../package');
+        const pkg = require('../package');
         res.should.have.header('Content-Length');
         res.body.should.eql(pkg);
         done();
@@ -799,14 +799,14 @@ describe('app.respond', function(){
     })
 
     it('should handle errors', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.set('Content-Type', 'application/json; charset=utf-8');
         this.body = fs.createReadStream('does not exist');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -816,14 +816,14 @@ describe('app.respond', function(){
     })
 
     it('should handle errors when no content status', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 204;
         this.body = fs.createReadStream('does not exist');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -832,7 +832,7 @@ describe('app.respond', function(){
 
 
     it('should handle all intermediate stream body errors', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = fs.createReadStream('does not exist');
@@ -840,7 +840,7 @@ describe('app.respond', function(){
         this.body = fs.createReadStream('does not exist');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -850,13 +850,13 @@ describe('app.respond', function(){
 
   describe('when .body is an Object', function(){
     it('should respond with json', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = { hello: 'world' };
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -867,7 +867,7 @@ describe('app.respond', function(){
 
   describe('when an error occurs', function(){
     it('should emit "error" on the app', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         throw new Error('boom');
@@ -885,10 +885,10 @@ describe('app.respond', function(){
 
     describe('with an .expose property', function(){
       it('should expose the message', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
-          var err = new Error('sorry!');
+          const err = new Error('sorry!');
           err.status = 403;
           err.expose = true;
           throw err;
@@ -903,10 +903,10 @@ describe('app.respond', function(){
 
     describe('with a .status property', function(){
       it('should respond with .status', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(){
-          var err = new Error('s3 explodes');
+          const err = new Error('s3 explodes');
           err.status = 403;
           throw err;
         });
@@ -919,13 +919,13 @@ describe('app.respond', function(){
     })
 
     it('should respond with 500', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         throw new Error('boom!');
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -934,7 +934,7 @@ describe('app.respond', function(){
     })
 
     it('should be catchable', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(next){
         try {
@@ -950,7 +950,7 @@ describe('app.respond', function(){
         this.body = 'Oh no';
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -961,7 +961,7 @@ describe('app.respond', function(){
 
   describe('when status and body property', function(){
     it('should 200', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 304;
@@ -969,7 +969,7 @@ describe('app.respond', function(){
         this.status = 200;
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -978,7 +978,7 @@ describe('app.respond', function(){
     })
 
     it('should 204', function(done) {
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = 200;
@@ -987,7 +987,7 @@ describe('app.respond', function(){
         this.status = 204;
       });
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -1001,9 +1001,9 @@ describe('app.respond', function(){
 })
 
 describe('app.context', function(){
-  var app1 = koa();
+  const app1 = koa();
   app1.context.msg = 'hello';
-  var app2 = koa();
+  const app2 = koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){
@@ -1029,9 +1029,9 @@ describe('app.context', function(){
 })
 
 describe('app.request', function(){
-  var app1 = koa();
+  const app1 = koa();
   app1.request.message = 'hello';
-  var app2 = koa();
+  const app2 = koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){
@@ -1057,9 +1057,9 @@ describe('app.request', function(){
 })
 
 describe('app.response', function(){
-  var app1 = koa();
+  const app1 = koa();
   app1.response.msg = 'hello';
-  var app2 = koa();
+  const app2 = koa();
 
   it('should merge properties', function(done){
     app1.use(function *(next){

--- a/test/context.js
+++ b/test/context.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const Stream = require('stream');
 const koa = require('..');
 

--- a/test/context.js
+++ b/test/context.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const Stream = require('stream');
-const koa = require('..');
+const Koa = require('..');
 
 exports = module.exports = function(req, res){
   const socket = new Stream.Duplex();
@@ -11,7 +11,7 @@ exports = module.exports = function(req, res){
   res.getHeader = function(k){ return res._headers[k.toLowerCase()] };
   res.setHeader = function(k, v){ res._headers[k.toLowerCase()] = v };
   res.removeHeader = function(k, v){ delete res._headers[k.toLowerCase()] };
-  return koa().createContext(req, res);
+  return (new Koa()).createContext(req, res);
 }
 
 exports.request = function(req, res){

--- a/test/context.js
+++ b/test/context.js
@@ -1,9 +1,9 @@
 
-var Stream = require('stream');
-var koa = require('..');
+const Stream = require('stream');
+const koa = require('..');
 
 exports = module.exports = function(req, res){
-  var socket = new Stream.Duplex();
+  const socket = new Stream.Duplex();
   req = req || { headers: {}, socket: socket, __proto__: Stream.Readable.prototype };
   res = res || { _headers: {}, socket: socket, __proto__: Stream.Writable.prototype };
   res.getHeader = function(k){ return res._headers[k.toLowerCase()] };

--- a/test/context/assert.js
+++ b/test/context/assert.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 var context = require('../context');
 var assert = require('assert');
 

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('supertest');
 const koa = require('../..');
 

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -2,11 +2,11 @@
 'use strict';
 
 const request = require('supertest');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('ctx.cookies.set()', function(){
   it('should set an unsigned cookie', function(done){
-    const app = koa();
+    const app = new Koa();
 
     app.use(function *(next){
       this.cookies.set('name', 'jon');
@@ -32,7 +32,7 @@ describe('ctx.cookies.set()', function(){
   describe('with .signed', function(){
     describe('when no .keys are set', function(){
       it('should error', function(done){
-        const app = koa();
+        const app = new Koa();;
 
         app.use(function *(next){
           try {
@@ -49,7 +49,7 @@ describe('ctx.cookies.set()', function(){
     })
 
     it('should send a signed cookie', function(done){
-      const app = koa();
+      const app = new Koa();;
 
       app.keys = ['a', 'b'];
 

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -1,17 +1,17 @@
 
-var request = require('supertest');
-var koa = require('../..');
+const request = require('supertest');
+const koa = require('../..');
 
 describe('ctx.cookies.set()', function(){
   it('should set an unsigned cookie', function(done){
-    var app = koa();
+    const app = koa();
 
     app.use(function *(next){
       this.cookies.set('name', 'jon');
       this.status = 204;
     })
 
-    var server = app.listen();
+    const server = app.listen();
 
     request(server)
     .get('/')
@@ -30,7 +30,7 @@ describe('ctx.cookies.set()', function(){
   describe('with .signed', function(){
     describe('when no .keys are set', function(){
       it('should error', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(next){
           try {
@@ -47,7 +47,7 @@ describe('ctx.cookies.set()', function(){
     })
 
     it('should send a signed cookie', function(done){
-      var app = koa();
+      const app = koa();
 
       app.keys = ['a', 'b'];
 
@@ -56,7 +56,7 @@ describe('ctx.cookies.set()', function(){
         this.status = 204;
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')
@@ -64,7 +64,7 @@ describe('ctx.cookies.set()', function(){
       .end(function(err, res){
         if (err) return done(err);
 
-        var cookies = res.headers['set-cookie'];
+        const cookies = res.headers['set-cookie'];
 
         cookies.some(function(cookie){
           return /^name=/.test(cookie);

--- a/test/context/inspect.js
+++ b/test/context/inspect.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.inspect()', function(){

--- a/test/context/inspect.js
+++ b/test/context/inspect.js
@@ -1,10 +1,10 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.inspect()', function(){
   it('should return a json representation', function(){
-    var ctx = context();
-    var toJSON = ctx.toJSON(ctx);
+    const ctx = context();
+    const toJSON = ctx.toJSON(ctx);
 
     toJSON.should.eql(ctx.inspect());
   })

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('supertest');
 const koa = require('../..');
 

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -2,11 +2,11 @@
 'use strict';
 
 const request = require('supertest');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('ctx.onerror(err)', function(){
   it('should respond', function(done){
-    const app = koa();
+    const app = new Koa();;
 
     app.use(function *(next){
       this.body = 'something else';
@@ -25,7 +25,7 @@ describe('ctx.onerror(err)', function(){
   })
 
   it('should unset all headers', function(done){
-    const app = koa();
+    const app = new Koa();;
 
     app.use(function *(next){
       this.set('Vary', 'Accept-Encoding');
@@ -55,7 +55,7 @@ describe('ctx.onerror(err)', function(){
   describe('when invalid err.status', function(){
     describe('not number', function(){
       it('should respond 500', function(done){
-        const app = koa();
+        const app = new Koa();;
 
         app.use(function *(next){
           this.body = 'something else';
@@ -76,7 +76,7 @@ describe('ctx.onerror(err)', function(){
 
     describe('not http status code', function(){
       it('should respond 500', function(done){
-        const app = koa();
+        const app = new Koa();;
 
         app.use(function *(next){
           this.body = 'something else';
@@ -98,7 +98,7 @@ describe('ctx.onerror(err)', function(){
 
   describe('when non-error thrown', function(){
     it('should response non-error thrown message', function(done){
-      const app = koa();
+      const app = new Koa();;
 
       app.use(function *(next){
         throw 'string error';

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -1,10 +1,10 @@
 
-var request = require('supertest');
-var koa = require('../..');
+const request = require('supertest');
+const koa = require('../..');
 
 describe('ctx.onerror(err)', function(){
   it('should respond', function(done){
-    var app = koa();
+    const app = koa();
 
     app.use(function *(next){
       this.body = 'something else';
@@ -12,7 +12,7 @@ describe('ctx.onerror(err)', function(){
       this.throw(418, 'boom');
     })
 
-    var server = app.listen();
+    const server = app.listen();
 
     request(server)
     .get('/')
@@ -23,7 +23,7 @@ describe('ctx.onerror(err)', function(){
   })
 
   it('should unset all headers', function(done){
-    var app = koa();
+    const app = koa();
 
     app.use(function *(next){
       this.set('Vary', 'Accept-Encoding');
@@ -33,7 +33,7 @@ describe('ctx.onerror(err)', function(){
       this.throw(418, 'boom');
     })
 
-    var server = app.listen();
+    const server = app.listen();
 
     request(server)
     .get('/')
@@ -53,16 +53,16 @@ describe('ctx.onerror(err)', function(){
   describe('when invalid err.status', function(){
     describe('not number', function(){
       it('should respond 500', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(next){
           this.body = 'something else';
-          var err = new Error('some error');
+          const err = new Error('some error');
           err.status = 'notnumber';
           throw err;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -74,16 +74,16 @@ describe('ctx.onerror(err)', function(){
 
     describe('not http status code', function(){
       it('should respond 500', function(done){
-        var app = koa();
+        const app = koa();
 
         app.use(function *(next){
           this.body = 'something else';
-          var err = new Error('some error');
+          const err = new Error('some error');
           err.status = 9999;
           throw err;
         })
 
-        var server = app.listen();
+        const server = app.listen();
 
         request(server)
         .get('/')
@@ -96,13 +96,13 @@ describe('ctx.onerror(err)', function(){
 
   describe('when non-error thrown', function(){
     it('should response non-error thrown message', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(next){
         throw 'string error';
       })
 
-      var server = app.listen();
+      const server = app.listen();
 
       request(server)
       .get('/')

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('supertest');
 const assert = require('assert');
 const koa = require('../..');

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -3,11 +3,11 @@
 
 const request = require('supertest');
 const assert = require('assert');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('ctx.state', function() {
   it('should provide a ctx.state namespace', function(done) {
-    const app = koa();
+    const app = new Koa();;
 
     app.use(function *() {
       assert.deepEqual(this.state, {});

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -1,17 +1,17 @@
 
-var request = require('supertest');
-var assert = require('assert');
-var koa = require('../..');
+const request = require('supertest');
+const assert = require('assert');
+const koa = require('../..');
 
 describe('ctx.state', function() {
   it('should provide a ctx.state namespace', function(done) {
-    var app = koa();
+    const app = koa();
 
     app.use(function *() {
       assert.deepEqual(this.state, {});
     });
 
-    var server = app.listen();
+    const server = app.listen();
 
     request(server)
     .get('/')

--- a/test/context/throw.js
+++ b/test/context/throw.js
@@ -1,10 +1,10 @@
 
-var context = require('../context');
-var assert = require('assert');
+const context = require('../context');
+const assert = require('assert');
 
 describe('ctx.throw(msg)', function(){
   it('should set .status to 500', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw('boom');
@@ -18,8 +18,8 @@ describe('ctx.throw(msg)', function(){
 
 describe('ctx.throw(err)', function(){
   it('should set .status to 500', function(done){
-    var ctx = context();
-    var err = new Error('test');
+    const ctx = context();
+    const err = new Error('test');
 
     try {
       ctx.throw(err);
@@ -34,8 +34,8 @@ describe('ctx.throw(err)', function(){
 
 describe('ctx.throw(err, status)', function(){
   it('should throw the error and set .status', function(done){
-    var ctx = context();
-    var error = new Error('test');
+    const ctx = context();
+    const error = new Error('test');
 
     try {
       ctx.throw(error, 422);
@@ -50,8 +50,8 @@ describe('ctx.throw(err, status)', function(){
 
 describe('ctx.throw(status, err)', function(){
   it('should throw the error and set .status', function(done){
-    var ctx = context();
-    var error = new Error('test');
+    const ctx = context();
+    const error = new Error('test');
 
     try {
       ctx.throw(422, error);
@@ -66,7 +66,7 @@ describe('ctx.throw(status, err)', function(){
 
 describe('ctx.throw(msg, status)', function(){
   it('should throw an error', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw('name required', 400);
@@ -81,7 +81,7 @@ describe('ctx.throw(msg, status)', function(){
 
 describe('ctx.throw(status, msg)', function(){
   it('should throw an error', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw(400, 'name required');
@@ -96,7 +96,7 @@ describe('ctx.throw(status, msg)', function(){
 
 describe('ctx.throw(status)', function(){
   it('should throw an error', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw(400);
@@ -110,10 +110,10 @@ describe('ctx.throw(status)', function(){
 
   describe('when not valid status', function(){
     it('should not expose', function(done){
-      var ctx = context();
+      const ctx = context();
 
       try {
-        var err = new Error('some error');
+        const err = new Error('some error');
         err.status = -1;
         ctx.throw(err);
       } catch(err) {
@@ -127,7 +127,7 @@ describe('ctx.throw(status)', function(){
 
 describe('ctx.throw(status, msg, props)', function(){
   it('should mixin props', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw(400, 'msg', { prop: true });
@@ -142,7 +142,7 @@ describe('ctx.throw(status, msg, props)', function(){
 
   describe('when props include status', function(){
     it('should be ignored', function(done){
-      var ctx = context();
+      const ctx = context();
 
       try {
         ctx.throw(400, 'msg', {
@@ -162,7 +162,7 @@ describe('ctx.throw(status, msg, props)', function(){
 
 describe('ctx.throw(msg, props)', function(){
   it('should mixin props', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw('msg', { prop: true });
@@ -178,7 +178,7 @@ describe('ctx.throw(msg, props)', function(){
 
 describe('ctx.throw(status, props)', function(){
   it('should mixin props', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw(400, { prop: true });
@@ -194,7 +194,7 @@ describe('ctx.throw(status, props)', function(){
 
 describe('ctx.throw(err, props)', function(){
   it('should mixin props', function(done){
-    var ctx = context();
+    const ctx = context();
 
     try {
       ctx.throw(new Error('test'), { prop: true });

--- a/test/context/throw.js
+++ b/test/context/throw.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 const assert = require('assert');
 

--- a/test/context/toJSON.js
+++ b/test/context/toJSON.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.toJSON()', function(){
   it('should return a json representation', function(){
-    var ctx = context();
+    const ctx = context();
 
     ctx.req.method = 'POST';
     ctx.req.url = '/items';
@@ -11,9 +11,9 @@ describe('ctx.toJSON()', function(){
     ctx.status = 200;
     ctx.body = '<p>Hey</p>';
 
-    var obj = JSON.parse(JSON.stringify(ctx));
-    var req = obj.request;
-    var res = obj.response;
+    const obj = JSON.parse(JSON.stringify(ctx));
+    const req = obj.request;
+    const res = obj.response;
 
     req.should.eql({
       method: 'POST',

--- a/test/context/toJSON.js
+++ b/test/context/toJSON.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.toJSON()', function(){

--- a/test/experimental/async.js
+++ b/test/experimental/async.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 /**
  * Separate file primarily because we use `require('babel/register')`.
  */

--- a/test/experimental/async.js
+++ b/test/experimental/async.js
@@ -6,11 +6,11 @@
  */
 
 const request = require('supertest');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('.experimental=true', function () {
   it('should support async functions', function (done) {
-    const app = koa();
+    const app = new Koa();;
     app.experimental = true;
     app.use(async function (next) {
       const string = await Promise.resolve('asdf');

--- a/test/experimental/async.js
+++ b/test/experimental/async.js
@@ -3,15 +3,15 @@
  * Separate file primarily because we use `require('babel/register')`.
  */
 
-var request = require('supertest');
-var koa = require('../..');
+const request = require('supertest');
+const koa = require('../..');
 
 describe('.experimental=true', function () {
   it('should support async functions', function (done) {
-    var app = koa();
+    const app = koa();
     app.experimental = true;
     app.use(async function (next) {
-      var string = await Promise.resolve('asdf');
+      const string = await Promise.resolve('asdf');
       this.body = string;
     });
 

--- a/test/experimental/index.js
+++ b/test/experimental/index.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 require('babel/register')({
   optional: ['asyncToGenerator']
 });

--- a/test/request/accepts.js
+++ b/test/request/accepts.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.accepts(types)', function(){
   describe('with no arguments', function(){
     describe('when Accept is populated', function(){
       it('should return all accepted types', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.req.headers.accept = 'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
         ctx.accepts().should.eql(['text/html', 'text/plain', 'image/jpeg', 'application/*']);
       })
@@ -15,7 +15,7 @@ describe('ctx.accepts(types)', function(){
   describe('with no valid types', function(){
     describe('when Accept is populated', function(){
       it('should return false', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.req.headers.accept = 'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
         ctx.accepts('image/png', 'image/tiff').should.be.false;
       })
@@ -23,7 +23,7 @@ describe('ctx.accepts(types)', function(){
 
     describe('when Accept is not populated', function(){
       it('should return the first type', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.accepts('text/html', 'text/plain', 'image/jpeg', 'application/*').should.equal('text/html');
       })
     })
@@ -31,7 +31,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when extensions are given', function(){
     it('should convert to mime types', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
       ctx.accepts('html').should.equal('html');
       ctx.accepts('.html').should.equal('.html');
@@ -43,7 +43,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when an array is given', function(){
     it('should return the first match', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
       ctx.accepts(['png', 'text', 'html']).should.equal('text');
       ctx.accepts(['png', 'html']).should.equal('html');
@@ -52,7 +52,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when multiple arguments are given', function(){
     it('should return the first match', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
       ctx.accepts('png', 'text', 'html').should.equal('text');
       ctx.accepts('png', 'html').should.equal('html');
@@ -61,7 +61,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when present in Accept as an exact match', function(){
     it('should return the type', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
       ctx.accepts('text/html').should.equal('text/html');
       ctx.accepts('text/plain').should.equal('text/plain');
@@ -70,7 +70,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when present in Accept as a type match', function(){
     it('should return the type', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'application/json, */*';
       ctx.accepts('text/html').should.equal('text/html');
       ctx.accepts('text/plain').should.equal('text/plain');
@@ -80,7 +80,7 @@ describe('ctx.accepts(types)', function(){
 
   describe('when present in Accept as a subtype match', function(){
     it('should return the type', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.accept = 'application/json, text/*';
       ctx.accepts('text/html').should.equal('text/html');
       ctx.accepts('text/plain').should.equal('text/plain');

--- a/test/request/accepts.js
+++ b/test/request/accepts.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.accepts(types)', function(){

--- a/test/request/acceptsCharsets.js
+++ b/test/request/acceptsCharsets.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.acceptsCharsets()', function(){

--- a/test/request/acceptsCharsets.js
+++ b/test/request/acceptsCharsets.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.acceptsCharsets()', function(){
   describe('with no arguments', function(){
     describe('when Accept-Charset is populated', function(){
       it('should return accepted types', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
         ctx.acceptsCharsets().should.eql(['utf-8', 'utf-7', 'iso-8859-1']);
       })
@@ -16,7 +16,7 @@ describe('ctx.acceptsCharsets()', function(){
     describe('when Accept-Charset is populated', function(){
       describe('if any types match', function(){
         it('should return the best fit', function(){
-          var ctx = context();
+          const ctx = context();
           ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
           ctx.acceptsCharsets('utf-7', 'utf-8').should.equal('utf-8');
         })
@@ -24,7 +24,7 @@ describe('ctx.acceptsCharsets()', function(){
 
       describe('if no types match', function(){
         it('should return false', function(){
-          var ctx = context();
+          const ctx = context();
           ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
           ctx.acceptsCharsets('utf-16').should.be.false;
         })
@@ -33,7 +33,7 @@ describe('ctx.acceptsCharsets()', function(){
 
     describe('when Accept-Charset is not populated', function(){
       it('should return the first type', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.acceptsCharsets('utf-7', 'utf-8').should.equal('utf-7');
       })
     })
@@ -41,7 +41,7 @@ describe('ctx.acceptsCharsets()', function(){
 
   describe('with an array', function(){
     it('should return the best fit', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
       ctx.acceptsCharsets(['utf-7', 'utf-8']).should.equal('utf-8');
     })

--- a/test/request/acceptsEncodings.js
+++ b/test/request/acceptsEncodings.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.acceptsEncodings()', function(){

--- a/test/request/acceptsEncodings.js
+++ b/test/request/acceptsEncodings.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.acceptsEncodings()', function(){
   describe('with no arguments', function(){
     describe('when Accept-Encoding is populated', function(){
       it('should return accepted types', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
         ctx.acceptsEncodings().should.eql(['gzip', 'compress', 'identity']);
         ctx.acceptsEncodings('gzip', 'compress').should.equal('gzip');
@@ -14,7 +14,7 @@ describe('ctx.acceptsEncodings()', function(){
 
     describe('when Accept-Encoding is not populated', function(){
       it('should return identity', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.acceptsEncodings().should.eql(['identity']);
         ctx.acceptsEncodings('gzip', 'deflate', 'identity').should.equal('identity');
       })
@@ -23,7 +23,7 @@ describe('ctx.acceptsEncodings()', function(){
 
   describe('with multiple arguments', function(){
     it('should return the best fit', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
       ctx.acceptsEncodings('compress', 'gzip').should.eql('gzip');
       ctx.acceptsEncodings('gzip', 'compress').should.eql('gzip');
@@ -32,7 +32,7 @@ describe('ctx.acceptsEncodings()', function(){
 
   describe('with an array', function(){
     it('should return the best fit', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
       ctx.acceptsEncodings(['compress', 'gzip']).should.eql('gzip');
     })

--- a/test/request/acceptsLanguages.js
+++ b/test/request/acceptsLanguages.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.acceptsLanguages(langs)', function(){

--- a/test/request/acceptsLanguages.js
+++ b/test/request/acceptsLanguages.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.acceptsLanguages(langs)', function(){
   describe('with no arguments', function(){
     describe('when Accept-Language is populated', function(){
       it('should return accepted types', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
         ctx.acceptsLanguages().should.eql(['es', 'pt', 'en']);
       })
@@ -16,7 +16,7 @@ describe('ctx.acceptsLanguages(langs)', function(){
     describe('when Accept-Language is populated', function(){
       describe('if any types types match', function(){
         it('should return the best fit', function(){
-          var ctx = context();
+          const ctx = context();
           ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
           ctx.acceptsLanguages('es', 'en').should.equal('es');
         })
@@ -24,7 +24,7 @@ describe('ctx.acceptsLanguages(langs)', function(){
 
       describe('if no types match', function(){
         it('should return false', function(){
-          var ctx = context();
+          const ctx = context();
           ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
           ctx.acceptsLanguages('fr', 'au').should.be.false;
         })
@@ -33,7 +33,7 @@ describe('ctx.acceptsLanguages(langs)', function(){
 
     describe('when Accept-Language is not populated', function(){
       it('should return the first type', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.acceptsLanguages('es', 'en').should.equal('es');
       })
     })
@@ -41,7 +41,7 @@ describe('ctx.acceptsLanguages(langs)', function(){
 
   describe('with an array', function(){
     it('should return the best fit', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
       ctx.acceptsLanguages(['es', 'en']).should.equal('es');
     })

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -1,18 +1,18 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('req.charset', function(){
   describe('with no content-type present', function(){
     it('should return ""', function(){
-      var req = request();
+      const req = request();
       assert('' === req.charset);
     })
   })
 
   describe('with charset present', function(){
     it('should return ""', function(){
-      var req = request();
+      const req = request();
       req.header['content-type'] = 'text/plain';
       assert('' === req.charset);
     })
@@ -20,7 +20,7 @@ describe('req.charset', function(){
 
   describe('with a charset', function(){
     it('should return the charset', function(){
-      var req = request();
+      const req = request();
       req.header['content-type'] = 'text/plain; charset=utf-8';
       req.charset.should.equal('utf-8');
     })

--- a/test/request/fresh.js
+++ b/test/request/fresh.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.fresh', function(){

--- a/test/request/fresh.js
+++ b/test/request/fresh.js
@@ -1,10 +1,10 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.fresh', function(){
   describe('the request method is not GET and HEAD', function (){
     it('should return false', function (){
-      var ctx = context();
+      const ctx = context();
       ctx.req.method = 'POST';
       ctx.fresh.should.be.false;
     })
@@ -12,7 +12,7 @@ describe('ctx.fresh', function(){
 
   describe('the response is non-2xx', function(){
     it('should return false', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.status = 404;
       ctx.req.method = 'GET';
       ctx.req.headers['if-none-match'] = '123';
@@ -24,7 +24,7 @@ describe('ctx.fresh', function(){
   describe('the response is 2xx', function(){
     describe('and etag matches', function(){
       it('should return true', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.status = 200;
         ctx.req.method = 'GET';
         ctx.req.headers['if-none-match'] = '123';
@@ -35,7 +35,7 @@ describe('ctx.fresh', function(){
 
     describe('and etag do not match', function(){
       it('should return false', function(){
-        var ctx = context();
+        const ctx = context();
         ctx.status = 200;
         ctx.req.method = 'GET';
         ctx.req.headers['if-none-match'] = '123';

--- a/test/request/get.js
+++ b/test/request/get.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.get(name)', function(){
   it('should return the field value', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.req.headers.host = 'http://google.com';
     ctx.req.headers.referer = 'http://google.com';
     ctx.get('HOST').should.equal('http://google.com');

--- a/test/request/get.js
+++ b/test/request/get.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.get(name)', function(){

--- a/test/request/header.js
+++ b/test/request/header.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.header', function(){

--- a/test/request/header.js
+++ b/test/request/header.js
@@ -1,9 +1,9 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.header', function(){
   it('should return the request header object', function(){
-    var req = request();
+    const req = request();
     req.header.should.equal(req.req.headers);
   })
 })

--- a/test/request/headers.js
+++ b/test/request/headers.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.headers', function(){

--- a/test/request/headers.js
+++ b/test/request/headers.js
@@ -1,9 +1,9 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.headers', function(){
   it('should return the request header object', function(){
-    var req = request();
+    const req = request();
     req.headers.should.equal(req.req.headers);
   })
 })

--- a/test/request/host.js
+++ b/test/request/host.js
@@ -1,17 +1,17 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('req.host', function(){
   it('should return host with port', function(){
-    var req = request();
+    const req = request();
     req.header.host = 'foo.com:3000';
     req.host.should.equal('foo.com:3000');
   })
 
   describe('with no host present', function(){
     it('should return ""', function(){
-      var req = request();
+      const req = request();
       assert.equal(req.host, '');
     })
   })
@@ -19,7 +19,7 @@ describe('req.host', function(){
   describe('when X-Forwarded-Host is present', function(){
     describe('and proxy is not trusted', function(){
       it('should be ignored', function(){
-        var req = request();
+        const req = request();
         req.header['x-forwarded-host'] = 'bar.com';
         req.header['host'] = 'foo.com';
         req.host.should.equal('foo.com');
@@ -28,7 +28,7 @@ describe('req.host', function(){
 
     describe('and proxy is trusted', function(){
       it('should be used', function(){
-        var req = request();
+        const req = request();
         req.app.proxy = true;
         req.header['x-forwarded-host'] = 'bar.com, baz.com';
         req.header['host'] = 'foo.com';

--- a/test/request/host.js
+++ b/test/request/host.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/request/hostname.js
+++ b/test/request/hostname.js
@@ -1,17 +1,17 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('req.hostname', function(){
   it('should return hostname void of port', function(){
-    var req = request();
+    const req = request();
     req.header.host = 'foo.com:3000';
     req.hostname.should.equal('foo.com');
   })
 
   describe('with no host present', function(){
     it('should return ""', function(){
-      var req = request();
+      const req = request();
       assert.equal(req.hostname, '');
     })
   })
@@ -19,7 +19,7 @@ describe('req.hostname', function(){
   describe('when X-Forwarded-Host is present', function(){
     describe('and proxy is not trusted', function(){
       it('should be ignored', function(){
-        var req = request();
+        const req = request();
         req.header['x-forwarded-host'] = 'bar.com';
         req.header['host'] = 'foo.com';
         req.hostname.should.equal('foo.com')
@@ -28,7 +28,7 @@ describe('req.hostname', function(){
 
     describe('and proxy is trusted', function(){
       it('should be used', function(){
-        var req = request();
+        const req = request();
         req.app.proxy = true;
         req.header['x-forwarded-host'] = 'bar.com, baz.com';
         req.header['host'] = 'foo.com';

--- a/test/request/hostname.js
+++ b/test/request/hostname.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/request/href.js
+++ b/test/request/href.js
@@ -3,7 +3,7 @@
 
 const Stream = require('stream');
 const http = require('http');
-const koa = require('../../');
+const Koa = require('../../');
 const context = require('../context');
 
 describe('ctx.href', function(){
@@ -25,7 +25,7 @@ describe('ctx.href', function(){
   })
 
   it('should work with `GET http://example.com/foo`', function(done){
-    const app = koa()
+    const app = new Koa();
     app.use(function* (){
       this.body = this.href
     })

--- a/test/request/href.js
+++ b/test/request/href.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const Stream = require('stream');
 const http = require('http');
 const koa = require('../../');

--- a/test/request/href.js
+++ b/test/request/href.js
@@ -1,13 +1,13 @@
 
-var Stream = require('stream');
-var http = require('http');
-var koa = require('../../');
-var context = require('../context');
+const Stream = require('stream');
+const http = require('http');
+const koa = require('../../');
+const context = require('../context');
 
 describe('ctx.href', function(){
   it('should return the full request url', function(){
-    var socket = new Stream.Duplex();
-    var req = {
+    const socket = new Stream.Duplex();
+    const req = {
       url: '/users/1?next=/dashboard',
       headers: {
         host: 'localhost'
@@ -15,7 +15,7 @@ describe('ctx.href', function(){
       socket: socket,
       __proto__: Stream.Readable.prototype
     };
-    var ctx = context(req);
+    const ctx = context(req);
     ctx.href.should.equal('http://localhost/users/1?next=/dashboard');
     // change it also work
     ctx.url = '/foo/users/1?next=/dashboard';
@@ -23,12 +23,12 @@ describe('ctx.href', function(){
   })
 
   it('should work with `GET http://example.com/foo`', function(done){
-    var app = koa()
+    const app = koa()
     app.use(function* (){
       this.body = this.href
     })
     app.listen(function(){
-      var address = this.address()
+      const address = this.address()
       http.get({
         host: 'localhost',
         path: 'http://example.com/foo',

--- a/test/request/idempotent.js
+++ b/test/request/idempotent.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('ctx.idempotent', function(){

--- a/test/request/idempotent.js
+++ b/test/request/idempotent.js
@@ -1,12 +1,12 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('ctx.idempotent', function(){
   describe('when the request method is idempotent', function (){
     it('should return true', function (){
       ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'].forEach(check);
       function check(method) {
-        var req = request();
+        const req = request();
         req.method = method;
         req.idempotent.should.equal(true);
       }
@@ -15,7 +15,7 @@ describe('ctx.idempotent', function(){
 
   describe('when the request method is not idempotent', function(){
     it('should return false', function (){
-      var req = request();
+      const req = request();
       req.method = 'POST';
       req.idempotent.should.equal(false);
     })

--- a/test/request/inspect.js
+++ b/test/request/inspect.js
@@ -1,11 +1,11 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('req.inspect()', function(){
   describe('with no request.req present', function(){
     it('should return null', function(){
-      var req = request();
+      const req = request();
       req.method = 'GET';
       delete req.req;
       assert(null == req.inspect());
@@ -13,7 +13,7 @@ describe('req.inspect()', function(){
   })
 
   it('should return a json representation', function(){
-    var req = request();
+    const req = request();
     req.method = 'GET';
     req.url = 'example.com';
     req.header.host = 'example.com';

--- a/test/request/inspect.js
+++ b/test/request/inspect.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/request/ip.js
+++ b/test/request/ip.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.ip', function(){

--- a/test/request/ip.js
+++ b/test/request/ip.js
@@ -1,10 +1,10 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.ip', function(){
   describe('with req.ips present', function(){
     it('should return req.ips[0]', function(){
-      var req = request();
+      const req = request();
       req.app.proxy = true;
       req.header['x-forwarded-for'] = '127.0.0.1';
       req.socket.remoteAddress = '127.0.0.2';
@@ -14,14 +14,14 @@ describe('req.ip', function(){
 
   describe('with no req.ips present', function(){
     it('should return req.socket.remoteAddress', function(){
-      var req = request();
+      const req = request();
       req.socket.remoteAddress = '127.0.0.2';
       req.ip.should.equal('127.0.0.2');
     })
 
     describe('with req.socket.remoteAddress not present', function(){
       it('should return an empty string', function(){
-        var req = request();
+        const req = request();
         req.socket.remoteAddress = null;
         req.ip.should.equal('');
       })

--- a/test/request/ips.js
+++ b/test/request/ips.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.ips', function(){

--- a/test/request/ips.js
+++ b/test/request/ips.js
@@ -1,11 +1,11 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.ips', function(){
   describe('when X-Forwarded-For is present', function(){
     describe('and proxy is not trusted', function(){
       it('should be ignored', function(){
-        var req = request();
+        const req = request();
         req.app.proxy = false;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
         req.ips.should.eql([]);
@@ -14,7 +14,7 @@ describe('req.ips', function(){
 
     describe('and proxy is trusted', function(){
       it('should be used', function(){
-        var req = request();
+        const req = request();
         req.app.proxy = true;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
         req.ips.should.eql(['127.0.0.1', '127.0.0.2']);

--- a/test/request/is.js
+++ b/test/request/is.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
-var should = require('should');
-var assert = require('assert');
+const context = require('../context');
+const should = require('should');
+const assert = require('assert');
 
 describe('ctx.is(type)', function(){
   it('should ignore params', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.header['content-type'] = 'text/html; charset=utf-8';
     ctx.header['transfer-encoding'] = 'chunked';
 
@@ -14,7 +14,7 @@ describe('ctx.is(type)', function(){
 
   describe('when no body is given', function(){
     it('should return null', function(){
-      var ctx = context();
+      const ctx = context();
 
       assert(null == ctx.is());
       assert(null == ctx.is('image/*'));
@@ -24,7 +24,7 @@ describe('ctx.is(type)', function(){
 
   describe('when no content type is given', function(){
     it('should return false', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.header['transfer-encoding'] = 'chunked';
 
       ctx.is().should.be.false;
@@ -35,7 +35,7 @@ describe('ctx.is(type)', function(){
 
   describe('give no types', function(){
     it('should return the mime type', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
@@ -45,7 +45,7 @@ describe('ctx.is(type)', function(){
 
   describe('given one type', function(){
     it('should return the type or false', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
@@ -65,7 +65,7 @@ describe('ctx.is(type)', function(){
 
   describe('given multiple types', function(){
     it('should return the first match or false', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
@@ -90,7 +90,7 @@ describe('ctx.is(type)', function(){
 
   describe('when Content-Type: application/x-www-form-urlencoded', function(){
     it('should match "urlencoded"', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.header['content-type'] = 'application/x-www-form-urlencoded';
       ctx.header['transfer-encoding'] = 'chunked';
 

--- a/test/request/is.js
+++ b/test/request/is.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 const should = require('should');
 const assert = require('assert');

--- a/test/request/length.js
+++ b/test/request/length.js
@@ -1,16 +1,16 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('ctx.length', function(){
   it('should return length in content-length', function(){
-    var req = request();
+    const req = request();
     req.header['content-length'] = '10';
     req.length.should.equal(10);
   })
 
   describe('with no content-length present', function(){
-    var req = request();
+    const req = request();
     assert(null == req.length);
   })
 })

--- a/test/request/length.js
+++ b/test/request/length.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/request/origin.js
+++ b/test/request/origin.js
@@ -1,13 +1,13 @@
 
-var Stream = require('stream');
-var http = require('http');
-var koa = require('../../');
-var context = require('../context');
+const Stream = require('stream');
+const http = require('http');
+const koa = require('../../');
+const context = require('../context');
 
 describe('ctx.origin', function(){
   it('should return the origin of url', function(){
-    var socket = new Stream.Duplex();
-    var req = {
+    const socket = new Stream.Duplex();
+    const req = {
       url: '/users/1?next=/dashboard',
       headers: {
         host: 'localhost'
@@ -15,7 +15,7 @@ describe('ctx.origin', function(){
       socket: socket,
       __proto__: Stream.Readable.prototype
     };
-    var ctx = context(req);
+    const ctx = context(req);
     ctx.origin.should.equal('http://localhost');
     // change it also work
     ctx.url = '/foo/users/1?next=/dashboard';

--- a/test/request/origin.js
+++ b/test/request/origin.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const Stream = require('stream');
 const http = require('http');
 const koa = require('../../');

--- a/test/request/origin.js
+++ b/test/request/origin.js
@@ -3,7 +3,7 @@
 
 const Stream = require('stream');
 const http = require('http');
-const koa = require('../../');
+const Koa = require('../../');
 const context = require('../context');
 
 describe('ctx.origin', function(){

--- a/test/request/path.js
+++ b/test/request/path.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.path', function(){

--- a/test/request/path.js
+++ b/test/request/path.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.path', function(){
   it('should return the pathname', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.url = '/login?next=/dashboard';
     ctx.path.should.equal('/login');
   })
@@ -11,7 +11,7 @@ describe('ctx.path', function(){
 
 describe('ctx.path=', function(){
   it('should set the pathname', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.url = '/login?next=/dashboard';
 
     ctx.path = '/logout';
@@ -20,7 +20,7 @@ describe('ctx.path=', function(){
   })
 
   it('should change .url but not .originalUrl', function(){
-    var ctx = context({ url: '/login' });
+    const ctx = context({ url: '/login' });
     ctx.path = '/logout';
     ctx.url.should.equal('/logout');
     ctx.originalUrl.should.equal('/login');

--- a/test/request/protocol.js
+++ b/test/request/protocol.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.protocol', function(){

--- a/test/request/protocol.js
+++ b/test/request/protocol.js
@@ -1,10 +1,10 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.protocol', function(){
   describe('when encrypted', function(){
     it('should return "https"', function(){
-      var req = request();
+      const req = request();
       req.req.socket = { encrypted: true };
       req.protocol.should.equal('https');
     })
@@ -12,7 +12,7 @@ describe('req.protocol', function(){
 
   describe('when unencrypted', function(){
     it('should return "http"', function(){
-      var req = request();
+      const req = request();
       req.req.socket = {};
       req.protocol.should.equal('http');
     })
@@ -21,7 +21,7 @@ describe('req.protocol', function(){
   describe('when X-Forwarded-Proto is set', function(){
     describe('and proxy is trusted', function(){
       it('should be used', function(){
-        var req = request();
+        const req = request();
         req.app.proxy = true;
         req.req.socket = {};
         req.header['x-forwarded-proto'] = 'https, http';
@@ -30,7 +30,7 @@ describe('req.protocol', function(){
 
       describe('and X-Forwarded-Proto is empty', function(){
         it('should return "http"', function(){
-          var req = request();
+          const req = request();
           req.app.proxy = true;
           req.req.socket = {};
           req.header['x-forwarded-proto'] = '';
@@ -41,7 +41,7 @@ describe('req.protocol', function(){
 
     describe('and proxy is not trusted', function(){
       it('should not be used', function(){
-        var req = request();
+        const req = request();
         req.req.socket = {};
         req.header['x-forwarded-proto'] = 'https, http';
         req.protocol.should.equal('http');

--- a/test/request/query.js
+++ b/test/request/query.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.query', function(){

--- a/test/request/query.js
+++ b/test/request/query.js
@@ -1,15 +1,15 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.query', function(){
   describe('when missing', function(){
     it('should return an empty object', function(){
-      var ctx = context({ url: '/' });
+      const ctx = context({ url: '/' });
       ctx.query.should.eql({});
     })
 
     it('should return the same object each time it\'s accessed', function(done) {
-      var ctx = context({ url: '/' });
+      const ctx = context({ url: '/' });
       ctx.query.a = '2';
       ctx.query.a.should.equal('2');
       done();
@@ -17,14 +17,14 @@ describe('ctx.query', function(){
   })
 
   it('should return a parsed query-string', function(){
-    var ctx = context({ url: '/?page=2' });
+    const ctx = context({ url: '/?page=2' });
     ctx.query.page.should.equal('2');
   })
 })
 
 describe('ctx.query=', function(){
   it('should stringify and replace the querystring and search', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.query = { page: 2, color: 'blue' };
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.querystring.should.equal('page=2&color=blue');
@@ -32,7 +32,7 @@ describe('ctx.query=', function(){
   })
 
   it('should change .url but not .originalUrl', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.query = { page: 2 };
     ctx.url.should.equal('/store/shoes?page=2');
     ctx.originalUrl.should.equal('/store/shoes');

--- a/test/request/querystring.js
+++ b/test/request/querystring.js
@@ -1,15 +1,15 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.querystring', function(){
   it('should return the querystring', function(){
-    var ctx = context({ url: '/store/shoes?page=2&color=blue' });
+    const ctx = context({ url: '/store/shoes?page=2&color=blue' });
     ctx.querystring.should.equal('page=2&color=blue');
   })
 
   describe('when ctx.req not present', function(){
     it('should return an empty string', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.request.req = null;
       ctx.querystring.should.equal('');
     })
@@ -18,14 +18,14 @@ describe('ctx.querystring', function(){
 
 describe('ctx.querystring=', function(){
   it('should replace the querystring', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.querystring.should.equal('page=2&color=blue');
   })
 
   it('should update ctx.search and ctx.query', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.search.should.equal('?page=2&color=blue');
@@ -36,7 +36,7 @@ describe('ctx.querystring=', function(){
   })
 
   it('should change .url but not .originalUrl', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.originalUrl.should.equal('/store/shoes');

--- a/test/request/querystring.js
+++ b/test/request/querystring.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.querystring', function(){

--- a/test/request/search.js
+++ b/test/request/search.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.search=', function(){

--- a/test/request/search.js
+++ b/test/request/search.js
@@ -1,16 +1,16 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.search=', function(){
   it('should replace the search', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.search.should.equal('?page=2&color=blue');
   })
 
   it('should update ctx.querystring and ctx.query', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.querystring.should.equal('page=2&color=blue');
@@ -21,7 +21,7 @@ describe('ctx.search=', function(){
   })
 
   it('should change .url but not .originalUrl', function(){
-    var ctx = context({ url: '/store/shoes' });
+    const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.originalUrl.should.equal('/store/shoes');
@@ -30,7 +30,7 @@ describe('ctx.search=', function(){
 
   describe('when missing', function(){
     it('should return ""', function(){
-      var ctx = context({ url: '/store/shoes' });
+      const ctx = context({ url: '/store/shoes' });
       ctx.search.should.equal('');
     })
   })

--- a/test/request/secure.js
+++ b/test/request/secure.js
@@ -1,9 +1,9 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.secure', function(){
   it('should return true when encrypted', function(){
-    var req = request();
+    const req = request();
     req.req.socket = { encrypted: true };
     req.secure.should.be.true;
   })

--- a/test/request/secure.js
+++ b/test/request/secure.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.secure', function(){

--- a/test/request/stale.js
+++ b/test/request/stale.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('req.stale', function(){
   it('should be the inverse of req.fresh', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.status = 200;
     ctx.method = 'GET';
     ctx.req.headers['if-none-match'] = '"123"';

--- a/test/request/stale.js
+++ b/test/request/stale.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('req.stale', function(){

--- a/test/request/subdomains.js
+++ b/test/request/subdomains.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 
 describe('req.subdomains', function(){

--- a/test/request/subdomains.js
+++ b/test/request/subdomains.js
@@ -1,9 +1,9 @@
 
-var request = require('../context').request;
+const request = require('../context').request;
 
 describe('req.subdomains', function(){
   it('should return subdomain array', function(){
-    var req = request();
+    const req = request();
     req.header.host = 'tobi.ferrets.example.com';
     req.app.subdomainOffset = 2;
     req.subdomains.should.eql(['ferrets', 'tobi']);
@@ -13,7 +13,7 @@ describe('req.subdomains', function(){
   })
 
   describe('with no host present', function(){
-    var req = request();
+    const req = request();
     req.subdomains.should.eql([]);
   })
 })

--- a/test/request/type.js
+++ b/test/request/type.js
@@ -1,16 +1,16 @@
 
-var request = require('../context').request;
-var assert = require('assert');
+const request = require('../context').request;
+const assert = require('assert');
 
 describe('req.type', function(){
   it('should return type void of parameters', function(){
-    var req = request();
+    const req = request();
     req.header['content-type'] = 'text/html; charset=utf-8';
     req.type.should.equal('text/html');
   })
 
   describe('with no host present', function(){
-    var req = request();
+    const req = request();
     assert('' === req.type);
   })
 })

--- a/test/request/type.js
+++ b/test/request/type.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const request = require('../context').request;
 const assert = require('assert');
 

--- a/test/response/append.js
+++ b/test/response/append.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.append(name, val)', function(){

--- a/test/response/append.js
+++ b/test/response/append.js
@@ -1,16 +1,16 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.append(name, val)', function(){
   it('should append multiple headers', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.append('x-foo', 'bar1');
     ctx.append('x-foo', 'bar2');
     ctx.response.header['x-foo'].should.eql(['bar1', 'bar2']);
   })
 
  it('should accept array of values', function (){
-    var ctx = context();
+    const ctx = context();
 
     ctx.append('Set-Cookie', ['foo=bar', 'fizz=buzz']);
     ctx.append('Set-Cookie', 'hi=again');
@@ -18,7 +18,7 @@ describe('ctx.append(name, val)', function(){
   })
 
   it('should get reset by res.set(field, val)', function (){
-    var ctx = context();
+    const ctx = context();
 
     ctx.append('Link', '<http://localhost/>');
     ctx.append('Link', '<http://localhost:80/>');
@@ -29,7 +29,7 @@ describe('ctx.append(name, val)', function(){
   })
 
   it('should work with res.set(field, val) first', function (){
-    var ctx = context();
+    const ctx = context();
 
     ctx.set('Link', '<http://localhost/>');
     ctx.append('Link', '<http://localhost:80/>');

--- a/test/response/attachment.js
+++ b/test/response/attachment.js
@@ -1,21 +1,21 @@
 
-var context = require('../context');
-var request = require('supertest');
-var koa = require('../..');
+const context = require('../context');
+const request = require('supertest');
+const koa = require('../..');
 
 describe('ctx.attachment([filename])', function(){
   describe('when given a filename', function(){
     it('should set the filename param', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.attachment('path/to/tobi.png');
-      var str = 'attachment; filename="tobi.png"';
+      const str = 'attachment; filename="tobi.png"';
       ctx.response.header['content-disposition'].should.equal(str);
     })
   })
 
   describe('when omitting filename', function(){
     it('should not set filename param', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.attachment();
       ctx.response.header['content-disposition'].should.equal('attachment');
     })
@@ -23,14 +23,14 @@ describe('ctx.attachment([filename])', function(){
 
   describe('when given a no-ascii filename', function(){
     it('should set the encodeURI filename param', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.attachment('path/to/include-no-ascii-char-中文名-ok.png');
-      var str = 'attachment; filename=\"include-no-ascii-char-???-ok.png\"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.png';
+      const str = 'attachment; filename=\"include-no-ascii-char-???-ok.png\"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.png';
       ctx.response.header['content-disposition'].should.equal(str);
     })
 
     it('should work with http client', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function* (next){
         this.attachment('path/to/include-no-ascii-char-中文名-ok.json')

--- a/test/response/attachment.js
+++ b/test/response/attachment.js
@@ -3,7 +3,7 @@
 
 const context = require('../context');
 const request = require('supertest');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('ctx.attachment([filename])', function(){
   describe('when given a filename', function(){
@@ -32,7 +32,7 @@ describe('ctx.attachment([filename])', function(){
     })
 
     it('should work with http client', function(done){
-      const app = koa();
+      const app = new Koa();;
 
       app.use(function* (next){
         this.attachment('path/to/include-no-ascii-char-中文名-ok.json')

--- a/test/response/attachment.js
+++ b/test/response/attachment.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 const request = require('supertest');
 const koa = require('../..');

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -1,12 +1,12 @@
 
-var response = require('../context').response;
-var assert = require('assert');
-var fs = require('fs');
+const response = require('../context').response;
+const assert = require('assert');
+const fs = require('fs');
 
 describe('res.body=', function(){
   describe('when Content-Type is set', function(){
     it('should not override', function(){
-      var res = response();
+      const res = response();
       res.type = 'png';
       res.body = new Buffer('something');
       assert('image/png' == res.header['content-type']);
@@ -14,7 +14,7 @@ describe('res.body=', function(){
 
     describe('when body is an object', function(){
       it('should override as json', function(){
-        var res = response();
+        const res = response();
 
         res.body = '<em>hey</em>';
         assert('text/html; charset=utf-8' == res.header['content-type']);
@@ -25,7 +25,7 @@ describe('res.body=', function(){
     })
 
     it('should override length', function(){
-      var res = response();
+      const res = response();
       res.type = 'html';
       res.body = 'something';
       res.length.should.equal(9);
@@ -34,20 +34,20 @@ describe('res.body=', function(){
 
   describe('when a string is given', function(){
     it('should default to text', function(){
-      var res = response();
+      const res = response();
       res.body = 'Tobi';
       assert('text/plain; charset=utf-8' == res.header['content-type']);
     })
 
     it('should set length', function(){
-      var res = response();
+      const res = response();
       res.body = 'Tobi';
       assert('4' == res.header['content-length']);
     })
 
     describe('and contains a non-leading <', function(){
       it('should default to text', function(){
-        var res = response();
+        const res = response();
         res.body = 'aklsdjf < klajsdlfjasd';
         assert('text/plain; charset=utf-8' == res.header['content-type']);
       })
@@ -56,21 +56,21 @@ describe('res.body=', function(){
 
   describe('when an html string is given', function(){
     it('should default to html', function(){
-      var res = response();
+      const res = response();
       res.body = '<h1>Tobi</h1>';
       assert('text/html; charset=utf-8' == res.header['content-type']);
     })
 
     it('should set length', function(){
-      var string = '<h1>Tobi</h1>';
-      var res = response();
+      const string = '<h1>Tobi</h1>';
+      const res = response();
       res.body = string;
       assert.equal(res.length, Buffer.byteLength(string));
     })
 
     it('should set length when body is overridden', function(){
-      var string = '<h1>Tobi</h1>';
-      var res = response();
+      const string = '<h1>Tobi</h1>';
+      const res = response();
       res.body = string;
       res.body = string + string;
       assert.equal(res.length, 2 * Buffer.byteLength(string));
@@ -78,7 +78,7 @@ describe('res.body=', function(){
 
     describe('when it contains leading whitespace', function(){
       it('should default to html', function(){
-        var res = response();
+        const res = response();
         res.body = '    <h1>Tobi</h1>';
         assert('text/html; charset=utf-8' == res.header['content-type']);
       })
@@ -94,7 +94,7 @@ describe('res.body=', function(){
        * You should `.type=` if this simple test fails.
        */
 
-      var res = response();
+      const res = response();
       res.body = '<?xml version="1.0" encoding="UTF-8"?>\n<俄语>данные</俄语>';
       assert('text/html; charset=utf-8' == res.header['content-type']);
     })
@@ -102,7 +102,7 @@ describe('res.body=', function(){
 
   describe('when a stream is given', function(){
     it('should default to an octet stream', function(){
-      var res = response();
+      const res = response();
       res.body = fs.createReadStream('LICENSE');
       assert('application/octet-stream' == res.header['content-type']);
     })
@@ -110,13 +110,13 @@ describe('res.body=', function(){
 
   describe('when a buffer is given', function(){
     it('should default to an octet stream', function(){
-      var res = response();
+      const res = response();
       res.body = new Buffer('hey');
       assert('application/octet-stream' == res.header['content-type']);
     })
 
     it('should set length', function(){
-      var res = response();
+      const res = response();
       res.body = new Buffer('Tobi');
       assert('4' == res.header['content-length']);
     })
@@ -124,7 +124,7 @@ describe('res.body=', function(){
 
   describe('when an object is given', function(){
     it('should default to json', function(){
-      var res = response();
+      const res = response();
       res.body = { foo: 'bar' };
       assert('application/json; charset=utf-8' == res.header['content-type']);
     })

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const assert = require('assert');
 const fs = require('fs');

--- a/test/response/etag.js
+++ b/test/response/etag.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 
 describe('res.etag=', function(){

--- a/test/response/etag.js
+++ b/test/response/etag.js
@@ -1,21 +1,21 @@
 
-var response = require('../context').response;
+const response = require('../context').response;
 
 describe('res.etag=', function(){
   it('should not modify an etag with quotes', function(){
-    var res = response();
+    const res = response();
     res.etag = '"asdf"';
     res.header.etag.should.equal('"asdf"');
   })
 
   it('should not modify a weak etag', function(){
-    var res = response();
+    const res = response();
     res.etag = 'W/"asdf"';
     res.header.etag.should.equal('W/"asdf"');
   })
 
   it('should add quotes around an etag if necessary', function(){
-    var res = response();
+    const res = response();
     res.etag = 'asdf';
     res.header.etag.should.equal('"asdf"');
   })
@@ -23,7 +23,7 @@ describe('res.etag=', function(){
 
 describe('res.etag', function(){
   it('should return etag', function(){
-    var res = response();
+    const res = response();
     res.etag = '"asdf"';
     res.etag.should.equal('"asdf"');
   })

--- a/test/response/header.js
+++ b/test/response/header.js
@@ -1,16 +1,16 @@
 
-var response = require('../context').response;
+const response = require('../context').response;
 
 describe('res.header', function(){
   it('should return the response header object', function(){
-    var res = response();
+    const res = response();
     res.set('X-Foo', 'bar');
     res.header.should.eql({ 'x-foo': 'bar' });
   })
 
   describe('when res._headers not present', function (){
     it('should return empty object', function (){
-      var res = response();
+      const res = response();
       res.res._headers = null;
       res.header.should.eql({});
     })

--- a/test/response/header.js
+++ b/test/response/header.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 
 describe('res.header', function(){

--- a/test/response/headers.js
+++ b/test/response/headers.js
@@ -1,16 +1,16 @@
 
-var response = require('../context').response;
+const response = require('../context').response;
 
 describe('res.header', function(){
   it('should return the response header object', function(){
-    var res = response();
+    const res = response();
     res.set('X-Foo', 'bar');
     res.headers.should.eql({ 'x-foo': 'bar' });
   })
 
   describe('when res._headers not present', function (){
     it('should return empty object', function (){
-      var res = response();
+      const res = response();
       res.res._headers = null;
       res.headers.should.eql({});
     })

--- a/test/response/headers.js
+++ b/test/response/headers.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 
 describe('res.header', function(){

--- a/test/response/inspect.js
+++ b/test/response/inspect.js
@@ -1,11 +1,11 @@
 
-var response = require('../context').response;
-var assert = require('assert');
+const response = require('../context').response;
+const assert = require('assert');
 
 describe('res.inspect()', function(){
   describe('with no response.res present', function(){
     it('should return null', function(){
-      var res = response();
+      const res = response();
       res.body = 'hello';
       delete res.res;
       assert(null == res.inspect());
@@ -13,7 +13,7 @@ describe('res.inspect()', function(){
   })
 
   it('should return a json representation', function(){
-    var res = response();
+    const res = response();
     res.body = 'hello';
 
     res.inspect().should.eql({

--- a/test/response/inspect.js
+++ b/test/response/inspect.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const assert = require('assert');
 

--- a/test/response/is.js
+++ b/test/response/is.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
-var should = require('should');
-var assert = require('assert');
+const context = require('../context');
+const should = require('should');
+const assert = require('assert');
 
 describe('response.is(type)', function(){
   it('should ignore params', function(){
-    var res = context().response;
+    const res = context().response;
     res.type = 'text/html; charset=utf-8';
 
     res.is('text/*').should.equal('text/html');
@@ -13,7 +13,7 @@ describe('response.is(type)', function(){
 
   describe('when no type is set', function(){
     it('should return false', function(){
-      var res = context().response;
+      const res = context().response;
 
       assert(false === res.is());
       assert(false === res.is('html'));
@@ -22,7 +22,7 @@ describe('response.is(type)', function(){
 
   describe('when given no types', function(){
     it('should return the type', function(){
-      var res = context().response;
+      const res = context().response;
       res.type = 'text/html; charset=utf-8';
 
       res.is().should.equal('text/html');
@@ -31,7 +31,7 @@ describe('response.is(type)', function(){
 
   describe('given one type', function(){
     it('should return the type or false', function(){
-      var res = context().response;
+      const res = context().response;
       res.type = 'image/png';
 
       res.is('png').should.equal('png');
@@ -50,7 +50,7 @@ describe('response.is(type)', function(){
 
   describe('given multiple types', function(){
     it('should return the first match or false', function(){
-      var res = context().response;
+      const res = context().response;
       res.type = 'image/png';
 
       res.is('png').should.equal('png');
@@ -74,7 +74,7 @@ describe('response.is(type)', function(){
 
   describe('when Content-Type: application/x-www-form-urlencoded', function(){
     it('should match "urlencoded"', function(){
-      var res = context().response;
+      const res = context().response;
       res.type = 'application/x-www-form-urlencoded';
 
       res.is('urlencoded').should.equal('urlencoded');

--- a/test/response/is.js
+++ b/test/response/is.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 const should = require('should');
 const assert = require('assert');

--- a/test/response/last-modified.js
+++ b/test/response/last-modified.js
@@ -1,25 +1,25 @@
 
-var response = require('../context').response;
+const response = require('../context').response;
 
 describe('res.lastModified', function(){
   it('should set the header as a UTCString', function(){
-    var res = response();
-    var date = new Date();
+    const res = response();
+    const date = new Date();
     res.lastModified = date;
     res.header['last-modified'].should.equal(date.toUTCString());
   })
 
   it('should work with date strings', function(){
-    var res = response();
-    var date = new Date();
+    const res = response();
+    const date = new Date();
     res.lastModified = date.toString();
     res.header['last-modified'].should.equal(date.toUTCString());
   })
 
   it('should get the header as a Date', function(){
     // Note: Date() removes milliseconds, but it's practically important.
-    var res = response();
-    var date = new Date();
+    const res = response();
+    const date = new Date();
     res.lastModified = date;
     (res.lastModified.getTime() / 1000)
     .should.equal(Math.floor(date.getTime() / 1000));
@@ -27,7 +27,7 @@ describe('res.lastModified', function(){
 
   describe('when lastModified not set', function (){
     it('should get undefined', function(){
-      var res = response();
+      const res = response();
       (res.lastModified === undefined).should.be.ok;
     })
   })

--- a/test/response/last-modified.js
+++ b/test/response/last-modified.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 
 describe('res.lastModified', function(){

--- a/test/response/length.js
+++ b/test/response/length.js
@@ -1,13 +1,13 @@
 
-var response = require('../context').response;
-var should = require('should');
-var assert = require('assert');
-var fs = require('fs');
+const response = require('../context').response;
+const should = require('should');
+const assert = require('assert');
+const fs = require('fs');
 
 describe('res.length', function(){
   describe('when Content-Length is defined', function(){
     it('should return a number', function(){
-      var res = response();
+      const res = response();
       res.header['content-length'] = '120';
       res.length.should.equal(120);
     })
@@ -17,7 +17,7 @@ describe('res.length', function(){
 describe('res.length', function(){
   describe('when Content-Length is defined', function(){
     it('should return a number', function(){
-      var res = response();
+      const res = response();
       res.set('Content-Length', '1024');
       res.length.should.equal(1024);
     })
@@ -26,7 +26,7 @@ describe('res.length', function(){
   describe('when Content-Length is not defined', function(){
     describe('and a .body is set', function(){
       it('should return a number', function(){
-        var res = response();
+        const res = response();
 
         res.body = 'foo';
         res.remove('Content-Length');
@@ -59,7 +59,7 @@ describe('res.length', function(){
 
     describe('and .body is not', function(){
       it('should return undefined', function(){
-        var res = response();
+        const res = response();
         assert(null == res.length);
       })
     })

--- a/test/response/length.js
+++ b/test/response/length.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const should = require('should');
 const assert = require('assert');

--- a/test/response/message.js
+++ b/test/response/message.js
@@ -1,17 +1,17 @@
 
-var response = require('../context').response;
-var Stream = require('stream');
+const response = require('../context').response;
+const Stream = require('stream');
 
 describe('res.message', function(){
   it('should return the response status message', function(){
-    var res = response();
+    const res = response();
     res.status = 200;
     res.message.should.equal('OK');
   })
 
   describe('when res.message not present', function(){
     it('should look up in statuses', function(){
-      var res = response();
+      const res = response();
       res.res.statusCode = 200;
       res.message.should.equal('OK');
     })
@@ -20,7 +20,7 @@ describe('res.message', function(){
 
 describe('res.message=', function(){
   it('should set response status message', function(){
-    var res = response();
+    const res = response();
     res.status = 200;
     res.message = 'ok';
     res.res.statusMessage.should.equal('ok');

--- a/test/response/message.js
+++ b/test/response/message.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const Stream = require('stream');
 

--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -44,7 +44,7 @@ describe('ctx.redirect(url)', function(){
       ctx.header.accept = 'text/html';
       ctx.redirect(url);
       ctx.response.header['content-type'].should.equal('text/html; charset=utf-8');
-      ctx.body.should.equal('Redirecting to <a href="' + url + '">' + url + '</a>.');
+      ctx.body.should.equal(`Redirecting to <a href="${url}">${url}</a>.`);
     })
 
     it('should escape the url', function(){
@@ -54,7 +54,7 @@ describe('ctx.redirect(url)', function(){
       ctx.redirect(url);
       url = escape(url);
       ctx.response.header['content-type'].should.equal('text/html; charset=utf-8');
-      ctx.body.should.equal('Redirecting to <a href="' + url + '">' + url + '</a>.');
+      ctx.body.should.equal(`Redirecting to <a href="${url}">${url}</a>.`);
     })
   })
 
@@ -64,7 +64,7 @@ describe('ctx.redirect(url)', function(){
       const url = 'http://google.com';
       ctx.header.accept = 'text/plain';
       ctx.redirect(url);
-      ctx.body.should.equal('Redirecting to ' + url + '.');
+      ctx.body.should.equal(`Redirecting to ${url}.`);
     })
   })
 
@@ -76,7 +76,7 @@ describe('ctx.redirect(url)', function(){
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
       ctx.status.should.equal(301);
-      ctx.body.should.equal('Redirecting to ' + url + '.');
+      ctx.body.should.equal(`Redirecting to ${url}.`);
     })
   })
 
@@ -88,7 +88,7 @@ describe('ctx.redirect(url)', function(){
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
       ctx.status.should.equal(302);
-      ctx.body.should.equal('Redirecting to ' + url + '.');
+      ctx.body.should.equal(`Redirecting to ${url}.`);
     })
   })
 
@@ -100,7 +100,7 @@ describe('ctx.redirect(url)', function(){
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
       ctx.status.should.equal(302);
-      ctx.body.should.equal('Redirecting to ' + url + '.');
+      ctx.body.should.equal(`Redirecting to ${url}.`);
       ctx.type.should.equal('text/plain');
     })
   })

--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.redirect(url)', function(){
   it('should redirect to the given url', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.redirect('http://google.com');
     ctx.response.header.location.should.equal('http://google.com');
     ctx.status.should.equal(302);
@@ -11,27 +11,27 @@ describe('ctx.redirect(url)', function(){
 
   describe('with "back"', function(){
     it('should redirect to Referrer', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.referrer = '/login';
       ctx.redirect('back');
       ctx.response.header.location.should.equal('/login');
     })
 
     it('should redirect to Referer', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.req.headers.referer = '/login';
       ctx.redirect('back');
       ctx.response.header.location.should.equal('/login');
     })
 
     it('should default to alt', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.redirect('back', '/index.html');
       ctx.response.header.location.should.equal('/index.html');
     })
 
     it('should default redirect to /', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.redirect('back');
       ctx.response.header.location.should.equal('/');
     })
@@ -39,8 +39,8 @@ describe('ctx.redirect(url)', function(){
 
   describe('when html is accepted', function(){
     it('should respond with html', function(){
-      var ctx = context();
-      var url = 'http://google.com';
+      const ctx = context();
+      const url = 'http://google.com';
       ctx.header.accept = 'text/html';
       ctx.redirect(url);
       ctx.response.header['content-type'].should.equal('text/html; charset=utf-8');
@@ -48,7 +48,7 @@ describe('ctx.redirect(url)', function(){
     })
 
     it('should escape the url', function(){
-      var ctx = context();
+      const ctx = context();
       var url = '<script>';
       ctx.header.accept = 'text/html';
       ctx.redirect(url);
@@ -60,8 +60,8 @@ describe('ctx.redirect(url)', function(){
 
   describe('when text is accepted', function(){
     it('should respond with text', function(){
-      var ctx = context();
-      var url = 'http://google.com';
+      const ctx = context();
+      const url = 'http://google.com';
       ctx.header.accept = 'text/plain';
       ctx.redirect(url);
       ctx.body.should.equal('Redirecting to ' + url + '.');
@@ -70,8 +70,8 @@ describe('ctx.redirect(url)', function(){
 
   describe('when status is 301', function(){
     it('should not change the status code', function(){
-      var ctx = context();
-      var url = 'http://google.com';
+      const ctx = context();
+      const url = 'http://google.com';
       ctx.status = 301;
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
@@ -82,8 +82,8 @@ describe('ctx.redirect(url)', function(){
 
   describe('when status is 304', function(){
     it('should change the status code', function(){
-      var ctx = context();
-      var url = 'http://google.com';
+      const ctx = context();
+      const url = 'http://google.com';
       ctx.status = 304;
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
@@ -94,9 +94,9 @@ describe('ctx.redirect(url)', function(){
 
   describe('when content-type was present', function(){
     it('should overwrite content-type', function() {
-      var ctx = context();
+      const ctx = context();
       ctx.body = {};
-      var url = 'http://google.com';
+      const url = 'http://google.com';
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
       ctx.status.should.equal(302);

--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.redirect(url)', function(){

--- a/test/response/remove.js
+++ b/test/response/remove.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.remove(name)', function(){

--- a/test/response/remove.js
+++ b/test/response/remove.js
@@ -1,9 +1,9 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.remove(name)', function(){
   it('should remove a field', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.set('x-foo', 'bar');
     ctx.remove('x-foo');
     ctx.response.header.should.eql({});

--- a/test/response/set.js
+++ b/test/response/set.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.set(name, val)', function(){

--- a/test/response/set.js
+++ b/test/response/set.js
@@ -1,21 +1,21 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.set(name, val)', function(){
   it('should set a field value', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.set('x-foo', 'bar');
     ctx.response.header['x-foo'].should.equal('bar');
   })
 
   it('should coerce to a string', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.set('x-foo', 5);
     ctx.response.header['x-foo'].should.equal('5');
   })
 
   it('should set a field value of array', function(){
-    var ctx = context();
+    const ctx = context();
     ctx.set('x-foo', ['foo', 'bar']);
     ctx.response.header['x-foo'].should.eql([ 'foo', 'bar' ]);
   })
@@ -23,7 +23,7 @@ describe('ctx.set(name, val)', function(){
 
 describe('ctx.set(object)', function(){
   it('should set multiple fields', function(){
-    var ctx = context();
+    const ctx = context();
 
     ctx.set({
       foo: '1',

--- a/test/response/socket.js
+++ b/test/response/socket.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const Stream = require('stream');
 

--- a/test/response/socket.js
+++ b/test/response/socket.js
@@ -1,10 +1,10 @@
 
-var response = require('../context').response;
-var Stream = require('stream');
+const response = require('../context').response;
+const Stream = require('stream');
 
 describe('res.socket', function(){
   it('should return the request socket object', function(){
-    var res = response();
+    const res = response();
     res.socket.should.be.instanceOf(Stream);
   })
 })

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 const request = require('supertest');
 const statuses = require('statuses');

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -1,15 +1,15 @@
 
-var response = require('../context').response;
-var request = require('supertest');
-var statuses = require('statuses');
-var assert = require('assert');
-var koa = require('../..');
+const response = require('../context').response;
+const request = require('supertest');
+const statuses = require('statuses');
+const assert = require('assert');
+const koa = require('../..');
 
 describe('res.status=', function(){
   describe('when a status code', function(){
     describe('and valid', function(){
       it('should set the status', function(){
-        var res = response();
+        const res = response();
         res.status = 403;
         res.status.should.equal(403);
       })
@@ -35,7 +35,7 @@ describe('res.status=', function(){
       })
 
       it('should set the status', function (){
-        var res = response();
+        const res = response();
         res.status = 700;
         res.status.should.equal(700);
       })
@@ -58,7 +58,7 @@ describe('res.status=', function(){
 
   function strip(status) {
     it('should strip content related header fields', function(done){
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.body = { foo: 'bar' };
@@ -84,7 +84,7 @@ describe('res.status=', function(){
     })
 
     it('should strip content releated header fields after status set', function(done) {
-      var app = koa();
+      const app = koa();
 
       app.use(function *(){
         this.status = status;

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -5,7 +5,7 @@ const response = require('../context').response;
 const request = require('supertest');
 const statuses = require('statuses');
 const assert = require('assert');
-const koa = require('../..');
+const Koa = require('../..');
 
 describe('res.status=', function(){
   describe('when a status code', function(){
@@ -60,7 +60,7 @@ describe('res.status=', function(){
 
   function strip(status) {
     it('should strip content related header fields', function(done){
-      const app = koa();
+      const app = new Koa();;
 
       app.use(function *(){
         this.body = { foo: 'bar' };
@@ -86,7 +86,7 @@ describe('res.status=', function(){
     })
 
     it('should strip content releated header fields after status set', function(done) {
-      const app = koa();
+      const app = new Koa();;
 
       app.use(function *(){
         this.status = status;

--- a/test/response/type.js
+++ b/test/response/type.js
@@ -1,11 +1,11 @@
 
-var context = require('../context');
-var assert = require('assert');
+const context = require('../context');
+const assert = require('assert');
 
 describe('ctx.type=', function(){
   describe('with a mime', function(){
     it('should set the Content-Type', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'text/plain';
       ctx.type.should.equal('text/plain');
       ctx.response.header['content-type'].should.equal('text/plain; charset=utf-8');
@@ -14,7 +14,7 @@ describe('ctx.type=', function(){
 
   describe('with an extension', function(){
     it('should lookup the mime', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'json';
       ctx.type.should.equal('application/json');
       ctx.response.header['content-type'].should.equal('application/json; charset=utf-8');
@@ -23,7 +23,7 @@ describe('ctx.type=', function(){
 
   describe('without a charset', function(){
     it('should default the charset', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'text/html';
       ctx.type.should.equal('text/html');
       ctx.response.header['content-type'].should.equal('text/html; charset=utf-8');
@@ -32,7 +32,7 @@ describe('ctx.type=', function(){
 
   describe('with a charset', function(){
     it('should not default the charset', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'text/html; charset=foo';
       ctx.type.should.equal('text/html');
       ctx.response.header['content-type'].should.equal('text/html; charset=foo');
@@ -41,7 +41,7 @@ describe('ctx.type=', function(){
 
   describe('with an unknown extension', function(){
     it('should default to application/octet-stream',function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'asdf';
       ctx.type.should.equal('application/octet-stream');
       ctx.response.header['content-type'].should.equal('application/octet-stream');
@@ -52,7 +52,7 @@ describe('ctx.type=', function(){
 describe('ctx.type', function(){
   describe('with no Content-Type', function(){
     it('should return ""', function(){
-      var ctx = context();
+      const ctx = context();
       // TODO: this is lame
       assert('' === ctx.type);
     })
@@ -60,7 +60,7 @@ describe('ctx.type', function(){
 
   describe('with a Content-Type', function(){
     it('should return the mime', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.type = 'json';
       ctx.type.should.equal('application/json');
     })

--- a/test/response/type.js
+++ b/test/response/type.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 const assert = require('assert');
 

--- a/test/response/vary.js
+++ b/test/response/vary.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const context = require('../context');
 
 describe('ctx.vary(field)', function(){

--- a/test/response/vary.js
+++ b/test/response/vary.js
@@ -1,10 +1,10 @@
 
-var context = require('../context');
+const context = require('../context');
 
 describe('ctx.vary(field)', function(){
   describe('when Vary is not set', function(){
     it('should set it', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.vary('Accept');
       ctx.response.header.vary.should.equal('Accept');
     })
@@ -12,7 +12,7 @@ describe('ctx.vary(field)', function(){
 
   describe('when Vary is set', function(){
     it('should append', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.vary('Accept');
       ctx.vary('Accept-Encoding');
       ctx.response.header.vary.should.equal('Accept, Accept-Encoding');
@@ -21,7 +21,7 @@ describe('ctx.vary(field)', function(){
 
   describe('when Vary already contains the value', function(){
     it('should not append', function(){
-      var ctx = context();
+      const ctx = context();
       ctx.vary('Accept');
       ctx.vary('Accept-Encoding');
       ctx.vary('Accept');

--- a/test/response/writeable.js
+++ b/test/response/writeable.js
@@ -1,15 +1,15 @@
 
-var response = require('../context').response;
+const response = require('../context').response;
 
 describe('res.writable', function(){
   it('should return the request is writable', function(){
-    var res = response();
+    const res = response();
     res.writable.should.be.ok;
   })
 
   describe('when res.socket not present', function (){
     it('should return the request is not writable', function (){
-      var res = response();
+      const res = response();
       res.res.socket = null;
       res.writable.should.not.be.ok;
     })

--- a/test/response/writeable.js
+++ b/test/response/writeable.js
@@ -1,4 +1,6 @@
 
+'use strict';
+
 const response = require('../context').response;
 
 describe('res.writable', function(){


### PR DESCRIPTION
Tracking PR for ES2015 classes
- depends on #501 
- only Application has been refactored thus far

Classes are always a breaking API change since the `new` keyword must be used to create an instance of one (calling `constructor()`; i.e. `new Koa()`). I'm -0 on classes:
- seems `extend` can't help us here due to `Emitter.prototype` vs `Emitter`
- no _major_ readability benefits, imo