### PR TITLE
Adds the ability to insert middleware at desired index in middleware stack

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -157,9 +157,9 @@ http.createServer(app.callback()).listen(3001);
   You may also use this callback function to mount your koa app in a
   Connect/Express app.
 
-## app.use(function)
+## app.use(function,[index])
 
-  Add the given middleware function to this application. See [Middleware](https://github.com/koajs/koa/wiki#middleware) for
+  Add the given middleware `function` to the application middleware stack or insert middleware `function` at desired `index` in stack. See [Middleware](https://github.com/koajs/koa/wiki#middleware) for
   more information.
 
 ## app.keys=
@@ -184,7 +184,7 @@ ctx.cookies.set('name', 'tobi', { signed: true });
 
 ## app.context
 
-  `app.context` is the prototype from which `ctx` is created from. 
+  `app.context` is the prototype from which `ctx` is created from.
   You may add additional properties to `ctx` by editing `app.context`.
   This is useful for adding properties or methods to `ctx` to be used across your entire app,
   which may be more performant (no middleware) and/or easier (fewer `require()`s)

--- a/lib/application.js
+++ b/lib/application.js
@@ -98,11 +98,12 @@ module.exports = class Application extends Emitter {
    * Old-style middleware will be converted.
    *
    * @param {Function} fn
+   * @param {number} [idx]
    * @return {Application} self
    * @api public
    */
 
-  use(fn) {
+  use(fn, idx) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
     if (isGeneratorFunction(fn)) {
       deprecate('Support for generators will be removed in v3. ' +
@@ -111,7 +112,11 @@ module.exports = class Application extends Emitter {
       fn = convert(fn);
     }
     debug('use %s', fn._name || fn.name || '-');
-    this.middleware.push(fn);
+    if (typeof idx === 'number' && idx >= 0) {
+      this.middleware.splice(idx, 0, fn);
+    } else {
+      this.middleware.push(fn);
+    }
     return this;
   }
 

--- a/test/application/use.js
+++ b/test/application/use.js
@@ -126,4 +126,14 @@ describe('app.use(fn)', () => {
 
     (() => app.use('not a function')).should.throw('middleware must be a function!');
   });
+
+  it('should insert middlware at desired index in middlware stack', done => {
+    const app = new Koa();
+    app.use(ctx => { ctx.body = 'first'; });
+    app.use(ctx => { ctx.body = 'second'; }, 0);
+
+    request(app.listen())
+      .get('/')
+      .expect(200, 'second', done);
+  });
 });


### PR DESCRIPTION
Because Koa runs middleware in sequence created by pushing middleware into app.middleware, sometimes there is a need to insert middleware at different position. For example when we use async/await or Promises when composing middleware.

In example below we can insert "first" middleware at first position after Promise has been resolved. The app will output "first", although "second" middleware was added first to the stack.

```javascript
const Koa = require('koa');
const app = new Koa();

// async/await
(async () => {
  var index = app.middleware.length;
  var resource = await getResource();
  app.use(ctx => { ctx.body = 'first'; }, index);
})();

// Promise
var index = app.middleware.length;
getResource().then( resource => {
   app.use(ctx => { ctx.body = 'first'; }, index);
} );

app.use(ctx => { ctx.body = 'second' });

function getResource() {
   return new Promise( (resolve,reject) => {
      setTimeout( () => {
         resolve(true);
      }, 500 );
   } );
}

app.listen(3000);
```