### PR TITLE
Add Troubleshooting documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,7 +140,7 @@ Check out an example in koa's [test](test/babel/index.js).
 
 ## Troubleshooting
 
-Check the [Troubleshooting Guide](docs/troubleshooting.md) or [Debugging Koa](docs/guide.md##debugging-koa) in 
+Check the [Troubleshooting Guide](docs/troubleshooting.md) or [Debugging Koa](docs/guide.md#debugging-koa) in 
 the general Koa guide.
 
 ## Running tests

--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,11 @@ require('babel-register')({
 
 Check out an example in koa's [test](test/babel/index.js).
 
+## Troubleshooting
+
+Check the [Troubleshooting Guide](docs/troubleshooting.md) or [Debugging Koa](docs/guide.md##debugging-koa) in 
+the general Koa guide.
+
 ## Running tests
 
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,10 +1,10 @@
-# Troubleshooting
+# Troubleshooting Koa
 
 - [Whenever I try to access my route, it sends back a 404](#whenever-i-try-to-access-my-route-it-sends-back-a-404)
 - [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect)
 - [My middleware is not called](#my-middleware-is-not-called)
 
-See also [debugging Koa](guide.md##debugging-koa).
+See also [debugging Koa](guide.md#debugging-koa).
 
 If you encounter a problem and later learn how to fix it, and think others might also encounter that problem, please 
 consider contributing to this documentation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,15 +11,18 @@ consider contributing to this documentation.
 
 This is a common but troublesome problem when working with Koa middleware. First, it is critical to understand when Koa generates a 404. Koa does not care which or how much middleware was run, in many cases a 200 and 404 trigger the same number of middleware. Instead, the default status for any response is 404. The most obvious way this is changed is through `ctx.status`. However, if `ctx.body` is set when the status has not been explicitly defined (through `ctx.status`), the status is set to 200. This explains why simply setting the body results in a 200. Once the middleware is done (when the middleware and any returned promises are complete), Koa sends out the response. After that, nothing can alter the response. If it was a 404 at the time, it will be a 404 at the end, even if `ctx.status` or `ctx.body` are set afterwords.
 
-Even though we now understand the basis of a 404, it might not be as clear why a 404 is generated in a specific case. This can be especially troublesome when it seems that `ctx.status` or `ctx.body` are set. Here are some common examples with solutions:
+Even though we now understand the basis of a 404, it might not be as clear why a 404 is generated in a specific case. This can be especially troublesome when it seems that `ctx.status` or `ctx.body` are set. 
+
+The unexpected 404 is a specific symptom of one of these more general problems:
 
 - [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect)
 - [My middleware is not called](#my-middleware-is-not-called)
 
 ## My response or context changes have no effect
 
-This can be caused by a Late `ctx.body` or `ctx.status` setter.
-This is by far the most common cause of these problems.
+This can be caused when the response is sent before the code making the change is
+executed.  If the change is to the `ctx.body` or `ctx.status` setter, this can cause a 404 and
+is by far the most common cause of these problems.
 
 ### Problematic code
 
@@ -33,7 +36,7 @@ router.get('/fetch', function (ctx, next) {
 
 When used, this route will always send back a 404, even though `ctx.body` is set.
 
-The same issue would occur in this `async` version:
+The same behavior would occur in this `async` version:
 
 ```js
 router.get('/fetch', async (ctx, next) => {
@@ -73,7 +76,7 @@ Middleware done
 Body set
 ```
 
-It means that the body is being set after the middleware is done, and after the response has been sent. If you see only one or none of these logs, proceed to [middleware flow interrupted](#middleware-flow-interrupted). If they are in the right order, make sure you haven't explicitly set the status to 404, make sure that it actually is a 404, and if that fails feel free to ask for help.
+It means that the body is being set after the middleware is done, and after the response has been sent. If you see only one or none of these logs, proceed to [My middleware is not called](#my-middleware-is-not-called). If they are in the right order, make sure you haven't explicitly set the status to 404, make sure that it actually is a 404, and if that fails feel free to ask for help.
 
 ### Solution
 
@@ -87,7 +90,7 @@ router.get('/fetch', function (ctx, next) {
 
 Returning the promise given by the database interface tells Koa to wait for the promise to finish before responding. At that time, the body will have been set. This results in Koa sending back a 200 with a proper response.
 
-The fix in the `async` version is to add an await statement:
+The fix in the `async` version is to add an `await` statement:
 
 ```js
 router.get('/fetch', async (ctx, next) => {
@@ -99,8 +102,10 @@ router.get('/fetch', async (ctx, next) => {
 
 ## My middleware is not called
 
-This can be due to an interrupted chain of middleware calls.  Even though this is less common than a 
-late `ctx.body` or `ctx.status` setter, it can be a much bigger pain to troubleshoot.
+This can be due to an interrupted chain of middleware calls.  This can cause a 404 if the
+middleware that is skipped is responsible for the `ctx.body` or `ctx.status` setter.
+This is less common than [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect),
+but it can be a much bigger pain to troubleshoot.
 
 ### Problematic code
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@
 - [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect)
 - [My middleware is not called](#my-middleware-is-not-called)
 
+See also [debugging Koa](guide.md##debugging-koa).
+
 If you encounter a problem and later learn how to fix it, and think others might also encounter that problem, please 
 consider contributing to this documentation.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,136 @@
+# Table of Contents
+
+- [Whenever I try to access my route, it sends back a 404](#Whenever-I-try-to-access-my-route-it-sends-back-a-404)
+- More to come :). If you encounter a common problem, feel free to add it here!
+
+# Whenever I try to access my route, it sends back a 404
+
+This is a common but troublesome problem when working with Koa middleware. First, it is critical to understand when Koa generates a 404. Koa does not care which or how much middleware was run, in many cases a 200 and 404 trigger the same number of middleware. Instead, the default status for any response is 404. The most obvious way this is changed is through `ctx.status`. However, if `ctx.body` is set when the status has not been explicitly defined (through `ctx.status`), the status is set to 200. This explains why simply setting the body results in a 200. Once the middleware is done (when the middleware and any returned promises are complete), Koa sends out the response. After that, nothing can alter the response. If it was a 404 at the time, it will be a 404 at the end, even if `ctx.status` or `ctx.body` are set afterwords.
+
+Even though we now understand the basis of a 404, it might not be as clear why a 404 is generated in a specific case. This can be especially troublesome when it seems that `ctx.status` or `ctx.body` are set. Here are some common examples with solutions:
+
+## Late `ctx.body` or `ctx.status` setter
+
+This is by far the most common cause of these problems.
+
+### Problematic code
+
+```js
+router.get('/fetch', function (ctx, next) {
+  models.Book.findById(parseInt(ctx.query.id)).then(function (book) {
+    ctx.body = book;
+  });
+});
+```
+
+When used, this route will always send back a 404, even though `ctx.body` is set.
+
+### Cause
+
+`ctx.body` is not set until *after* the response has been sent. The code doesn't tell Koa to wait for the database to return the record. Koa sends the response after the middleware has been run, but not after the callback inside the middleware has been run. In the gap there, `ctx.body` has not yet been set, so Koa responds with a 404.
+
+### Identifying this as the issue
+
+Adding another piece of middleware and some logging can be extremely helpful in identifying this issue.
+
+```js
+router.use('/fetch', function (ctx, next) {
+  return next().then(function () {
+    console.log('Middleware done'); 
+  }); 
+});
+
+router.get('/fetch', function (ctx, next) {
+  models.Book.findById(parseInt(ctx.query.id)).then(function (book) {
+    ctx.body = book;
+    console.log('Body set');
+  });
+});
+```
+
+If you see this in the logs:
+
+```
+Middleware done 
+Body set
+```
+
+It means that the body is being set after the middleware is done, and after the response has been sent. If you see only one or none of these logs, proceed to [middleware flow interrupted](#middleware-flow-interrupted). If they are in the right order, make sure you haven't explicitly set the status to 404, make sure that it actually is a 404, and if that fails feel free to ask for help.
+
+### Solution
+
+```js
+router.get('/fetch', function (ctx, next) {
+  return models.Book.findById(parseInt(ctx.query.id)).then(function (book) {
+    ctx.body = book;
+  });
+});
+```
+
+Returning the promise given by the database interface tells Koa to wait for the promise to finish before responding. At that time, the body will have been set. This results in Koa sending back a 200 with a proper response.
+
+## Middleware flow interrupted
+
+Even though this is less common than a late `ctx.body` or `ctx.status` setter, it can be a much bigger pain to troubleshoot.
+
+### Problematic code
+
+```js
+router.use(function (ctx, next) {
+  // Don't Repeat Yourself! Let's parse the ID here for all our middleware
+  if (ctx.query.id) {
+    ctx.state.id = parseInt(ctx.query.id);
+  }
+});
+
+router.get('/fetch', function (ctx, next) {
+  return models.Book.findById(ctx.state.id).then(function (book) {
+    ctx.body = book;
+  });
+});
+```
+
+### Cause
+
+In the code above, the book is never fetched from the database, and in fact our route was never called. Look closely at our helper middleware. We forgot to `return next()`! This causes the middleware flow to never reach our route, ending our "helper" middleware.
+
+### Identifying this as the issue
+
+Identifying this problem is easier than most, add a log at the beginning of the route. If it doesn't trigger, your route was never reached in the middleware chain.
+
+```js
+router.use(function (ctx, next) {
+  // Don't Repeat Yourself! Let's parse the ID here for all our middleware
+  if (ctx.query.id) {
+    ctx.state.id = parseInt(ctx.query.id);
+  }
+});
+
+router.get('/fetch', function (ctx, next) {
+  console.log('Route called'); // Never happens
+  return models.Book.findById(ctx.state.id).then(function (book) {
+    ctx.body = book;
+  });
+});
+```
+
+To find the middleware causing the problem, try adding logging at various points in the middleware chain.
+
+### Solution
+
+The solution for this is rather easy, simply add `return next()` to the end of your helper middleware.
+
+```js
+router.use(function (ctx, next) {
+  if (ctx.query.id) {
+    ctx.state.id = parseInt(ctx.query.id);
+  }
+  return next();
+});
+
+router.get('/fetch', function (ctx, next) {
+  return models.Book.findById(ctx.state.id).then(function (book) {
+    ctx.body = book;
+  });
+});
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,19 +1,22 @@
-# Table of Contents
+# Troubleshooting
 
 - [Whenever I try to access my route, it sends back a 404](#Whenever-I-try-to-access-my-route-it-sends-back-a-404)
-- More to come :). If you encounter a common problem, feel free to add it here!
+- [My middleware is not called](#My-middleware-is-not-called)
 
-# Whenever I try to access my route, it sends back a 404
+If you encounter a problem and later learn how to fix it, and think others might also encounter that problem, please 
+consider contributing to this documentation.
+
+## Whenever I try to access my route, it sends back a 404
 
 This is a common but troublesome problem when working with Koa middleware. First, it is critical to understand when Koa generates a 404. Koa does not care which or how much middleware was run, in many cases a 200 and 404 trigger the same number of middleware. Instead, the default status for any response is 404. The most obvious way this is changed is through `ctx.status`. However, if `ctx.body` is set when the status has not been explicitly defined (through `ctx.status`), the status is set to 200. This explains why simply setting the body results in a 200. Once the middleware is done (when the middleware and any returned promises are complete), Koa sends out the response. After that, nothing can alter the response. If it was a 404 at the time, it will be a 404 at the end, even if `ctx.status` or `ctx.body` are set afterwords.
 
 Even though we now understand the basis of a 404, it might not be as clear why a 404 is generated in a specific case. This can be especially troublesome when it seems that `ctx.status` or `ctx.body` are set. Here are some common examples with solutions:
 
-## Late `ctx.body` or `ctx.status` setter
+### Late `ctx.body` or `ctx.status` setter
 
 This is by far the most common cause of these problems.
 
-### Problematic code
+#### Problematic code
 
 ```js
 router.get('/fetch', function (ctx, next) {
@@ -25,11 +28,11 @@ router.get('/fetch', function (ctx, next) {
 
 When used, this route will always send back a 404, even though `ctx.body` is set.
 
-### Cause
+#### Cause
 
 `ctx.body` is not set until *after* the response has been sent. The code doesn't tell Koa to wait for the database to return the record. Koa sends the response after the middleware has been run, but not after the callback inside the middleware has been run. In the gap there, `ctx.body` has not yet been set, so Koa responds with a 404.
 
-### Identifying this as the issue
+#### Identifying this as the issue
 
 Adding another piece of middleware and some logging can be extremely helpful in identifying this issue.
 
@@ -57,7 +60,7 @@ Body set
 
 It means that the body is being set after the middleware is done, and after the response has been sent. If you see only one or none of these logs, proceed to [middleware flow interrupted](#middleware-flow-interrupted). If they are in the right order, make sure you haven't explicitly set the status to 404, make sure that it actually is a 404, and if that fails feel free to ask for help.
 
-### Solution
+#### Solution
 
 ```js
 router.get('/fetch', function (ctx, next) {
@@ -69,11 +72,12 @@ router.get('/fetch', function (ctx, next) {
 
 Returning the promise given by the database interface tells Koa to wait for the promise to finish before responding. At that time, the body will have been set. This results in Koa sending back a 200 with a proper response.
 
-## Middleware flow interrupted
+### My middleware is not called
 
-Even though this is less common than a late `ctx.body` or `ctx.status` setter, it can be a much bigger pain to troubleshoot.
+This can be due to an interrupted chain of middleware calls.  Even though this is less common than a 
+late `ctx.body` or `ctx.status` setter, it can be a much bigger pain to troubleshoot.
 
-### Problematic code
+#### Problematic code
 
 ```js
 router.use(function (ctx, next) {
@@ -90,11 +94,11 @@ router.get('/fetch', function (ctx, next) {
 });
 ```
 
-### Cause
+#### Cause
 
 In the code above, the book is never fetched from the database, and in fact our route was never called. Look closely at our helper middleware. We forgot to `return next()`! This causes the middleware flow to never reach our route, ending our "helper" middleware.
 
-### Identifying this as the issue
+#### Identifying this as the issue
 
 Identifying this problem is easier than most, add a log at the beginning of the route. If it doesn't trigger, your route was never reached in the middleware chain.
 
@@ -116,7 +120,7 @@ router.get('/fetch', function (ctx, next) {
 
 To find the middleware causing the problem, try adding logging at various points in the middleware chain.
 
-### Solution
+#### Solution
 
 The solution for this is rather easy, simply add `return next()` to the end of your helper middleware.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-- [Whenever I try to access my route, it sends back a 404](#Whenever-I-try-to-access-my-route-it-sends-back-a-404)
-- [My response or context changes have no effect](#My-response-or-context-changes-have-no-effect)
-- [My middleware is not called](#My-middleware-is-not-called)
+- [Whenever I try to access my route, it sends back a 404](#whenever-i-try-to-access-my-route-it-sends-back-a-404)
+- [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect)
+- [My middleware is not called](#my-middleware-is-not-called)
 
 If you encounter a problem and later learn how to fix it, and think others might also encounter that problem, please 
 consider contributing to this documentation.
@@ -13,8 +13,8 @@ This is a common but troublesome problem when working with Koa middleware. First
 
 Even though we now understand the basis of a 404, it might not be as clear why a 404 is generated in a specific case. This can be especially troublesome when it seems that `ctx.status` or `ctx.body` are set. Here are some common examples with solutions:
 
-- [My response or context changes have no effect](#My-response-or-context-changes-have-no-effect)
-- [My middleware is not called](#My-middleware-is-not-called)
+- [My response or context changes have no effect](#my-response-or-context-changes-have-no-effect)
+- [My middleware is not called](#my-middleware-is-not-called)
 
 ## My response or context changes have no effect
 


### PR DESCRIPTION
This pulls the really fantastic [Common Problems](https://github.com/koajs/koa/wiki/Common-Problems) wiki page into the main documentation as a troubleshooting guide to give it greater exposure.  I also linked to it from the main read me for the same reason.

I generalized the headings for the two 404 causes after surveying closed tickets to give more surface area in the document for problem diagnosis.

I added an example of a missing `await`, also based on survey of closed tickets.
