### PR TITLE
Refactor tests - add arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,3 +9,5 @@ rules:
   semi: [2, always]
   space-before-function-paren: [2, never]
   yoda: 0
+  arrow-parens: [2, "as-needed"]
+  arrow-spacing: 2

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -9,9 +9,8 @@ describe('app.onerror(err)', function(){
   it('should throw an error if a non-error is given', function(done){
     const app = new Koa();
 
-    (function(){
-      app.onerror('foo');
-    }).should.throw(AssertionError, {message: 'non-error thrown: foo'});
+    (() => app.onerror('foo'))
+    .should.throw(AssertionError, {message: 'non-error thrown: foo'});
 
     done();
   });
@@ -22,9 +21,7 @@ describe('app.onerror(err)', function(){
 
     err.status = 404;
 
-    const output = stderr.inspectSync(function(){
-      app.onerror(err);
-    });
+    const output = stderr.inspectSync(() => app.onerror(err));
 
     output.should.eql([]);
 
@@ -36,9 +33,7 @@ describe('app.onerror(err)', function(){
     app.silent = true;
     const err = new Error();
 
-    const output = stderr.inspectSync(function(){
-      app.onerror(err);
-    });
+    const output = stderr.inspectSync(() => app.onerror(err));
 
     output.should.eql([]);
 
@@ -52,9 +47,7 @@ describe('app.onerror(err)', function(){
     const err = new Error();
     err.stack = 'Foo';
 
-    const output = stderr.inspectSync(function(){
-      app.onerror(err);
-    });
+    const output = stderr.inspectSync(() => app.onerror(err));
 
     output.should.eql(['\n', '  Foo\n', '\n']);
 
@@ -68,9 +61,7 @@ describe('app.onerror(err)', function(){
     const err = new Error('mock stack null');
     err.stack = null;
 
-    const output = stderr.inspectSync(function(){
-      app.onerror(err);
-    });
+    const output = stderr.inspectSync(() => app.onerror(err));
 
     output.should.eql(['\n', '  Error: mock stack null\n', '\n']);
 

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -9,8 +9,7 @@ describe('app.onerror(err)', function(){
   it('should throw an error if a non-error is given', function(done){
     const app = new Koa();
 
-    (() => app.onerror('foo'))
-    .should.throw(AssertionError, {message: 'non-error thrown: foo'});
+    (() => app.onerror('foo')).should.throw(AssertionError, {message: 'non-error thrown: foo'});
 
     done();
   });

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -207,16 +207,12 @@ describe('app.respond', function(){
         ctx.status = 200;
         res.setHeader('Content-Type', 'text/html');
         res.write('Hello');
-        setTimeout(function(){
-          res.end('Goodbye');
-        }, 0);
+        setTimeout(() => res.end('Goodbye'), 0);
       });
 
       let errorCaught = false;
 
-      app.on('error', function(err){
-        errorCaught = err;
-      });
+      app.on('error', err => errorCaught = err);
 
       const server = app.listen();
 

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -21,9 +21,8 @@ describe('ctx.cookies.set()', function(){
     .end(function(err, res){
       if (err) return done(err);
 
-      res.headers['set-cookie'].some(function(cookie){
-        return /^name=/.test(cookie);
-      }).should.be.ok;
+      res.headers['set-cookie'].some(cookie => /^name=/.test(cookie))
+      .should.be.ok;
 
       done();
     });
@@ -68,13 +67,9 @@ describe('ctx.cookies.set()', function(){
 
         const cookies = res.headers['set-cookie'];
 
-        cookies.some(function(cookie){
-          return /^name=/.test(cookie);
-        }).should.be.ok;
+        cookies.some(cookie => /^name=/.test(cookie)).should.be.ok;
 
-        cookies.some(function(cookie){
-          return /^name\.sig=/.test(cookie);
-        }).should.be.ok;
+        cookies.some(cookie => /^name\.sig=/.test(cookie)).should.be.ok;
 
         done();
       });

--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -8,16 +8,12 @@ module.exports = function(req, res){
   const socket = new Stream.Duplex();
   req = req || { headers: {}, socket: socket, __proto__: Stream.Readable.prototype };
   res = res || { _headers: {}, socket: socket, __proto__: Stream.Writable.prototype };
-  res.getHeader = function(k){ return res._headers[k.toLowerCase()]; };
-  res.setHeader = function(k, v){ res._headers[k.toLowerCase()] = v; };
-  res.removeHeader = function(k, v){ delete res._headers[k.toLowerCase()]; };
+  res.getHeader = k => res._headers[k.toLowerCase()];
+  res.setHeader = (k, v) => res._headers[k.toLowerCase()] = v;
+  res.removeHeader = (k, v) => delete res._headers[k.toLowerCase()];
   return (new Koa()).createContext(req, res);
 };
 
-module.exports.request = function(req, res){
-  return module.exports(req, res).request;
-};
+module.exports.request = (req, res) => module.exports(req, res).request;
 
-module.exports.response = function(req, res){
-  return module.exports(req, res).response;
-};
+module.exports.response = (req, res) => module.exports(req, res).response;

--- a/test/request/href.js
+++ b/test/request/href.js
@@ -39,7 +39,7 @@ describe('ctx.href', function(){
         res.statusCode.should.equal(200);
         let buf = '';
         res.setEncoding('utf8');
-        res.on('data', function(s){ buf += s; });
+        res.on('data', s => buf += s);
         res.on('end', function(){
           buf.should.equal('http://example.com/foo');
           done();


### PR DESCRIPTION
Again arrow functions.
However, I changed only one line functions, and I left something like this as it was:
```
app.on('error', function(err){
  err.message.should.equal('boom');
  done();
});
```
Not sure if we are getting anything with this:
```
app.on('error', err => {
  err.message.should.equal('boom');
  done();
});
```
except maybe consistency (using arrow functions for all callbacks) and 4-6 characters less.