### PR TITLE
Updated AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,70 +1,95 @@
-TJ Holowaychuk <tj@vision-media.ca>
-Jonathan Ong <jonathanrichardong@gmail.com>
-dead_horse <dead_horse@qq.com>
-Yiyu He <dead_horse@qq.com>
-fengmk2 <fengmk2@gmail.com>
-Julian Gruber <julian@juliangruber.com>
-Rui Marinho <rpm@seegno.com>
-Jonathan Ong <me@jongleberry.com>
-jongleberry <jonathanong@users.noreply.github.com>
-Ian Storm Taylor <ian@ianstormtaylor.com>
-pana <pana.wang@outlook.com>
+Aaron Heckmann <aaron.heckmann+github@gmail.com>
+Adam L <skyros@gmail.com>
+AlexeyKhristov <AlexeyKhristov@users.noreply.github.com>
 alsotang <alsotang@gmail.com>
-PatrickJS <github@gdi2290.com>
-yoshuawuyts <i@yoshuawuyts.com>
-Jesús Rodríguez Rodríguez <Foxandxss@gmail.com>
-Sonny Piers <sonny@fastmail.net>
+Bartol Karuza <bartol.k@gmail.com>
+Ben Reinhart <breinhart@groupon.com>
+bhanuc <bhanuc@iitk.ac.in>
+Bryan Bess <squarejaw@bsbess.com>
+Chris Tarquini <chris@ilsken.com>
+Christoffer Hallas <hallas@users.noreply.github.com>
+C.T. Lin <chentsulin@gmail.com>
+Darren Cauthon <darren@cauthon.com>
+dead_horse <dead_horse@qq.com>
+Debjeet Biswas <debjeet@vxtindia.com>
+Dmitry Mazuro <dmitry.mazuro@icloud.com>
+Douglas Christopher Wilson <doug@somethingdoug.com>
+Eivind Fjeldstad <eivind.fjeldstad@gmail.com>
+fengmk2 <fengmk2@gmail.com>
+fengmk2 <m@fengmk2.com>
+fundon <cfddream@gmail.com>
+greenkeeperio-bot <support@greenkeeper.io>
+Guilherme Pacheco <guilherme.f.pacheco@hotmail.com>
+gyson <eilian.yunsong@gmail.com>
+HanHor Wu <hanhor.wu@gmail.com>
+haoxin <coderhaoxin@outlook.com>
+Hugh Kennedy <hughskennedy@gmail.com>
+Ian Storm Taylor <ian@ianstormtaylor.com>
+James Ide <ide@jameside.com>
+Jan Buschtöns <buschtoens@gmail.com>
+Jan Carlo Viray <virayjancarlo@yahoo.com>
+janriemer <janriemer@tutanota.de>
+Jed Schmidt <where@jed.is>
+jeromew <jerome.wagner@m4x.org>
 Jesus Rodriguez <foxandxss@gmail.com>
+Jesús Rodríguez Rodríguez <Foxandxss@gmail.com>
 Jingwei "John" Liu <liujingwei@gmail.com>
 Johan Bergström <bugs@bergstroem.nu>
+Jonathan Ong <jonathanrichardong@gmail.com>
+Jonathan Ong <me@jongleberry.com>
+jongleberry <jonathanong@users.noreply.github.com>
+jongleberry <me@jongleberry.com>
+Julian Gruber <julian@juliangruber.com>
+Julien Fontanet <julien.fontanet@isonoe.net>
 Karl Böhlmark <karl.bohlmark@gmail.com>
 Kenneth Ormandy <kenneth@chloi.io>
 Kim Joar Bekkelund <kjbekkelund@gmail.com>
 Kyle Suss <susskyle@gmail.com>
+Lee Bousfield <ljbousfield@gmail.com>
+llambda <xxgsoftware@gmail.com>
+Louis DeScioli <louis.descioli@gmail.com>
+mako-taco <jake.y.scott@gmail.com>
 Matheus Azzi <matheuslazzi@gmail.com>
 Mathieu Gallé-Tessonneau <mathieu.galletessonneau@gmail.com>
 Matthew Chase Whittemore <matthew@socialtables.com>
 Matthew King <mking@users.noreply.github.com>
 Matthew Mueller <mattmuelle@gmail.com>
+mdemo <mds@xue.bi>
 Michaël Zasso <mic.besace@gmail.com>
 Nathan Rajlich <nathan@tootallnate.net>
-Aaron Heckmann <aaron.heckmann+github@gmail.com>
+New Now Nohow <empty@cqdr.es>
+nicoder <nicolas.dermine@gmail.com>
+pana <pana.wang@outlook.com>
+PatrickJS <github@gdi2290.com>
 Peeyush Kushwaha <peeyush.p97@gmail.com>
 Phillip Alexander <git@phillipalexander.io>
+Prayag Verma <prayag.verma@gmail.com>
 Qiming zhao <chemzqm@gmail.com>
+ReadmeCritic <frankensteinbot@gmail.com>
 Robert Sköld <robert@publicclass.se>
+Robin Pokorný <me@robinpokorny.com>
+Rui Marinho <rpm@seegno.com>
 Ryunosuke SATO <tricknotes.rs@gmail.com>
+Santiago Sotomayor <sansoto2003@yahoo.com.ar>
+Sheryl Hohman <SherylHohman@users.noreply.github.com>
+Sonny Piers <sonny@fastmail.net>
+Sterling Williams <sterlingw@qualtrics.com>
+Stig Otnes Kolstad <stigok@users.noreply.github.com>
+superchink <superchink@gmail.com>
+Tejas Manohar <me@tejas.io>
 Teoman Soygul <teo@soygul.com>
 Tiago Ribeiro <tlr@seegno.com>
 Tim Schaub <tim.schaub@gmail.com>
+TJ Holowaychuk <tj@vision-media.ca>
+tmilewski <tmilewski@gmail.com>
+tonykung06 <tonykung06@hotmail.com>
+Travis Jeffery <tj@travisjeffery.com>
 Veselin Todorov <veselin@veselin.bg>
 Yazhong Liu <l900422@vip.qq.com>
 Yazhong Liu <yorkiefixer@gmail.com>
+Yiyu He <dead_horse@qq.com>
+yoshuawuyts <i@yoshuawuyts.com>
 Yoshua Wuyts <yoshuawuyts@gmail.com>
-bhanuc <bhanuc@iitk.ac.in>
-fengmk2 <m@fengmk2.com>
-fundon <cfddream@gmail.com>
-haoxin <coderhaoxin@outlook.com>
-jeromew <jerome.wagner@m4x.org>
-mako-taco <jake.y.scott@gmail.com>
-nicoder <nicolas.dermine@gmail.com>
-superchink <superchink@gmail.com>
-tmilewski <tmilewski@gmail.com>
 yosssi <yoshida.keiji.84@gmail.com>
+Yu Qi <iyuq@outlook.com>
 zensh <admin@zensh.com>
-New Now Nohow <empty@cqdr.es>
-Adam L <skyros@gmail.com>
-Ben Reinhart <breinhart@groupon.com>
-Chris Tarquini <chris@ilsken.com>
-Christoffer Hallas <hallas@users.noreply.github.com>
-Darren Cauthon <darren@cauthon.com>
-Debjeet Biswas <debjeet@vxtindia.com>
-Dmitry Mazuro <dmitry.mazuro@icloud.com>
-Douglas Christopher Wilson <doug@somethingdoug.com>
-Eivind Fjeldstad <eivind.fjeldstad@gmail.com>
-Guilherme Pacheco <guilherme.f.pacheco@hotmail.com>
-HanHor Wu <hanhor.wu@gmail.com>
-Hugh Kennedy <hughskennedy@gmail.com>
-Jan Buschtöns <buschtoens@gmail.com>
-Jan Carlo Viray <virayjancarlo@yahoo.com>
-Jed Schmidt <where@jed.is>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Koa web app framework",
   "main": "lib/application.js",
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "update-authors": "git log --format='%aN <%aE>' | sort -u > AUTHORS"
   },
   "repository": "koajs/koa",
   "keywords": [


### PR DESCRIPTION
It's now alphabetically sorted, with info at the top on how to update it. Should we only keep names with spaces in here? (as in, not usernames, just real names) It would leave out some contributors, but we already have the contributors button at the top of the repo; this serves a different purpose.

Also, we have different combinations of usernames, emails, and real names, but there's no good way to unique them independently I think.

I'll make this for v2.x once it's merged for master.