### PR TITLE
Amend typo, request.is() return null|fasle|string.

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -195,7 +195,7 @@ ctx.body = yield db.find('something');
 
   Check if the incoming request contains the "Content-Type"
   header field, and it contains any of the give mime `type`s.
-  If there is no request body, `undefined` is returned.
+  If there is no request body, `null` is returned.
   If there is no content type, or the match fails `false` is returned.
   Otherwise, it returns the matching content-type.
 

--- a/test/request/is.js
+++ b/test/request/is.js
@@ -17,9 +17,9 @@ describe('ctx.is(type)', () => {
     it('should return null', () => {
       const ctx = context();
 
-      assert(null == ctx.is());
-      assert(null == ctx.is('image/*'));
-      assert(null == ctx.is('image/*', 'text/*'));
+      assert(null === ctx.is());
+      assert(null === ctx.is('image/*'));
+      assert(null === ctx.is('image/*', 'text/*'));
     });
   });
 


### PR DESCRIPTION
Modifying the test for `null` from `==` to `===` to make sure it must be `null`.