### PR TITLE
Fix typo for accepts().

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -415,7 +415,7 @@ module.exports = {
 
   /**
    * Check if the given `type(s)` is acceptable, returning
-   * the best match when true, otherwise `undefined`, in which
+   * the best match when true, otherwise `false`, in which
    * case you should respond with 406 "Not Acceptable".
    *
    * The `type` value may be a single mime type string
@@ -442,7 +442,7 @@ module.exports = {
    *     // Accept: text/*, application/json
    *     this.accepts('image/png');
    *     this.accepts('png');
-   *     // => undefined
+   *     // => false
    *
    *     // Accept: text/*;q=.5, application/json
    *     this.accepts(['html', 'json']);
@@ -450,7 +450,7 @@ module.exports = {
    *     // => "json"
    *
    * @param {String|Array} type(s)...
-   * @return {String|Array|Boolean}
+   * @return {String|Array|false}
    * @api public
    */
 

--- a/test/request/accepts.js
+++ b/test/request/accepts.js
@@ -87,6 +87,7 @@ describe('ctx.accepts(types)', () => {
       ctx.accepts('text/html').should.equal('text/html');
       ctx.accepts('text/plain').should.equal('text/plain');
       ctx.accepts('image/png').should.be.false;
+      ctx.accepts('png').should.be.false;
     });
   });
 });


### PR DESCRIPTION
It returns {String|Array|false}, never return undeifined.

Is the old description a typo? I also look the source code of `accepts` [index.js#L81](https://github.com/jshttp/accepts/blob/master/index.js#L81), seems there is no branch returned a `undefined`. 
```
   *     // Accept: text/*, application/json
   *     this.accepts('image/png');
   *     this.accepts('png');
   *     // => undefined
```