### PR TITLE
Don't use http.ServerResponse._header when accessors exist

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -121,8 +121,14 @@ const proto = module.exports = {
       return;
     }
 
-    // unset all headers, and set those specified
-    this.res._headers = {};
+    // first unset all headers
+    if (this.res.getHeaderNames) {
+      this.res.getHeaderNames().forEach(name => this.res.removeHeader(name));
+    } else {
+      this.res._headers = {}; // Node < 7.7
+    }
+
+    // then set those specified
     this.set(err.headers);
 
     // force text/plain

--- a/lib/response.js
+++ b/lib/response.js
@@ -44,7 +44,9 @@ module.exports = {
    */
 
   get header() {
-    return this.res._headers || {};
+    return this.res.getHeaders
+      ? this.res.getHeaders()
+      : this.res._headers || {};  // Node < 7.7
   },
 
   /**

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -1,8 +1,10 @@
 
 'use strict';
 
+const assert = require('assert');
 const request = require('supertest');
 const Koa = require('../..');
+const context = require('../helpers/context');
 
 describe('ctx.onerror(err)', () => {
   it('should respond', done => {
@@ -169,5 +171,23 @@ describe('ctx.onerror(err)', () => {
         .expect('Content-Type', 'text/plain; charset=utf-8')
         .expect('Internal Server Error', done);
     });
+
+    it('should use res.getHeaderNames() accessor when available', () => {
+      let removed = 0;
+      const ctx = context();
+
+      ctx.app.emit = () => {};
+      ctx.res = {
+        getHeaderNames: () => ['content-type', 'content-length'],
+        removeHeader: () => removed++,
+        end: () => {},
+        emit: () => {}
+      };
+
+      ctx.onerror(new Error('error'));
+
+      assert.equal(removed, 2);
+    });
   });
 });
+

--- a/test/response/header.js
+++ b/test/response/header.js
@@ -19,6 +19,23 @@ describe('res.header', () => {
     res.header.should.eql({ 'x-foo': 'baz' });
   });
 
+  it('should return the response header object when no mocks are in use', done => {
+    const app = new Koa();
+    let header;
+
+    app.use(ctx => {
+      ctx.set('x-foo', '42');
+      header = Object.assign({}, ctx.response.header);
+    });
+
+    request(app.listen())
+      .get('/')
+      .end(() => {
+        header.should.eql({ 'x-foo': '42' });
+        done();
+      });
+  });
+
   describe('when res._headers not present', () => {
     it('should return empty object', () => {
       const res = response();

--- a/test/response/header.js
+++ b/test/response/header.js
@@ -1,13 +1,22 @@
 
 'use strict';
 
+const request = require('supertest');
 const response = require('../helpers/context').response;
+const Koa = require('../..');
 
 describe('res.header', () => {
   it('should return the response header object', () => {
     const res = response();
     res.set('X-Foo', 'bar');
     res.header.should.eql({ 'x-foo': 'bar' });
+  });
+
+  it('should use res.getHeaders() accessor when available', () => {
+    const res = response();
+    res.res._headers = null;
+    res.res.getHeaders = () => ({ 'x-foo': 'baz' });
+    res.header.should.eql({ 'x-foo': 'baz' });
   });
 
   describe('when res._headers not present', () => {


### PR DESCRIPTION
Node HTTP module response._headers is considered internal to node itself. Its value will
change in a backwards incompatible way in the future node releases.

Use the documented accessor functions instead when they are available.

This is an ES6 version of the commit that went to 1.x branch: https://github.com/koajs/koa/commit/91c403a541ba91e3ba10afdfa8b28adeae74fbbe

Should close https://github.com/koajs/koa/issues/903