### PR TITLE
Fix async/await babel recommendation

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,7 +31,7 @@ For example, in your `.babelrc` file, you should have:
 }
 ```
 
-You can also use the [stage-3 preset](http://babeljs.io/docs/plugins/preset-stage-3/) instead.
+You can also use the [env preset](http://babeljs.io/docs/plugins/preset-env/) with a target option `"node": "current"` instead.
 
 # Application
 


### PR DESCRIPTION
async/await is not stage-3 feature anymore, it got included to ES2017.

Better advice is to recommend babel `preset-env`. It will enable only the missing features based on the node version in use.