### PR TITLE
test: add a babel example

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,13 +3,19 @@ parser: babel-eslint
 
 extends: standard
 
+plugins: [
+  "babel"
+]
+
 rules:
+  arrow-parens: 0
+  babel/arrow-parens: [2, "as-needed"]
+
   eqeqeq: 0
   no-var: 2
   semi: [2, always]
   space-before-function-paren: [2, never]
   yoda: 0
-  arrow-parens: [2, "as-needed"]
   arrow-spacing: 2
   dot-location: [2, "property"]
   prefer-arrow-callback: 2

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ REQUIRED = --require should --require should-http
 TESTS = test/application/* \
 	test/context/* \
 	test/request/* \
-	test/response/*
+	test/response/* \
+	test/babel/index.js
 
 lint:
 	@./node_modules/.bin/eslint lib test

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -85,6 +85,29 @@ app.use(function *(){
 app.listen(3000);
 ```
 
+## Async Functions with Babel
+
+To use `async` functions in Koa, we recommend using [babel's require hook](http://babeljs.io/docs/usage/require/).
+
+```js
+require('babel-core/register');
+// require the rest of the app that needs to be transpiled after the hook
+const app = require('./app');
+```
+
+To parse and transpile async functions,
+you should at a minimum have the [transform-async-to-generator](http://babeljs.io/docs/plugins/transform-async-to-generator/)
+or [transform-async-to-module-method](http://babeljs.io/docs/plugins/transform-async-to-module-method/) plugins.
+For example, in your `.babelrc` file, you should have:
+
+```json
+{
+  "plugins": ["transform-async-to-generator"]
+}
+```
+
+Currently, you could also use the [stage-3 preset](http://babeljs.io/docs/plugins/preset-stage-3/).
+
 ## Settings
 
   Application settings are properties on the `app` instance, currently

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
     "vary": "^1.0.0"
   },
   "devDependencies": {
-    "babel": "^5.0.0",
+    "babel-core": "^6.0.20",
     "babel-eslint": "^4.1.3",
+    "babel-preset-stage-3": "^6.0.15",
     "eslint": "^1.6.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "^1.2.2",
-    "babel-core": "^6.1.2",
-    "babel-preset-stage-3": "^6.1.2",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
     "cookies": "~0.5.0",
@@ -44,11 +42,12 @@
     "vary": "^1.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.0.20",
+    "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.3",
-    "babel-preset-stage-3": "^6.0.15",
+    "babel-preset-stage-3": "^6.1.2",
     "eslint": "^1.6.0",
     "eslint-config-standard": "^4.4.0",
+    "eslint-plugin-babel": "^2.1.1",
     "eslint-plugin-standard": "^1.3.1",
     "istanbul": "^0.4.0",
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.3",
-    "babel-preset-stage-3": "^6.1.2",
+    "babel-plugin-transform-async-to-generator": "^6.0.14",
     "eslint": "^1.6.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-babel": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "^1.2.2",
+    "babel-core": "^6.1.2",
+    "babel-preset-stage-3": "^6.1.2",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
     "cookies": "~0.5.0",

--- a/test/babel/.babelrc
+++ b/test/babel/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["stage-3"]
+}

--- a/test/babel/.babelrc
+++ b/test/babel/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["stage-3"]
+  "plugins": ["transform-async-to-generator"]
 }

--- a/test/babel/_test.js
+++ b/test/babel/_test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const request = require('supertest');
+const Koa = require('../..');
+
+describe('require("babel-core/register")', () => {
+  describe('app.use(fn)', () => {
+    it('should compose middleware w/ async functions', done => {
+      const app = new Koa();
+      const calls = [];
+
+      app.use(async function (ctx, next){
+        calls.push(1);
+        await next();
+        calls.push(6);
+      });
+
+      app.use(async function (ctx, next){
+        calls.push(2);
+        await next();
+        calls.push(5);
+      });
+
+      app.use(async function (ctx, next){
+        calls.push(3);
+        await next();
+        calls.push(4);
+      });
+
+      const server = app.listen();
+
+      request(server)
+        .get('/')
+        .expect(404)
+        .end(err => {
+          if (err) return done(err);
+          calls.should.eql([1, 2, 3, 4, 5, 6]);
+          done();
+        });
+    });
+  });
+});

--- a/test/babel/_test.js
+++ b/test/babel/_test.js
@@ -9,19 +9,19 @@ describe('require("babel-core/register")', () => {
       const app = new Koa();
       const calls = [];
 
-      app.use(async function (ctx, next){
+      app.use(async (ctx, next) => {
         calls.push(1);
         await next();
         calls.push(6);
       });
 
-      app.use(async function (ctx, next){
+      app.use(async (ctx, next) => {
         calls.push(2);
         await next();
         calls.push(5);
       });
 
-      app.use(async function (ctx, next){
+      app.use(async (ctx, next) => {
         calls.push(3);
         await next();
         calls.push(4);

--- a/test/babel/index.js
+++ b/test/babel/index.js
@@ -1,0 +1,6 @@
+'ues strict';
+
+// http://babeljs.io/docs/setup/#babel_register
+
+require('babel-core/register');
+require('./_test.js');

--- a/test/babel/index.js
+++ b/test/babel/index.js
@@ -1,4 +1,4 @@
-'ues strict';
+'use strict';
 
 // http://babeljs.io/docs/setup/#babel_register
 


### PR DESCRIPTION
closes #539
closes #572

TODO:

- [x] docs linking to `require('babel-core/register')` + `stage-3` preset or babel
- [x] figuring out why `async (ctx, next) => {}` doesn't work. anyone know why it doesn't work?