### PR TITLE
Update error handling doc to use promises+async (v2.x)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -6,9 +6,9 @@
   this example prepends all error messages with "Error: "
 
   ```js
-  app.use(function*(next){
+  app.use(async (ctx, next) => {
     try {
-      yield next;
+      await next();
     } catch (error) {
       error.message = 'Error: ' + error.message;
       throw error;


### PR DESCRIPTION
I was thinking about eslint-plugin-markdown, when I realized that I had forgotten to update this when I cherry picked it from master. I guess eslint-plugin-markdown couldn't hurt, but I doubt it would come in handy much. Thoughts?