### PR TITLE
babel-node required -> Babel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ app.use(ctx => {
 app.listen(3000);
 ```
 
-## Example with ___async___ functions (babel-node required)
+## Example with ___async___ functions (Babel required)
 
 ```js
 const Koa = require('koa');


### PR DESCRIPTION
was looking over the docs and stumbled across this. there are a few different ways to use babel in node apps like precompile, babel-node to compile and execute on the fly, require hooks, and whatnot so i'd prefer to be less specific