### PR TITLE
2.x change three console.error statements into one.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -105,9 +105,9 @@ module.exports = class Application extends Emitter {
   use(fn) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
     if (isGeneratorFunction(fn)) {
-      deprecate('Support for generators will been removed in v3. ' +
-                'See the documentation for examples of how to convert old middleware ' +
-                'https://github.com/koajs/koa/tree/v2.x#old-signature-middleware-v1x');
+      deprecate(`Support for generators will been removed in v3. 
+                See the documentation for examples of how to convert old middleware 
+                https://github.com/koajs/koa/tree/v2.x#old-signature-middleware-v1x`);
       fn = convert(fn);
     }
     debug('use %s', fn._name || fn.name || '-');

--- a/lib/application.js
+++ b/lib/application.js
@@ -178,9 +178,7 @@ module.exports = class Application extends Emitter {
     if (this.silent) return;
 
     const msg = err.stack || err.toString();
-    console.error();
-    console.error(msg.replace(/^/gm, '  '));
-    console.error();
+    console.error(`\n${msg.replace(/^/gm, '  ')}\n`);
   }
 
 };

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -48,7 +48,7 @@ describe('app.onerror(err)', () => {
 
     const output = stderr.inspectSync(() => app.onerror(err));
 
-    output.should.eql(['\n', '  Foo\n', '\n']);
+    output.should.eql(['\n  Foo\n\n']);
 
     done();
   });
@@ -62,7 +62,7 @@ describe('app.onerror(err)', () => {
 
     const output = stderr.inspectSync(() => app.onerror(err));
 
-    output.should.eql(['\n', '  Error: mock stack null\n', '\n']);
+    output.should.eql(['\n  Error: mock stack null\n\n']);
 
     done();
   });


### PR DESCRIPTION
1. change three console.error statements into one, this should improve some performance for the console.error is a sync io operation, reduce the number of times to call to console.error should improve some performance although this will not cause realtime problem.
2. user template string in multiple lines of strings to avoid + operator.
