### PR TITLE
remove unused app.name

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -110,7 +110,6 @@ app.listen(3000);
   Application settings are properties on the `app` instance, currently
   the following are supported:
 
-  - `app.name` optionally give your application a name
   - `app.env` defaulting to the __NODE_ENV__ or "development"
   - `app.proxy` when true proxy header fields will be trusted
   - `app.subdomainOffset` offset of `.subdomains` to ignore [2]


### PR DESCRIPTION
`app.name` is mentioned in the documentation, but doesn't seem to have any semantic meaning.

Application instances are not frozen and as far as I can tell there's no reason to force people to use `name` specifically (people may want to use `id` / `machineId`, etc., or even better, don't rely on koa app's namespace to pass this information)