### PR TITLE
Fix a typo

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,7 +58,7 @@ app.use(function *(next){
 Note that the final middleware (step __6__) yields to what looks to be nothing - it's actually
 yielding to a no-op generator within Koa. This is so that every middleware can conform with the
 same API, and may be placed before or after others. If you removed `yield next;` from the furthest
-"downstream" middleware everything would function appropritaely, however it would no longer conform
+"downstream" middleware everything would function appropriately, however it would no longer conform
 to this behaviour.
 
  For example this would be fine:


### PR DESCRIPTION
`appropritaely` → `appropriately`