### PR TITLE
fix(app): fix comment for 'experimental' check

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -101,7 +101,8 @@ app.toJSON = function(){
 
 app.use = function(fn){
   if (!this.experimental) {
-    // es7 async functions are allowed
+    // es7 async functions are not allowed,
+    // so we have to make sure that `fn` is a generator function
     assert(fn && 'GeneratorFunction' == fn.constructor.name, 'app.use() requires a generator function');
   }
   debug('use %s', fn._name || fn.name || '-');


### PR DESCRIPTION
The comment stated that when 'experimental' is false,
es7 async would be allowed, but the exact opposite is true.