### PR TITLE
fix Application.inspect() – missing .proxy value. Closes #563

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -38,9 +38,10 @@ module.exports = class Application extends Emitter {
   constructor() {
     super();
 
-    this.env = process.env.NODE_ENV || 'development';
-    this.subdomainOffset = 2;
+    this.proxy = false;
     this.middleware = [];
+    this.subdomainOffset = 2;
+    this.env = process.env.NODE_ENV || 'development';
     this.context = Object.create(context);
     this.request = Object.create(request);
     this.response = Object.create(response);
@@ -73,9 +74,17 @@ module.exports = class Application extends Emitter {
   toJSON() {
     return only(this, [
       'subdomainOffset',
+      'proxy',
       'env'
     ]);
   }
+
+  /**
+   * Inspect implementation.
+   *
+   * @return {Object}
+   * @api public
+   */
 
   inspect() {
     return this.toJSON();

--- a/test/application/inspect.js
+++ b/test/application/inspect.js
@@ -1,12 +1,14 @@
 
 'use strict';
 
+const assert = require('assert');
 const Koa = require('../..');
 
 describe('app.inspect()', function(){
   it('should work', function(){
     const app = new Koa();
     const util = require('util');
-    util.inspect(app);
+    const str = util.inspect(app);
+    assert.equal("{ subdomainOffset: 2, proxy: false, env: 'test' }", str);
   });
 });

--- a/test/application/toJSON.js
+++ b/test/application/toJSON.js
@@ -10,6 +10,7 @@ describe('app.toJSON()', function(){
 
     obj.should.eql({
       subdomainOffset: 2,
+      proxy: false,
       env: 'test'
     });
   });


### PR DESCRIPTION
As mentioned in #563 we were just missing an initial value and output