### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ const app = new Koa();
 
 // logger
 
-app.use(async (ctx, next) => {
+app.use(async function(ctx, next) {
   const start = new Date;
   await next();
   const ms = new Date - start;


### PR DESCRIPTION
Babel will not currently transpile an async arrow function into a generator function, it will leave it as a regular arrow function, and thus not work.