### PR TITLE
Return middleware chain promise from `callback()`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -169,6 +169,12 @@ this.cookies.set('name', 'tobi', { signed: true });
 app.context.db = db();
 ```
 
+## app.usedAsMiddleware
+
+  Disables the default 404 status code and empty response.
+  This is very useful if you're using Koa as part of another framework, where Koa tries
+  to handle a request first and then falls back to the legacy framework.
+
 ## Error Handling
 
   By default outputs all errors to stderr unless __NODE_ENV__ is "test" or `app.silent` is `true`.

--- a/lib/application.js
+++ b/lib/application.js
@@ -130,7 +130,10 @@ app.callback = function(){
   if (!this.listeners('error').length) this.on('error', this.onerror);
 
   return function handleRequest(req, res){
-    res.statusCode = 404;
+    // don't set the default status code if Koa is part of a larger framework
+    if (!self.usedAsMiddleware) {
+      res.statusCode = 404;
+    }
     var ctx = self.createContext(req, res);
     onFinished(res, ctx.onerror);
     return fn.call(ctx).then(function handleResponse() {
@@ -215,6 +218,8 @@ function respond() {
 
   // status body
   if (null == body) {
+    // don't send back the default empty response if Koa is part of a larger framework
+    if (this.app.usedAsMiddleware) return;
     this.type = 'text';
     body = this.message || String(code);
     this.length = Buffer.byteLength(body);

--- a/lib/application.js
+++ b/lib/application.js
@@ -133,7 +133,7 @@ app.callback = function(){
     res.statusCode = 404;
     var ctx = self.createContext(req, res);
     onFinished(res, ctx.onerror);
-    fn.call(ctx).then(function handleResponse() {
+    return fn.call(ctx).then(function handleResponse() {
       respond.call(ctx);
     }).catch(ctx.onerror);
   }


### PR DESCRIPTION
Without this, there's no way of hooking into after Koa is done with the response. This can be extremely important if used with `ctx.respond = false`, as in #846 (see there for use case). While this is technically a breaking change, I don't expect it to break anything.
