### PR TITLE
context.state can inherit app.context.state

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -48,7 +48,7 @@ function Application() {
   this.middleware = [];
   this.proxy = false;
   this.context = Object.create(context);
-  this.context.state = {};
+  this.state = {};
   this.request = Object.create(request);
   this.response = Object.create(response);
 }
@@ -163,8 +163,8 @@ app.createContext = function(req, res){
     secure: request.secure
   });
   context.accept = request.accept = accepts(req);
-  if (typeof this.context.state === 'object') {
-    context.state = Object.create(this.context.state);
+  if (typeof this.state === 'object') {
+    context.state = Object.create(this.state);
   } else {
     context.state = {};
   }

--- a/lib/application.js
+++ b/lib/application.js
@@ -48,6 +48,7 @@ function Application() {
   this.middleware = [];
   this.proxy = false;
   this.context = Object.create(context);
+  this.context.state = {};
   this.request = Object.create(request);
   this.response = Object.create(response);
 }
@@ -162,7 +163,11 @@ app.createContext = function(req, res){
     secure: request.secure
   });
   context.accept = request.accept = accepts(req);
-  context.state = {};
+  if (typeof this.context.state === 'object') {
+    context.state = Object.create(this.context.state);
+  } else {
+    context.state = {};
+  }
   return context;
 };
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -163,11 +163,7 @@ app.createContext = function(req, res){
     secure: request.secure
   });
   context.accept = request.accept = accepts(req);
-  if (typeof this.state === 'object') {
-    context.state = Object.create(this.state);
-  } else {
-    context.state = {};
-  }
+  context.state = Object.create(this.state);
   return context;
 };
 

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -38,22 +38,4 @@ describe('ctx.state', function() {
     .end(done);
 
   })
-
-  it('should not inherit app.state when the latter is not an object', function(done) {
-    var app = koa();
-
-    app.state = 1;
-
-    app.use(function *() {
-      assert.notEqual(this.state, 1);
-    });
-
-    var server = app.listen();
-
-    request(server)
-    .get('/')
-    .expect(404)
-    .end(done);
-
-  })
 })

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -20,4 +20,40 @@ describe('ctx.state', function() {
     .expect(404)
     .end(done);
   })
+
+  it('should inherit app.context.state object', function(done) {
+    var app = koa();
+
+    app.context.state = { foo: 'bar' };
+
+    app.use(function *() {
+      assert.equal(this.state.foo, 'bar');
+    });
+
+    var server = app.listen();
+
+    request(server)
+    .get('/')
+    .expect(404)
+    .end(done);
+
+  })
+
+  it('should not inherit app.context.state when the latter is not object', function(done) {
+    var app = koa();
+
+    app.context.state = 1;
+
+    app.use(function *() {
+      assert.notEqual(this.state, 1);
+    });
+
+    var server = app.listen();
+
+    request(server)
+    .get('/')
+    .expect(404)
+    .end(done);
+
+  })
 })

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -21,10 +21,10 @@ describe('ctx.state', function() {
     .end(done);
   })
 
-  it('should inherit app.context.state object', function(done) {
+  it('should inherit app.state object', function(done) {
     var app = koa();
 
-    app.context.state = { foo: 'bar' };
+    app.state.foo = 'bar';
 
     app.use(function *() {
       assert.equal(this.state.foo, 'bar');
@@ -39,10 +39,10 @@ describe('ctx.state', function() {
 
   })
 
-  it('should not inherit app.context.state when the latter is not object', function(done) {
+  it('should not inherit app.state when the latter is not an object', function(done) {
     var app = koa();
 
-    app.context.state = 1;
+    app.state = 1;
 
     app.use(function *() {
       assert.notEqual(this.state, 1);


### PR DESCRIPTION
In some middlewares like [koa-views](/queckezz/koa-views/), `ctx.state` will automatically inject to view engine. Therefore, if I want to inject some global functions to `ctx.state`, at present I have to build a middleware for it. Although there are some other ways to implement that, I think give `ctx.state` an access at application level will make context self less polluted.