### PR TITLE
no more exports! only module.exports

### DIFF
--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -4,7 +4,7 @@
 const Stream = require('stream');
 const koa = require('../..');
 
-exports = module.exports = function(req, res){
+module.exports = function(req, res){
   const socket = new Stream.Duplex();
   req = req || { headers: {}, socket: socket, __proto__: Stream.Readable.prototype };
   res = res || { _headers: {}, socket: socket, __proto__: Stream.Writable.prototype };
@@ -14,10 +14,10 @@ exports = module.exports = function(req, res){
   return koa().createContext(req, res);
 }
 
-exports.request = function(req, res){
-  return exports(req, res).request;
+module.exports.request = function(req, res){
+  return module.exports(req, res).request;
 }
 
-exports.response = function(req, res){
-  return exports(req, res).response;
+module.exports.response = function(req, res){
+  return module.exports(req, res).response;
 }


### PR DESCRIPTION
extension of #513

cleared up other instances of `exports.x` and `exports = x` since it's just misleading when we already have `module.exports` (sometimes in the same file). i.e. we don't know what happens if exports and module.exports export different values + we're in node so module.exports works everywhere- no extra clutter necessary.