### PR TITLE
possible typo

### DIFF
--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -17,7 +17,7 @@
 
 ### response.socket
 
-  Request socket.
+  Response socket.
 
 ### response.status
 


### PR DESCRIPTION
Is documentation correct? 
or should it be: ?

from:
response.socket

Request socket.

to:
response.socket

Response socket.

if so:
fixes #737