### PR TITLE
update minimum node version in README for ES2015

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,10 +18,7 @@
 $ npm install koa
 ```
 
-  Koa is supported in all versions of [iojs](https://iojs.org) without any flags.
-
-  To use Koa with node, you must be running __node 0.12.0__ or higher for generator and promise support, and must run node(1)
-  with the `--harmony-generators` or `--harmony` flag.
+  Koa requires __node v4.0.0__ or higher for (partial) ES2015 support.
 
 ## Community
 


### PR DESCRIPTION
- dropped iojs since there was the whole node foundation merge
- upped node v to 4.0.0