### PR TITLE
Remove TODO from the response type test

### DIFF
--- a/test/response/type.js
+++ b/test/response/type.js
@@ -55,8 +55,7 @@ describe('ctx.type', function(){
   describe('with no Content-Type', function(){
     it('should return ""', function(){
       const ctx = context();
-      // TODO: ctx is lame
-      assert('' === ctx.type);
+      assert(!ctx.type);
     });
   });
 


### PR DESCRIPTION
Not sure if this is a best way to do it, but we have something similar [10 lines above](https://github.com/koajs/koa/blob/master/test/response/type.js#L48).