### PR TITLE
Fix malformed content-type header causing exception on charset get

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -319,7 +319,13 @@ module.exports = {
     var type = this.get('Content-Type');
     if (!type) return '';
 
-    return contentType.parse(type).parameters.charset || '';
+    try {
+      type = contentType.parse(type);
+    } catch (e) {
+      return '';
+    }
+
+    return type.parameters.charset || '';
   },
 
   /**

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -26,5 +26,11 @@ describe('req.charset', function(){
       req.header['content-type'] = 'text/plain; charset=utf-8';
       req.charset.should.equal('utf-8');
     })
+
+    it('should return "" if content-type is invalid', function(){
+      var req = request();
+      req.header['content-type'] = 'application/json; application/text; charset=utf-8';
+      req.charset.should.equal('');
+    })
   })
 })


### PR DESCRIPTION
A malformed content-type header may cause an exception when the charset getter is triggered. This is unexpected as the returning value should always be a string. This can be exploited by bad actors.