### PR TITLE
Upgrade mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "istanbul": "^0.4.0",
-    "mocha": "^2.0.1",
+    "mocha": "^3.2.0",
     "should": "^6.0.3",
     "should-http": "0.0.3",
     "supertest": "^1.0.1",


### PR DESCRIPTION
upgrade mocha to eliminate these warnings:

```
npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```