### PR TITLE
update bench case

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -11,15 +11,15 @@ let n = parseInt(process.env.MW || '1', 10);
 console.log(`  ${n} middleware`);
 
 while (n--) {
-  app.use(function *(next){
-    yield *next;
+  app.use(function *(ctx, next){
+    yield next();
   });
 }
 
 const body = new Buffer('Hello World');
 
-app.use(function *(next){
-  yield *next;
+app.use(function *(ctx, next){
+  yield next();
   this.body = body;
 });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -115,7 +115,7 @@ module.exports = class Application extends Emitter {
       res.statusCode = 404;
       const ctx = this.createContext(req, res);
       onFinished(res, ctx.onerror);
-      fn(ctx).then(function() {
+      fn(ctx).then(() => {
         respond(ctx);
       }).catch(ctx.onerror);
     };


### PR DESCRIPTION
Fix benchmarks TypeError

```
  TypeError: next[(intermediate value)] is not a function
      at /Users/fundon/Dev/open-sources/koa/benchmarks/middleware.js:15:12
      at next (native)
      at onFulfilled (/Users/fundon/Dev/open-sources/koa/node_modules/co/index.js:65:19)
```