### PR TITLE
fix: should not destroy streams

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -6,6 +6,7 @@
  */
 
 var contentDisposition = require('content-disposition');
+var BlackHoleStream = require('black-hole-stream');
 var ensureErrorHandler = require('error-inject');
 var getType = require('mime-types').contentType;
 var onFinish = require('on-finished');
@@ -15,6 +16,8 @@ var typeis = require('type-is').is;
 var statuses = require('statuses');
 var destroy = require('destroy');
 var assert = require('assert');
+var Stream = require('stream');
+var http = require('http');
 var path = require('path');
 var vary = require('vary');
 var extname = path.extname;
@@ -161,8 +164,15 @@ module.exports = {
     }
 
     // stream
-    if ('function' == typeof val.pipe) {
-      onFinish(this.res, destroy.bind(null, val));
+    if (val instanceof Stream) {
+      onFinish(this.res, function(){
+        // don't destroy http IncomingMessage, keep `keep-alive` conncetion alive.
+        if (val instanceof http.IncomingMessage) {
+          if (val.readable) val.pipe(new BlackHoleStream());
+        } else {
+          destroy(val);
+        }
+      });
       ensureErrorHandler(val, this.ctx.onerror);
 
       // overwriting

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "^1.2.2",
+    "black-hole-stream": "0.0.1",
     "co": "^4.4.0",
     "composition": "^2.1.1",
     "content-disposition": "~0.5.0",
@@ -43,14 +44,18 @@
     "vary": "^1.0.0"
   },
   "devDependencies": {
+    "agentkeepalive": "~2.0.3",
     "babel": "^5.0.0",
+    "freeport": "^1.0.5",
     "istanbul": "^0.4.0",
     "make-lint": "^1.0.1",
     "mocha": "^2.0.1",
+    "pedding": "^1.0.0",
     "should": "^6.0.3",
     "should-http": "0.0.3",
     "supertest": "^1.0.1",
-    "test-console": "^0.7.1"
+    "test-console": "^0.7.1",
+    "urllib": "^2.6.0"
   },
   "engines": {
     "node": ">= 0.12.0",


### PR DESCRIPTION
use black-hole-stream to make sure stream's data has been read.

since user may set `this.body` to a http `IncomingMessage`, if we destroy this stream, it will destroy the http socket that make `keep-alive` failed, and may affect other http requests reusing this socket.
I think maybe we shouldn't destroy streams, only need to insure streams' data will be read and don't leak.