### PR TITLE
Remove 'TODO' comment for this.res._headers

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -45,7 +45,6 @@ module.exports = {
    */
 
   get header() {
-    // TODO: wtf
     return this.res._headers || {};
   },
 


### PR DESCRIPTION
#575 - node probably doesn't plan to change this so there's no point of having 'TODO' comment in the code.
Even if they change it it can't be updated without a major version release because it'll not work for node 4 and 5.0.