### PR TITLE
adding ctx.redirect test case

### DIFF
--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -94,6 +94,18 @@ describe('ctx.redirect(url)', () => {
     });
   });
 
+  describe('when custom status is set', () => {
+    it('should change the status code to 401', () => {
+      const ctx = context();
+      const url = 'http://google.com';
+      ctx.status = 401;
+      ctx.header.accept = 'text/plain';
+      ctx.redirect('http://google.com');
+      ctx.status.should.equal(401);
+      ctx.body.should.equal(`Redirecting to ${url}.`);
+    });
+  });
+
   describe('when content-type was present', () => {
     it('should overwrite content-type', () => {
       const ctx = context();


### PR DESCRIPTION
#857 

when setting status code to 401 before calling ctx.redirect(), koajs does not persist it.

per documentation @ https://github.com/koajs/koa/blob/v2.x/docs/api/response.md#responseredirecturl-alt
copy suggests that i could set status to something other then 302 and expect this status to persist. Either documentation is not clear about the outcome or this is a bug.