### PR TITLE
Correct ctx.assert documentation parameter order (v2.x)

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -119,7 +119,7 @@ ctx.throw('access_denied', { user: user });
 
 koa uses [http-errors](https://github.com/jshttp/http-errors) to create errors.
 
-### ctx.assert(value, [msg], [status], [properties])
+### ctx.assert(value, [status], [msg], [properties])
 
   Helper method to throw an error similar to `.throw()`
   when `!value`. Similar to node's [assert()](http://nodejs.org/api/assert.html)


### PR DESCRIPTION
Essentially #696 for v2.x