### PR TITLE
Adding option to use µWebSockets

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -19,7 +19,8 @@ var Cookies = require('cookies');
 var accepts = require('accepts');
 var assert = require('assert');
 var Stream = require('stream');
-var http = require('uws').http;
+var http = require('http');
+var uws = require('uws');
 var only = require('only');
 var co = require('co');
 
@@ -41,7 +42,7 @@ module.exports = Application;
  * @api public
  */
 
-function Application() {
+function Application({ transformer }) {
   if (!(this instanceof Application)) return new Application;
   this.env = process.env.NODE_ENV || 'development';
   this.subdomainOffset = 2;
@@ -50,6 +51,14 @@ function Application() {
   this.context = Object.create(context);
   this.request = Object.create(request);
   this.response = Object.create(response);
+  switch (transformer) {
+  default:
+    this.transformer = http;
+    break;
+  case 'uws':
+    this.transformer = uws.http;
+    break;
+  }
 }
 
 /**
@@ -70,7 +79,7 @@ Object.setPrototypeOf(Application.prototype, Emitter.prototype);
 
 app.listen = function(){
   debug('listen');
-  var server = http.createServer(this.callback());
+  var server = this.transformer.createServer(this.callback());
   return server.listen.apply(server, arguments);
 };
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -19,7 +19,7 @@ var Cookies = require('cookies');
 var accepts = require('accepts');
 var assert = require('assert');
 var Stream = require('stream');
-var http = require('http');
+var http = require('uws').http;
 var only = require('only');
 var co = require('co');
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -42,7 +42,7 @@ module.exports = Application;
  * @api public
  */
 
-function Application({ transformer }) {
+function Application(transformer) {
   if (!(this instanceof Application)) return new Application;
   this.env = process.env.NODE_ENV || 'development';
   this.subdomainOffset = 2;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "parseurl": "^1.3.0",
     "statuses": "^1.2.0",
     "type-is": "^1.5.5",
+    "uws": "^0.12.0",
     "vary": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Creating an option to inform that you want to use koajs using µWebSockets http wrapper, instead of node default http module.