### PR TITLE
Modified request.get to return undefined

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -593,9 +593,9 @@ module.exports = {
     switch (field = field.toLowerCase()) {
       case 'referer':
       case 'referrer':
-        return req.headers.referrer || req.headers.referer || undefined;
+        return req.headers.referrer || req.headers.referer;
       default:
-        return req.headers[field] || undefined;
+        return req.headers[field];
     }
   },
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -593,9 +593,9 @@ module.exports = {
     switch (field = field.toLowerCase()) {
       case 'referer':
       case 'referrer':
-        return req.headers.referrer || req.headers.referer || '';
+        return req.headers.referrer || req.headers.referer || undefined;
       default:
-        return req.headers[field] || '';
+        return req.headers[field] || undefined;
     }
   },
 


### PR DESCRIPTION
This modifies request.get to return undefined for undefined headers, instead of an empty string. This preserves falsiness, but prevents ambiguity relating to empty versus missing headers, and makes the API more similar to Express to reduce module integration pain.

Issue request documented [here](https://github.com/koajs/koa/issues/663).