### PR TITLE
this.is() returns null when no body is passed

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -195,7 +195,7 @@ this.body = yield db.find('something');
 
   Check if the incoming request contains the "Content-Type"
   header field, and it contains any of the give mime `type`s.
-  If there is no request body, `undefined` is returned.
+  If there is no request body, `null` is returned.
   If there is no content type, or the match fails `false` is returned.
   Otherwise, it returns the matching content-type.
 


### PR DESCRIPTION
It doesn't return `undefined`. It returns `null`. 

https://github.com/jshttp/type-is#each-type-can-be

> `null` will be returned if the request does not have a body.