### PR TITLE
fix cookies' secure detect

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -157,7 +157,10 @@ app.createContext = function(req, res){
   response.request = request;
   context.onerror = context.onerror.bind(context);
   context.originalUrl = request.originalUrl = req.url;
-  context.cookies = new Cookies(req, res, this.keys);
+  context.cookies = new Cookies(req, res, {
+    keys: this.keys,
+    secure: request.secure
+  });
   context.accept = request.accept = accepts(req);
   context.state = {};
   return context;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "composition": "^2.1.1",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
-    "cookies": "~0.5.0",
+    "cookies": "~0.6.1",
     "debug": "*",
     "delegates": "^1.0.0",
     "destroy": "^1.0.3",

--- a/test/context.js
+++ b/test/context.js
@@ -8,6 +8,8 @@ exports = module.exports = function(req, res){
   var socket = new Stream.Duplex();
   req = req || { headers: {}, socket: socket, __proto__: Stream.Readable.prototype };
   res = res || { _headers: {}, socket: socket, __proto__: Stream.Writable.prototype };
+  req.socket = req.socket || socket;
+  res.socket = res.socket || socket;
   res.getHeader = function(k){ return res._headers[k.toLowerCase()] };
   res.setHeader = function(k, v){ res._headers[k.toLowerCase()] = v };
   res.removeHeader = function(k, v){ delete res._headers[k.toLowerCase()] };


### PR DESCRIPTION
koa don't change the original request object, need to pass koa's request object to cookies.

(but you can't replace res with response, so this is kind of weird. :( 