### PR TITLE
[CI] Configure tests for Circle CI as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "4"
   - "5"
 sudo: false
-script: "make test-travis"
+script: "make test-ci"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-cov:
 		$(TESTS) \
 		--bail
 
-test-travis: lint
+test-ci: lint
 	@NODE_ENV=test node \
 		./node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+machine:
+  node:
+    version: 5
+test:
+  override:
+    - make test-ci
+  post:
+    - npm install coveralls@2
+    - cat ./coverage/lcov.info | coveralls


### PR DESCRIPTION
I've seen Circle CI get a lot of praise and they support some nice features like being able to SSH into a test box for a short while after the test has run. Getting the tests to run on Circle is pretty straightforward - there is a YAML file whose format is documented here: https://circleci.com/docs/configuration.