### PR TITLE
Cache node_modules with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
 cache:
   directories:
     - wrk/bin
+    - node_modules
 before_script:
+  - npm prune
   - "[ ! -f wrk/bin/wrk ] && rm -rf wrk && git clone https://github.com/wg/wrk.git && make -C wrk && mkdir wrk/bin && mv wrk/wrk wrk/bin || true"
   - export PATH=$PATH:$PWD/wrk/bin/
 script:


### PR DESCRIPTION
Also prunes modules, so we shouldn't worry about situations where a module not listed in `package.json` is required.