### PR TITLE
Replace co with bluebird-co

### DIFF
--- a/benchmarks/experimental/async.js
+++ b/benchmarks/experimental/async.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var http = require('http');
+var Promise = require('bluebird');
 var koa = require('../..');
 var app = koa();
 

--- a/benchmarks/experimental/index.js
+++ b/benchmarks/experimental/index.js
@@ -2,8 +2,8 @@
 'use strict';
 
 // support async await by babel
-require('babel/register')({
-  optional: ['asyncToGenerator']
+require('babel-core/register')({
+  plugins: ['babel-plugin-syntax-async-functions', 'babel-plugin-bluebird-async-functions']
 });
 
 require('./async');

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo
-MW=$1 node --harmony $2 &
+MW=$1 node $2 &
 pid=$!
 
 sleep 2

--- a/lib/application.js
+++ b/lib/application.js
@@ -21,7 +21,7 @@ var assert = require('assert');
 var Stream = require('stream');
 var http = require('http');
 var only = require('only');
-var co = require('co');
+var co = require('bluebird-co');
 
 /**
  * Application prototype.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "koa",
+  "name": "koa-bluebird-co",
   "version": "1.2.0",
   "description": "Koa web app framework",
   "main": "lib/application.js",
@@ -7,7 +7,7 @@
     "test": "make test",
     "update-authors": "git log --format='%aN <%aE>' | sort -u > AUTHORS"
   },
-  "repository": "koajs/koa",
+  "repository": "andyhu/koa",
   "keywords": [
     "web",
     "app",
@@ -20,8 +20,9 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "^1.2.2",
-    "co": "^4.4.0",
-    "composition": "^2.1.1",
+    "bluebird": "^3.4.1",
+    "bluebird-co": "^2.1.2",
+    "composition": "^2.3.0",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
     "cookies": "~0.6.1",
@@ -33,7 +34,7 @@
     "fresh": "^0.3.0",
     "http-assert": "^1.1.0",
     "http-errors": "^1.2.8",
-    "koa-compose": "^2.3.0",
+    "koa-compose": "^2.4.0",
     "koa-is-json": "^1.0.0",
     "mime-types": "^2.0.7",
     "on-finished": "^2.1.0",
@@ -44,14 +45,16 @@
     "vary": "^1.0.0"
   },
   "devDependencies": {
-    "babel": "^5.0.0",
+    "babel-core": "^6.10.4",
+    "babel-plugin-bluebird-async-functions": "^1.2.0",
+    "babel-plugin-syntax-async-functions": "^6.8.0",
     "istanbul": "^0.4.0",
     "make-lint": "^1.0.1",
     "mocha": "^2.0.1",
-    "should": "^6.0.3",
-    "should-http": "0.0.3",
+    "should": "^9.0.2",
+    "should-http": "0.0.4",
     "supertest": "^1.0.1",
-    "test-console": "^0.7.1"
+    "test-console": "^1.0.0"
   },
   "engines": {
     "node": ">= 0.12.0",


### PR DESCRIPTION
By replacing `co` with `bliebird-co`, the benchmark is nearly doubled!
See result below:

### Benchmarks with koa 1.2.0:
![image](https://cloud.githubusercontent.com/assets/203980/16855918/36fc0a64-4a4a-11e6-8eed-1572bf4eacff.png)

### Benchmarks with koa 1.2.0 (modified version, replaced co with bluebird-co)
![image](https://cloud.githubusercontent.com/assets/203980/16855912/31b0a2cc-4a4a-11e6-916b-b3a223a81f78.png)

### Benchmarks with koa 2.0.0-alpha3:
![image](https://cloud.githubusercontent.com/assets/203980/16855851/e0453f7e-4a49-11e6-87f4-1a112f7cd7ca.png)


Here is the benchmark for `co` vs `bluebird` `coroutine`:
https://github.com/novacrazy/bluebird-co/tree/master/benchmark

This is a huge gain.

Here is the npm package I published with this pr:
http://npmjs.com/package/koa-bluebird-co