### PR TITLE
Fix malformed content-type header causing exception on charset get (v2.x)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -315,10 +315,16 @@ module.exports = {
    */
 
   get charset() {
-    const type = this.get('Content-Type');
+    let type = this.get('Content-Type');
     if (!type) return '';
 
-    return contentType.parse(type).parameters.charset || '';
+    try {
+      type = contentType.parse(type);
+    } catch (e) {
+      return '';
+    }
+
+    return type.parameters.charset || '';
   },
 
   /**

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -26,5 +26,11 @@ describe('req.charset', () => {
       req.header['content-type'] = 'text/plain; charset=utf-8';
       req.charset.should.equal('utf-8');
     });
+
+    it('should return "" if content-type is invalid', () => {
+      const req = request();
+      req.header['content-type'] = 'application/json; application/text; charset=utf-8';
+      req.charset.should.equal('');
+    });
   });
 });


### PR DESCRIPTION
Ported https://github.com/koajs/koa/pull/897 to `v2.x` branch as [requested](https://github.com/koajs/koa/pull/897#issuecomment-279155482).