### PR TITLE
ensure parseurl always working as expected

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -127,6 +127,8 @@ module.exports = {
 
   set path(path) {
     const url = parse(this.req);
+    if (url.pathname === path) return;
+
     url.pathname = path;
     url.path = null;
 
@@ -178,6 +180,8 @@ module.exports = {
 
   set querystring(str) {
     const url = parse(this.req);
+    if (url.search === `?${str}`) return;
+
     url.search = str;
     url.path = null;
 

--- a/test/request/path.js
+++ b/test/request/path.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const context = require('../helpers/context');
+const parseurl = require('parseurl');
 
 describe('ctx.path', () => {
   it('should return the pathname', () => {
@@ -27,5 +28,12 @@ describe('ctx.path=', () => {
     ctx.url.should.equal('/logout');
     ctx.originalUrl.should.equal('/login');
     ctx.request.originalUrl.should.equal('/login');
+  });
+
+  it('should not affect parseurl', () => {
+    const ctx = context({ url: '/login?foo=bar' });
+    ctx.path = '/login';
+    const url = parseurl(ctx.req);
+    url.path.should.equal('/login?foo=bar');
   });
 });

--- a/test/request/querystring.js
+++ b/test/request/querystring.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const context = require('../helpers/context');
+const parseurl = require('parseurl');
 
 describe('ctx.querystring', () => {
   it('should return the querystring', () => {
@@ -43,5 +44,12 @@ describe('ctx.querystring=', () => {
     ctx.url.should.equal('/store/shoes?page=2&color=blue');
     ctx.originalUrl.should.equal('/store/shoes');
     ctx.request.originalUrl.should.equal('/store/shoes');
+  });
+
+  it('should not affect parseurl', () => {
+    const ctx = context({ url: '/login?foo=bar' });
+    ctx.querystring = 'foo=bar';
+    const url = parseurl(ctx.req);
+    url.path.should.equal('/login?foo=bar');
   });
 });


### PR DESCRIPTION
`url.path = null` is introduced in https://github.com/koajs/koa/commit/d108926f4634fabe4b18c49ab0ab25a169dbd665

The code rely on `parseurl` will unpredictable when people write some code like `this.path = this.path`.