### PR TITLE
Link to v2.x in docs

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/api/context.md) (recommended).
+
+
 # Context
 
   A Koa Context encapsulates node's `request` and `response` objects

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/api/index.md) (recommended).
+
+
 # Installation
 
 Koa works out of the box with recent versions of Node.

--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/api/request.md) (recommended).
+
+
 # Request
 
   A Koa `Request` object is an abstraction on top of node's vanilla request object,

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/api/response.md) (recommended).
+
+
 # Response
 
   A Koa `Response` object is an abstraction on top of node's vanilla response object,

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/error-handling.md) (recommended).
+
+
 # Error Handling
 
 ## Try-Catch

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/faq.md) (recommended).
+
+
 # Frequently Asked Questions
 
 ## Does Koa replace Express?

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,3 +1,5 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/guide.md) (recommended).
+
 
 # Guide
 

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -1,3 +1,6 @@
+Viewing docs for **v1.x** (stable). [View for v2.x](https://github.com/koajs/koa/blob/v2.x/docs/koa-vs-express.md) (recommended).
+
+
 THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT IS DONE.
 
 # Koa vs Express


### PR DESCRIPTION
A first step towards https://github.com/koajs/koa/issues/533#issuecomment-235300442

If you like the direction, let's workshop the wording and I'll add the inverse to the v2.x branch and figure out a way to clean it up on https://github.com/koajs/koajs.com . 

Sound good?
