### PR TITLE
Allow to use other flow control libraries. Defaults to co.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -50,6 +50,7 @@ function Application() {
   this.context = Object.create(context);
   this.request = Object.create(request);
   this.response = Object.create(response);
+  this.co = co.wrap;
 }
 
 /**
@@ -121,7 +122,7 @@ app.use = function(fn){
 app.callback = function(){
   var fn = this.experimental
     ? compose_es7(this.middleware)
-    : co.wrap(compose(this.middleware));
+    : this.co(compose(this.middleware));
   var self = this;
 
   if (!this.listeners('error').length) this.on('error', this.onerror);


### PR DESCRIPTION
Recent Sequelize upgrade depends on bluebird@3 and yielding two or more times inside a generator causes a "_a promise was created in a handler but was not returned from it_" warning.

For example the code:
```javascript
app.use( function* ( next ) {
 var post = yield this.db.Post.findById( this.params.postId );
 var author = yield post.getAuthor();
 this.body = JSON.stringify( author );   
} ); 
```
causes the aforementioned warning.

Bluebird documentation states, that `Promise.coroutine` should be used with `yield`. My change allows to use other flow control solution, for example mentioned Bluebird's `coroutine`.

Example use:
```javascript
var coroutine = require( 'bluebird' ).coroutine;
var bluebird_co = require( 'bluebird-co/manual' );
coroutine.addYieldHandler( bluebird_co.toPromise );

var app = require('koa')();
app.co = coroutine;
```
