### PR TITLE
Use object methods

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -24,7 +24,7 @@ const proto = module.exports = {
    * @api public
    */
 
-  inspect: function(){
+  inspect() {
     return this.toJSON();
   },
 
@@ -40,7 +40,7 @@ const proto = module.exports = {
    * @api public
    */
 
-  toJSON: function(){
+  toJSON() {
     return {
       request: this.request.toJSON(),
       response: this.response.toJSON(),
@@ -87,7 +87,7 @@ const proto = module.exports = {
    * @api public
    */
 
-  throw: function(){
+  throw() {
     throw createError.apply(null, arguments);
   },
 
@@ -98,7 +98,7 @@ const proto = module.exports = {
    * @api private
    */
 
-  onerror: function(err){
+  onerror(err) {
     // don't do anything if there is no error.
     // this allows you to pass `this.onerror`
     // to node-style callbacks.

--- a/lib/request.js
+++ b/lib/request.js
@@ -461,7 +461,7 @@ module.exports = {
    * @api public
    */
 
-  accepts: function(){
+  accepts() {
     return this.accept.types.apply(this.accept, arguments);
   },
 
@@ -478,7 +478,7 @@ module.exports = {
    * @api public
    */
 
-  acceptsEncodings: function(){
+  acceptsEncodings() {
     return this.accept.encodings.apply(this.accept, arguments);
   },
 
@@ -495,7 +495,7 @@ module.exports = {
    * @api public
    */
 
-  acceptsCharsets: function(){
+  acceptsCharsets() {
     return this.accept.charsets.apply(this.accept, arguments);
   },
 
@@ -512,7 +512,7 @@ module.exports = {
    * @api public
    */
 
-  acceptsLanguages: function(){
+  acceptsLanguages() {
     return this.accept.languages.apply(this.accept, arguments);
   },
 
@@ -542,7 +542,7 @@ module.exports = {
    * @api public
    */
 
-  is: function(types){
+  is(types) {
     if (!types) return typeis(this.req);
     if (!Array.isArray(types)) types = [].slice.call(arguments);
     return typeis(this.req, types);
@@ -584,7 +584,7 @@ module.exports = {
    * @api public
    */
 
-  get: function(field){
+  get(field) {
     const req = this.req;
     switch (field = field.toLowerCase()) {
       case 'referer':
@@ -602,7 +602,7 @@ module.exports = {
    * @api public
    */
 
-  inspect: function(){
+  inspect() {
     if (!this.req) return;
     return this.toJSON();
   },
@@ -614,7 +614,7 @@ module.exports = {
    * @api public
    */
 
-  toJSON: function(){
+  toJSON() {
     return {
       method: this.method,
       url: this.url,

--- a/lib/response.js
+++ b/lib/response.js
@@ -228,7 +228,7 @@ module.exports = {
    * @api public
    */
 
-  vary: function(field){
+  vary(field) {
     vary(this.res, field);
   },
 
@@ -251,7 +251,7 @@ module.exports = {
    * @api public
    */
 
-  redirect: function(url, alt){
+  redirect(url, alt) {
     // location
     if ('back' == url) url = this.ctx.get('Referrer') || alt || '/';
     this.set('Location', url);
@@ -279,7 +279,7 @@ module.exports = {
    * @api public
    */
 
-  attachment: function(filename){
+  attachment(filename) {
     if (filename) this.type = extname(filename);
     this.set('Content-Disposition', contentDisposition(filename));
   },
@@ -382,7 +382,7 @@ module.exports = {
    * @api public
    */
 
-  is: function(types){
+  is(types) {
     const type = this.type;
     if (!types) return type || false;
     if (!Array.isArray(types)) types = [].slice.call(arguments);
@@ -405,7 +405,7 @@ module.exports = {
    * @api public
    */
 
-  get: function(field){
+  get(field) {
     return this.header[field.toLowerCase()] || '';
   },
 
@@ -424,7 +424,7 @@ module.exports = {
    * @api public
    */
 
-  set: function(field, val){
+  set(field, val) {
     if (2 == arguments.length) {
       if (Array.isArray(val)) val = val.map(String);
       else val = String(val);
@@ -450,7 +450,7 @@ module.exports = {
    * @api public
    */
 
-  append: function(field, val){
+  append(field, val) {
     const prev = this.get(field);
 
     if (prev) {
@@ -469,7 +469,7 @@ module.exports = {
    * @api public
    */
 
-  remove: function(field){
+  remove(field) {
     this.res.removeHeader(field);
   },
 
@@ -495,7 +495,7 @@ module.exports = {
    * @api public
    */
 
-  inspect: function(){
+  inspect() {
     if (!this.res) return;
     const o = this.toJSON();
     o.body = this.body;
@@ -509,7 +509,7 @@ module.exports = {
    * @api public
    */
 
-  toJSON: function(){
+  toJSON() {
     return {
       status: this.status,
       message: this.message,


### PR DESCRIPTION
I noticed you're doing all kinds of fun refactoring right now so I just wanted to suggest switching to shorthand functions (or "object methods" as they seem to be called in ES2015). 

For no other reason than that I think they align nicely with the `get x()`/`set x()` object shorthands.