### PR TITLE
[breaking change] don't bind onerror to context

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -131,8 +131,9 @@ module.exports = class Application extends Emitter {
     return (req, res) => {
       res.statusCode = 404;
       const ctx = this.createContext(req, res);
-      onFinished(res, ctx.onerror);
-      fn(ctx).then(() => respond(ctx)).catch(ctx.onerror);
+      const onerror = err => ctx.onerror(err);
+      onFinished(res, onerror);
+      fn(ctx).then(() => respond(ctx)).catch(onerror);
     };
   }
 
@@ -152,7 +153,6 @@ module.exports = class Application extends Emitter {
     request.ctx = response.ctx = context;
     request.response = response;
     response.request = request;
-    context.onerror = context.onerror.bind(context);
     context.originalUrl = request.originalUrl = req.url;
     context.cookies = new Cookies(req, res, {
       keys: this.keys,

--- a/lib/response.js
+++ b/lib/response.js
@@ -164,7 +164,7 @@ module.exports = {
     // stream
     if ('function' == typeof val.pipe) {
       onFinish(this.res, destroy.bind(null, val));
-      ensureErrorHandler(val, this.ctx.onerror);
+      ensureErrorHandler(val, err => this.ctx.onerror(err));
 
       // overwriting
       if (null != original && original != val) this.remove('Content-Length');


### PR DESCRIPTION
1. People should understand javascript's `this`, and it's easy to handle with arrow functions just like `stream.on('error', err => this.onerror(err));`.
2. We already handled all the errors automatically in koa, 99.9% people won't use `this.onerror` in app level. We have written 100+ apps and middlewares in production, no one used `this.onerror`.
3. It's has higher performance(~10% increase).

- before

```
  1 middleware
  9134.88

  5 middleware
  9209.45

  10 middleware
  8261.05

  15 middleware
  8873.18

  20 middleware
  8957.63

  30 middleware
  9036.78

  50 middleware
  8543.95

  100 middleware
  8088.44
```

- after

```
  1 middleware
  9939.28

  5 middleware
  9806.14

  10 middleware
  9636.60

  15 middleware
  9603.57

  20 middleware
  9664.59

  30 middleware
  9695.19

  50 middleware
  9220.74

  100 middleware
  8498.86
```