### PR TITLE
Rename request.ips to request.forwardedFor

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -158,7 +158,7 @@ module.exports = class Application extends Emitter {
       keys: this.keys,
       secure: request.secure
     });
-    request.ip = request.ips[0] || req.socket.remoteAddress || '';
+    request.ip = request.forwardedFor[0] || req.socket.remoteAddress || '';
     context.accept = request.accept = accepts(req);
     context.state = {};
     return context;

--- a/lib/context.js
+++ b/lib/context.js
@@ -192,4 +192,5 @@ delegate(proto, 'request')
   .getter('stale')
   .getter('fresh')
   .getter('ips')
+  .getter('forwardedFor')
   .getter('ip');

--- a/lib/request.js
+++ b/lib/request.js
@@ -12,6 +12,7 @@ const qs = require('querystring');
 const typeis = require('type-is');
 const fresh = require('fresh');
 const only = require('only');
+const deprecate = require('depd')('koa');
 
 /**
  * Prototype.
@@ -378,12 +379,24 @@ module.exports = {
    * @api public
    */
 
-  get ips() {
+  get forwardedFor() {
     const proxy = this.app.proxy;
     const val = this.get('X-Forwarded-For');
     return proxy && val
       ? val.split(/\s*,\s*/)
       : [];
+  },
+
+  /**
+   * Deprecated alias of forwardedFor
+   * @return {Array}
+   * @api public
+   */
+
+  get ips() {
+    deprecate('This is a deprecated alias of forwardedFor. ' +
+              'Please use forwardedFor instead.');
+    return this.forwardedFor;
   },
 
   /**

--- a/test/request/forwardedFor.js
+++ b/test/request/forwardedFor.js
@@ -1,16 +1,17 @@
 
 'use strict';
 
+const assert = require('assert');
 const request = require('../helpers/context').request;
 
-describe('req.ips', () => {
+describe('req.forwardedFor', () => {
   describe('when X-Forwarded-For is present', () => {
     describe('and proxy is not trusted', () => {
       it('should be ignored', () => {
         const req = request();
         req.app.proxy = false;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
-        req.ips.should.eql([]);
+        req.forwardedFor.should.eql([]);
       });
     });
 
@@ -19,8 +20,18 @@ describe('req.ips', () => {
         const req = request();
         req.app.proxy = true;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
-        req.ips.should.eql(['127.0.0.1', '127.0.0.2']);
+        req.forwardedFor.should.eql(['127.0.0.1', '127.0.0.2']);
       });
     });
+  });
+
+  it('should also be usable with deprecated .ips', () => {
+    let deprecated = false;
+    process.on('deprecation', message => deprecated = true);
+    const req = request();
+    req.app.proxy = true;
+    req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
+    req.ips.should.eql(['127.0.0.1', '127.0.0.2']);
+    assert(deprecated);
   });
 });


### PR DESCRIPTION
The name is somewhat deceiving IMO. Another option would be to always add `this.socket.remoteAddress` to the beginning of request.ips, and then have request.ip simply return `this.ips[0]`. However, that would be a breaking change, and this is not.