### PR TITLE
JSDoc question/suggestion on optional parameters

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -247,7 +247,7 @@ module.exports = {
    *    this.redirect('http://google.com');
    *
    * @param {String} url
-   * @param {String} alt
+   * @param {String} [alt]
    * @api public
    */
 


### PR DESCRIPTION
Hi, Webstorm keeps giving me warnings on the 'redirect' method, because the JSDoc specified two input parameters, both required. There is a JSDoc standard for optional parameters. What is your view on using these in KOA documentation?
http://usejsdoc.org/tags-param.html#optional-parameters-and-default-values