### PR TITLE
Better expose documentation in overview readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,41 @@ app.use(convert(function *(next) {
 }));
 ```
 
+## Context, Request and Response
+
+Each middleware receives a Koa Context object that encapsulates node's request and response objects
+and provides many helpful methods for writing web applications and APIs.
+
+Koa provides a Request object as the `request` property of the Context.  Koa's Request object
+provides a clean abstraction that delegates to, rather than extends node's request object.  This
+helps provide a cleaner interface and reduces conflicts between middleware and with node
+as well as providing better stream handling.  For more
+information, see the [Request API Reference](docs/api/request.md)
+
+Koa provides a Response object as the `response` property of the Context.  Koa's Response object
+follows the same abstraction and delegation pattern as the Request object.  For more information,
+see the [Response API Reference](docs/api/response.md)
+
+For more information on the Context object, see the [Context API Reference](docs/api/context.md).
+
+## Koa Application
+
+The object created when executing `new Koa()` is known as the Koa application object.
+
+The application object is Koa's interface with node's http server and handles the registration
+of middleware, dispatching to the middleware from http, default error handling, as well as
+configuration of the context, request and response objects.
+
+Learn more about the application object in the [Application API Reference](docs/api/index.md).
+
+## Documentation
+
+ - [Usage Guide](docs/guide.md)
+ - [Error Handling](docs/error-handling.md)
+ - [Koa for Express Users](docs/koa-vs-express.md)
+ - [FAQ](docs/faq.md)
+ - [API documentation](docs/api/index.md)
+
 ## Babel setup
 
 For Node 4.0+ and Babel 6.0 you can setup like this:
@@ -150,7 +185,6 @@ See [AUTHORS](AUTHORS).
 
 ## Community
 
- - [API](docs/api/index.md) documentation
  - [Badgeboard](https://koajs.github.io/badgeboard) and list of official modules
  - [Examples](https://github.com/koajs/examples)
  - [Middleware](https://github.com/koajs/koa/wiki) list
@@ -158,8 +192,6 @@ See [AUTHORS](AUTHORS).
  - [G+ Community](https://plus.google.com/communities/101845768320796750641)
  - [Reddit Community](https://www.reddit.com/r/koajs)
  - [Mailing list](https://groups.google.com/forum/#!forum/koajs)
- - [Guide](docs/guide.md)
- - [FAQ](docs/faq.md)
  - [中文文档](https://github.com/guo-yu/koa-guide)
  - __[#koajs]__ on freenode
 

--- a/Readme.md
+++ b/Readme.md
@@ -123,20 +123,55 @@ app.use(convert(function *(next) {
 
 ## Context, Request and Response
 
-Each middleware receives a Koa Context object that encapsulates node's request and response objects
-and provides many helpful methods for writing web applications and APIs.
+Each middleware receives a Koa `Context` object that encapsulates an incoming 
+http message and the corresponding response to that message.  `ctx` is often used
+as the parameter name for the context object.
 
-Koa provides a Request object as the `request` property of the Context.  Koa's Request object
-provides a clean abstraction that delegates to, rather than extends node's request object.  This
-helps provide a cleaner interface and reduces conflicts between middleware and with node
-as well as providing better stream handling.  For more
-information, see the [Request API Reference](docs/api/request.md)
+```js
+app.use(async (ctx, next) => { await next(); });
+```
 
-Koa provides a Response object as the `response` property of the Context.  Koa's Response object
-follows the same abstraction and delegation pattern as the Request object.  For more information,
-see the [Response API Reference](docs/api/response.md)
+Koa provides a `Request` object as the `request` property of the `Context`.  
+Koa's `Request` object provides helpful methods for working with
+http requests which delegate to an [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+from the node `http` module.
 
-For more information on the Context object, see the [Context API Reference](docs/api/context.md).
+Here is an example of checking that a requesting client supports xml.
+
+```js
+app.use(async (ctx, next) => {
+  if (!ctx.request.accepts('xml')) ctx.throw(406);
+  await next();
+});
+```
+
+Koa provides a `Response` object as the `response` property of the `Context`.  
+Koa's `Response` object provides helpful methods for working with
+http responses which delegate to a [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
+.  
+
+Koa's pattern of delegating to Node's request and response objects rather than extending them
+provides a cleaner interface and reduces conflicts between different middleware and with Node
+itself as well as providing better support for stream handling.  The `IncomingMessage` can still be
+directly accessed as the `req` property on the `Context` and `ServerResponse` can be directly 
+accessed as the `res` property on the `Context`.
+
+Here is an example using Koa's `Response` object to stream a file as the response body.
+
+```js
+app.use(async (ctx, next) => {
+  await next();
+  ctx.response.type = 'xml';
+  ctx.response.body = fs.createReadStream('really_large.xml');
+});
+```
+
+The `Context` object also provides shortcuts for methods on its `request` and `response`.  In the prior
+examples,  `ctx.type` can be used instead of `ctx.request.type` and `ctx.accepts` can be used 
+instead of `ctx.request.accepts`.
+
+For more information on `Request`, `Response` and `Context`, see the [Request API Reference](docs/api/request.md), 
+[Response API Reference](docs/api/response.md) and [Context API Reference](docs/api/context.md).
 
 ## Koa Application
 


### PR DESCRIPTION
Highlighting the existing documentation from the overview readme.

When I started evaluating 2.x this weekend, It took quite a while before I stumbled on the api docs, which I found helpful.  Hopefully, this will help improve visibility.