### PR TITLE
make response.append more smartly.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -460,14 +460,26 @@ module.exports = {
 
   append(field, val) {
     const prev = this.get(field);
-
+    let rlt = [];
     if (prev) {
-      val = Array.isArray(prev)
-        ? prev.concat(val)
-        : [prev].concat(val);
+      rlt = rlt.concat(prev).map(e => e.toLowerCase());
+    }
+    if (!Array.isArray(val)) {
+      val = [val];
+    }
+    if (rlt.indexOf('*') !== -1 || val.indexOf('*') !== -1) {
+      rlt = '*';
+    } else {
+      for (let i = 0; i < val.length; i++) {
+        let fld = val[i].toLowerCase();
+        // append value (case-preserving)
+        if (prev.indexOf(fld) === -1) {
+          rlt.push(fld);
+        }
+      }
     }
 
-    return this.set(field, val);
+    return this.set(field, rlt);
   },
 
   /**

--- a/test/response/append.js
+++ b/test/response/append.js
@@ -19,6 +19,22 @@ describe('ctx.append(name, val)', () => {
     ctx.response.header['set-cookie'].should.eql(['foo=bar', 'fizz=buzz', 'hi=again']);
   });
 
+  it('should return * when already has a *', () => {
+    const ctx = context();
+
+    ctx.append('x-foo', '*');
+    ctx.append('x-foo', 'bar');
+    ctx.response.header['x-foo'].should.eql('*');
+  });
+
+  it('should ignore duplicate case values', () => {
+    const ctx = context();
+
+    ctx.append('x-foo', ['Foo']);
+    ctx.append('x-foo', ['foo', 'bar']);
+    ctx.response.header['x-foo'].should.eql(['foo', 'bar']);
+  });
+
   it('should get reset by res.set(field, val)', () => {
     const ctx = context();
 


### PR DESCRIPTION
change response.append to set headers field to * when field is * or val contains *, also only add val of case-insensitive.
inspired by [vary](https://github.com/jshttp/vary).