### PR TITLE
Update benchmark with arrow functions and remove --harmony flag

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -16,6 +16,6 @@ while (n--) {
 
 const body = new Buffer('Hello World');
 
-app.use((ctx, next) => next().then(() => this.body = body));
+app.use((ctx, next) => next().then(() => ctx.body = body));
 
 app.listen(3333);

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -11,17 +11,11 @@ let n = parseInt(process.env.MW || '1', 10);
 console.log(`  ${n} middleware`);
 
 while (n--) {
-  app.use(function(ctx, next){
-    return next();
-  });
+  app.use((ctx, next) => next());
 }
 
 const body = new Buffer('Hello World');
 
-app.use(function(ctx, next){
-  return next().then(function(){
-    this.body = body;
-  });
-});
+app.use((ctx, next) => next().then(() => this.body = body));
 
 app.listen(3333);

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo
-MW=$1 node --harmony $2 &
+MW=$1 node $2 &
 pid=$!
 
 sleep 2


### PR DESCRIPTION
remove --harmony flag and use arrow functions

Koa seems much faster with promises:
```
// Generators
1 middleware
  6382.11

  5 middleware
  6044.99

  10 middleware
  4655.37

  15 middleware
  4185.59

  20 middleware
  4439.08

  30 middleware
  3546.34

  50 middleware
  2617.97

  100 middleware
  1791.49

// Promises

1 middleware
  7728.82

  5 middleware
  7543.43

  10 middleware
  7647.59

  15 middleware
  7525.95

  20 middleware
  7691.17

  30 middleware
  7719.34

  50 middleware
  7469.19

  100 middleware
  6706.20
```
