### PR TITLE
Unify badges to flat-square style

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,8 +112,8 @@ $ make test
 [npm-url]: https://www.npmjs.com/package/koa
 [travis-image]: https://img.shields.io/travis/koajs/koa/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/koajs/koa
-[coveralls-image]: https://codecov.io/github/koajs/koa/coverage.svg?branch=master
+[coveralls-image]: https://img.shields.io/codecov/c/github/koajs/koa.svg?style=flat-square
 [coveralls-url]: https://codecov.io/github/koajs/koa?branch=master
-[gitter-image]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-image]: https://img.shields.io/gitter/room/koajs/koa.svg?style=flat-square
 [gitter-url]: https://gitter.im/koajs/koa?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [#koajs]: https://webchat.freenode.net/?channels=#koajs


### PR DESCRIPTION
I noticed that badges have different styles; having them all elegant suits Koa more.

<img width="890" alt="screen shot 2016-03-15 at 11 27 28" src="https://cloud.githubusercontent.com/assets/68341/13774741/f22dae46-eaa0-11e5-9dd7-6efd8efc484b.png">
