### PR TITLE
Remove deprecated babel/arrow-parens

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,9 +8,7 @@ plugins: [
 ]
 
 rules:
-  arrow-parens: 0
-  babel/arrow-parens: [2, "as-needed"]
-
+  arrow-parens: [2, as-needed]
   eqeqeq: 0
   no-return-assign: 0 # fails for arrow functions
   no-var: 2


### PR DESCRIPTION
The babel/arrow-parens rule is deprecated. Please use the built in arrow-parens rule instead.
From [log message](https://travis-ci.org/koajs/koa/jobs/215667166#L169)