### PR TITLE
Removed deprecated ordering of throw arguments

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -73,10 +73,8 @@ var proto = module.exports = {
    * errors, and the message may be exposed to the client.
    *
    *    this.throw(403)
-   *    this.throw('name required', 400)
    *    this.throw(400, 'name required')
    *    this.throw('something exploded')
-   *    this.throw(new Error('invalid'), 400);
    *    this.throw(400, new Error('invalid'));
    *
    * See: https://github.com/jshttp/http-errors


### PR DESCRIPTION
Let's go the safe path since the ones i removed are now deprecated from `http-errors`.