### PR TITLE
docs: replace the reference to co on the async function

### DIFF
--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -4,7 +4,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 
   Philosophically, Koa aims to "fix and replace node", whereas Express "augments node".
   Koa uses async functions to rid apps of callback hell and simplify error handling.
-  It exposes its own `this.request` and `this.response` objects instead of node's `req` and `res` objects.
+  It exposes its own `this.req` and `this.res` objects instead of node's `req` and `res` objects.
 
   Express, on the other hand, augments node's `req` and `res` objects with additional properties and methods
   and includes many other "framework" features, such as routing and templating, which Koa does not.

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -4,7 +4,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 
   Philosophically, Koa aims to "fix and replace node", whereas Express "augments node".
   Koa uses async functions to rid apps of callback hell and simplify error handling.
-  It exposes its own `cxt.req` and `ctx.res` objects instead of node's `req` and `res` objects.
+  It exposes its own `cxt.request` and `ctx.response` objects instead of node's `req` and `res` objects.
 
   Express, on the other hand, augments node's `req` and `res` objects with additional properties and methods
   and includes many other "framework" features, such as routing and templating, which Koa does not.

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -3,7 +3,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 # Koa vs Express
 
   Philosophically, Koa aims to "fix and replace node", whereas Express "augments node".
-  Koa uses co to rid apps of callback hell and simplify error handling.
+  Koa uses async functions to rid apps of callback hell and simplify error handling.
   It exposes its own `this.request` and `this.response` objects instead of node's `req` and `res` objects.
 
   Express, on the other hand, augments node's `req` and `res` objects with additional properties and methods
@@ -55,9 +55,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 
 ## How is Koa different than Connect/Express?
 
-### Generated-based control flow
-
-  Thanks to co.
+### Async/await control flow
 
   No callback hell.
 

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -4,7 +4,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 
   Philosophically, Koa aims to "fix and replace node", whereas Express "augments node".
   Koa uses async functions to rid apps of callback hell and simplify error handling.
-  It exposes its own `this.req` and `this.res` objects instead of node's `req` and `res` objects.
+  It exposes its own `cxt.req` and `ctx.res` objects instead of node's `req` and `res` objects.
 
   Express, on the other hand, augments node's `req` and `res` objects with additional properties and methods
   and includes many other "framework" features, such as routing and templating, which Koa does not.

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -55,7 +55,7 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
 
 ## How is Koa different than Connect/Express?
 
-### Async/await control flow
+### Generated-based control flow
 
   No callback hell.
 


### PR DESCRIPTION
Replaced the reference to co on the async function