### PR TITLE
don't use 'exports' but only 'module.exports'

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -33,7 +33,7 @@ var app = Application.prototype;
  * Expose `Application`.
  */
 
-exports = module.exports = Application;
+module.exports = Application;
 
 /**
  * Initialize a new `Application`.


### PR DESCRIPTION
don't see a reason behind using `exports = ` here? seems useless since we're working in node where `module.exports` always works. if this was a browser library, then _maybe_ since we may be working w/ different module loaders