### PR TITLE
[CI] Run tests on the stable version of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "1"
-  - "2"
-  - "3"
-  - "4"
+  - stable
+  - 4
+  - 3
+  - 2
+  - 1
+  - 0.12
 sudo: false
 script: "make test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
This ensures that Koa is regularly tested against the latest version of Node and surfaces issues early. The main thing is that new version of Node could be released and tests that were previously passing would suddenly start failing (if there were a breaking change) -- as such, tests against stable version of Node are allowed to fail.

I also reversed the order of Node versions in the test matrix so that recent = more relevant versions are at the top.