### PR TITLE
doc: Change usage of reserved word `static` in guide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -256,16 +256,16 @@ $ DEBUG=koa* node --harmony examples/simple
 
 ```js
 var path = require('path');
-var static = require('koa-static');
+var serve = require('koa-static');
 
-var publicFiles = static(path.join(__dirname, 'public'));
-publicFiles._name = 'static /public';
+var publicFiles = serve(path.join(__dirname, 'public'));
+publicFiles._name = 'serve /public';
 
 app.use(publicFiles);
 ```
 
-  Now, instead of just seeing "static" when debugging, you will see:
+  Now, instead of just seeing "serve" when debugging, you will see:
 
 ```
-  koa:application use static /public +0ms
+  koa:application use serve /public +0ms
 ```


### PR DESCRIPTION
Very minor, but I think `static` is a reserved word so it might be better to use `serve` instead, I think that's what `koa-static` uses in its examples as well.