### PR TITLE
chore(package): update should to version 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "istanbul": "^0.4.0",
     "make-lint": "^1.0.1",
     "mocha": "^2.0.1",
-    "should": "^6.0.3",
+    "should": "^8.1.0",
     "should-http": "0.0.3",
     "supertest": "^1.0.1",
     "test-console": "^0.7.1"


### PR DESCRIPTION
someone needs to make up for api changes in should, everything now needs to be called as a function, eg `is.a.function()` instead of `is.a.function`