### PR TITLE
Switch from supertest to assert-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "tag": "next"
   },
   "devDependencies": {
+    "assert-request": "^1.0.4",
     "babel-core": "^6.1.2",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-async-to-generator": "^6.0.14",
@@ -59,7 +60,6 @@
     "mocha": "^2.0.1",
     "should": "^6.0.3",
     "should-http": "0.0.3",
-    "supertest": "^1.0.1",
     "test-console": "^0.7.1"
   },
   "engines": {

--- a/test/application/context.js
+++ b/test/application/context.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
@@ -10,25 +10,27 @@ describe('app.context', () => {
   app1.context.msg = 'hello';
   const app2 = new Koa();
 
-  it('should merge properties', done => {
+  it('should merge properties', () => {
     app1.use((ctx, next) => {
       assert.equal(ctx.msg, 'hello');
       ctx.status = 204;
     });
 
-    request(app1.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app1);
+
+    return request('/')
+      .status(204);
   });
 
-  it('should not affect the original prototype', done => {
+  it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
       assert.equal(ctx.msg, undefined);
       ctx.status = 204;
     });
 
-    request(app2.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app1);
+
+    return request('/')
+      .status(204);
   });
 });

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
@@ -19,9 +19,9 @@ describe('app', () => {
       done();
     });
 
-    request(app.listen())
-      .get('/')
-      .end(() => {});
+    const request = AssertRequest(app);
+
+    request('/').catch(err => err);
   });
 
   it('should not .writeHead when !socket.writable', done => {
@@ -41,9 +41,9 @@ describe('app', () => {
     // hackish, but the response should occur in a single tick
     setImmediate(done);
 
-    request(app.listen())
-      .get('/')
-      .end(() => {});
+    const request = AssertRequest(app);
+
+    request('/');
   });
 
   it('should set development env when NODE_ENV missing', () => {

--- a/test/application/request.js
+++ b/test/application/request.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
@@ -10,25 +10,27 @@ describe('app.request', () => {
   app1.request.message = 'hello';
   const app2 = new Koa();
 
-  it('should merge properties', done => {
+  it('should merge properties', () => {
     app1.use((ctx, next) => {
       assert.equal(ctx.request.message, 'hello');
       ctx.status = 204;
     });
 
-    request(app1.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app1);
+
+    return request('/')
+      .status(204);
   });
 
-  it('should not affect the original prototype', done => {
+  it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
       assert.equal(ctx.request.message, undefined);
       ctx.status = 204;
     });
 
-    request(app2.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app2);
+
+    return request('/')
+      .status(204);
   });
 });

--- a/test/application/response.js
+++ b/test/application/response.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
@@ -10,25 +10,27 @@ describe('app.response', () => {
   app1.response.msg = 'hello';
   const app2 = new Koa();
 
-  it('should merge properties', done => {
+  it('should merge properties', () => {
     app1.use((ctx, next) => {
       assert.equal(ctx.response.msg, 'hello');
       ctx.status = 204;
     });
 
-    request(app1.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app1);
+
+    return request('/')
+      .status(204);
   });
 
-  it('should not affect the original prototype', done => {
+  it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
       assert.equal(ctx.response.msg, undefined);
       ctx.status = 204;
     });
 
-    request(app2.listen())
-      .get('/')
-      .expect(204, done);
+    const request = AssertRequest(app1);
+
+    return request('/')
+      .status(204);
   });
 });

--- a/test/babel/_test.js
+++ b/test/babel/_test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const Koa = require('../..');
 
 describe('require("babel-core/register")', () => {
   describe('app.use(fn)', () => {
-    it('should compose middleware w/ async functions', done => {
+    it('should compose middleware w/ async functions', () => {
       const app = new Koa();
       const calls = [];
 
@@ -27,16 +27,11 @@ describe('require("babel-core/register")', () => {
         calls.push(4);
       });
 
-      const server = app.listen();
+      const request = AssertRequest(app);
 
-      request(server)
-        .get('/')
-        .expect(404)
-        .end(err => {
-          if (err) return done(err);
-          calls.should.eql([1, 2, 3, 4, 5, 6]);
-          done();
-        });
+      return request('/')
+        .status(404)
+        .assert(() => calls.should.eql([1, 2, 3, 4, 5, 6]));
     });
   });
 });

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -1,23 +1,21 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
 describe('ctx.state', () => {
-  it('should provide a ctx.state namespace', done => {
+  it('should provide a ctx.state namespace', () => {
     const app = new Koa();
 
     app.use(ctx => {
       assert.deepEqual(ctx.state, {});
     });
 
-    const server = app.listen();
+    const request = AssertRequest(app);
 
-    request(server)
-      .get('/')
-      .expect(404)
-      .end(done);
+    return request('/')
+      .status(404);
   });
 });

--- a/test/response/attachment.js
+++ b/test/response/attachment.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const context = require('../helpers/context');
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const Koa = require('../..');
 
 describe('ctx.attachment([filename])', () => {
@@ -31,7 +31,7 @@ describe('ctx.attachment([filename])', () => {
       ctx.response.header['content-disposition'].should.equal(str);
     });
 
-    it('should work with http client', done => {
+    it('should work with http client', () => {
       const app = new Koa();
 
       app.use((ctx, next) => {
@@ -39,11 +39,12 @@ describe('ctx.attachment([filename])', () => {
         ctx.body = {foo: 'bar'};
       });
 
-      request(app.listen())
-        .get('/')
-        .expect('content-disposition', 'attachment; filename="include-no-ascii-char-???-ok.json"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.json')
-        .expect({foo: 'bar'})
-        .expect(200, done);
+      const request = AssertRequest(app);
+
+      return request('/')
+        .header('content-disposition', 'attachment; filename="include-no-ascii-char-???-ok.json"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.json')
+        .json({foo: 'bar'})
+        .okay();
     });
   });
 });

--- a/test/response/flushHeaders.js
+++ b/test/response/flushHeaders.js
@@ -1,12 +1,12 @@
 
 'use strict';
 
-const request = require('supertest');
+const AssertRequest = require('assert-request');
 const assert = require('assert');
 const Koa = require('../..');
 
 describe('ctx.flushHeaders()', () => {
-  it('should set headersSent', done => {
+  it('should set headersSent', () => {
     const app = new Koa();
 
     app.use((ctx, next) => {
@@ -16,15 +16,14 @@ describe('ctx.flushHeaders()', () => {
       assert(ctx.res.headersSent);
     });
 
-    const server = app.listen();
+    const request = AssertRequest(app);
 
-    request(server)
-      .get('/')
-      .expect(200)
-      .expect('Body', done);
+    return request('/')
+      .status(200)
+      .body('Body');
   });
 
-  it('should allow a response afterwards', done => {
+  it('should allow a response afterwards', () => {
     const app = new Koa();
 
     app.use((ctx, next) => {
@@ -34,15 +33,15 @@ describe('ctx.flushHeaders()', () => {
       ctx.body = 'Body';
     });
 
-    const server = app.listen();
-    request(server)
-      .get('/')
-      .expect(200)
-      .expect('Content-Type', 'text/plain')
-      .expect('Body', done);
+    const request = AssertRequest(app);
+
+    return request('/')
+      .status(200)
+      .header('Content-Type', 'text/plain')
+      .body('Body');
   });
 
-  it('should send the correct status code', done => {
+  it('should send the correct status code', () => {
     const app = new Koa();
 
     app.use((ctx, next) => {
@@ -52,15 +51,15 @@ describe('ctx.flushHeaders()', () => {
       ctx.body = 'Body';
     });
 
-    const server = app.listen();
-    request(server)
-      .get('/')
-      .expect(401)
-      .expect('Content-Type', 'text/plain')
-      .expect('Body', done);
+    const request = AssertRequest(app);
+
+    return request('/')
+      .status(401)
+      .header('Content-Type', 'text/plain')
+      .body('Body');
   });
 
-  it('should fail to set the headers after flushHeaders', done => {
+  it('should fail to set the headers after flushHeaders', () => {
     const app = new Koa();
 
     app.use((ctx, next) => {
@@ -85,14 +84,11 @@ describe('ctx.flushHeaders()', () => {
       }
     });
 
-    const server = app.listen();
-    request(server)
-      .get('/')
-      .expect(401)
-      .expect('Content-Type', 'text/plain')
-      .expect('ctx.set fail ctx.status fail ctx.length fail', (err, res) => {
-        assert(res.headers['x-shouldnt-work'] === undefined, 'header set after flushHeaders');
-        done(err);
-      });
+    const request = AssertRequest(app);
+
+    return request('/')
+      .status(401)
+      .header('Content-Type', 'text/plain')
+      .header('X-Shouldnt-Work', null);
   });
 });

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -1,8 +1,8 @@
 
 'use strict';
 
+const AssertRequest = require('assert-request');
 const response = require('../helpers/context').response;
-const request = require('supertest');
 const statuses = require('statuses');
 const assert = require('assert');
 const Koa = require('../..');
@@ -53,7 +53,7 @@ describe('res.status=', () => {
   });
 
   function strip(status){
-    it('should strip content related header fields', done => {
+    it('should strip content related header fields', () => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -67,19 +67,17 @@ describe('res.status=', () => {
         assert(null == ctx.response.header['transfer-encoding']);
       });
 
-      request(app.listen())
-        .get('/')
-        .expect(status)
-        .end((err, res) => {
-          res.should.not.have.header('content-type');
-          res.should.not.have.header('content-length');
-          res.should.not.have.header('content-encoding');
-          res.text.should.have.length(0);
-          done(err);
-        });
+      const request = AssertRequest(app);
+
+      return request('/')
+        .status(status)
+        .header('Content-Type', null)
+        .header('Content-Length', null)
+        .header('Content-Encoding', null)
+        .body(body => body.should.have.length(0));
     });
 
-    it('should strip content releated header fields after status set', done => {
+    it('should strip content releated header fields after status set', () => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -90,16 +88,14 @@ describe('res.status=', () => {
         ctx.set('Transfer-Encoding', 'chunked');
       });
 
-      request(app.listen())
-        .get('/')
-        .expect(status)
-        .end((err, res) => {
-          res.should.not.have.header('content-type');
-          res.should.not.have.header('content-length');
-          res.should.not.have.header('content-encoding');
-          res.text.should.have.length(0);
-          done(err);
-        });
+      const request = AssertRequest(app);
+
+      return request('/')
+        .status(status)
+        .header('Content-Type', null)
+        .header('Content-Length', null)
+        .header('Content-Encoding', null)
+        .body(body => body.should.have.length(0));
     });
   }
 


### PR DESCRIPTION
Assert-request is a promise-based utility I created to replace supertest. Supertest often leads to a custom .end function checking things like a header not existing. In addition, .expect [is messy](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L78) because it tries to be a single function to assert everything. As you can see by looking through the diff, assert-request leads to much cleaner code.

If you're worried about this getting unpublished, NPM recently changed the unpublish feature after left-pad (you first have to contact support and they will check if anything will break because it's gone). If you're worried about this not being maintained, first of all I plan to maintain this, and second of all you can always fork it. The code base is well tested, and IMO well written.