### PR TITLE
Fix for #532. 'Content-Type' hard not to send.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -212,9 +212,6 @@ function respond() {
     return res.end(body);
   }
 
-  // remove content-type header if there is no content
-  if (0 == this.length) this.remove('Content-Type');
-
   // responses
   if (Buffer.isBuffer(body)) return res.end(body);
   if ('string' == typeof body) return res.end(body);

--- a/lib/application.js
+++ b/lib/application.js
@@ -212,6 +212,9 @@ function respond() {
     return res.end(body);
   }
 
+  // remove content-type header if there is no content
+  if (0 == this.length) this.remove('Content-Type');
+
   // responses
   if (Buffer.isBuffer(body)) return res.end(body);
   if ('string' == typeof body) return res.end(body);

--- a/lib/response.js
+++ b/lib/response.js
@@ -302,6 +302,7 @@ module.exports = {
 
   set type(type) {
     this.set('Content-Type', getType(type) || 'application/octet-stream');
+    null == type && this.remove("Content-Type")
   },
 
   /**

--- a/test/application.js
+++ b/test/application.js
@@ -237,6 +237,28 @@ describe('app.respond', function(){
     })
   })
 
+  describe('when this.type === null', function(){
+    it('should not send Content-Type header', function(done){
+      var app = koa();
+
+      app.use(function*() {
+        this.body = '';
+        this.type = null;
+      });
+
+      var server = app.listen();
+
+      request(server)
+        .get('/')
+        .expect(200)
+        .end(function(err, res){
+          if (err) return done(err);
+          res.should.not.have.header('content-type');
+          done();
+        });
+    })
+  })
+
   describe('when HEAD is used', function(){
     it('should not respond with the body', function(done){
       var app = koa();


### PR DESCRIPTION
Since it's impossible to know the order in which the user will set the response options, i'm removing the Content-Type header on *lib/application.js*. However the response will differ if the body is null or empty string. Is there any reason why *'application/octet-stream'* is the default type?