### PR TITLE
application: removed koa-convert (v3)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,9 +81,8 @@ app.use((ctx, next) => {
 
 ### Koa v1.x Middleware Signature
 
-The middleware signature changed between v1.x and v2.x.  The older signature is deprecated.
-
-**Old signature middleware support will be removed in v3**
+The middleware signature changed between v1.x and v2.x.
+The older signature was deprecated in v2, and removed in v3.
 
 Please see the [Migration Guide](docs/migration.md) for more information on upgrading from v1.x and
 using v1.x middleware with v2.x.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,7 +4,7 @@
 
 Koa v2 introduces a new signature for middleware.
 
-**Old signature middleware (v1.x) support will be removed in v3**
+**Old signature middleware (v1.x) support was removed in v3**
 
 The new middleware signature is:
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -19,8 +19,6 @@ const util = require('util');
 const Stream = require('stream');
 const http = require('http');
 const only = require('only');
-const convert = require('koa-convert');
-const deprecate = require('depd')('koa');
 
 /**
  * Expose `Application` class.
@@ -104,12 +102,7 @@ module.exports = class Application extends Emitter {
 
   use(fn) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
-    if (isGeneratorFunction(fn)) {
-      deprecate('Support for generators will be removed in v3. ' +
-                'See the documentation for examples of how to convert old middleware ' +
-                'https://github.com/koajs/koa/blob/master/docs/migration.md');
-      fn = convert(fn);
-    }
+    if (isGeneratorFunction(fn)) throw new TypeError('old signature is not supported.');
     debug('use %s', fn._name || fn.name || '-');
     this.middleware.push(fn);
     return this;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "http-errors": "^1.6.3",
     "is-generator-function": "^1.0.7",
     "koa-compose": "^4.1.0",
-    "koa-convert": "^1.2.0",
     "koa-is-json": "^1.0.0",
     "on-finished": "^2.3.0",
     "only": "~0.0.2",

--- a/test/application/use.js
+++ b/test/application/use.js
@@ -40,40 +40,6 @@ describe('app.use(fn)', () => {
     assert.deepEqual(calls, [1, 2, 3, 4, 5, 6]);
   });
 
-  it('should compose mixed middleware', async () => {
-    process.once('deprecation', () => {}); // silence deprecation message
-    const app = new Koa();
-    const calls = [];
-
-    app.use((ctx, next) => {
-      calls.push(1);
-      return next().then(() => {
-        calls.push(6);
-      });
-    });
-
-    app.use(function * (next){
-      calls.push(2);
-      yield next;
-      calls.push(5);
-    });
-
-    app.use((ctx, next) => {
-      calls.push(3);
-      return next().then(() => {
-        calls.push(4);
-      });
-    });
-
-    const server = app.listen();
-
-    await request(server)
-      .get('/')
-      .expect(404);
-
-    assert.deepEqual(calls, [1, 2, 3, 4, 5, 6]);
-  });
-
   // https://github.com/koajs/koa/pull/530#issuecomment-148138051
   it('should catch thrown errors in non-async functions', () => {
     const app = new Koa();
@@ -85,19 +51,6 @@ describe('app.use(fn)', () => {
       .expect(404);
   });
 
-  it('should accept both generator and function middleware', () => {
-    process.once('deprecation', () => {}); // silence deprecation message
-    const app = new Koa();
-
-    app.use((ctx, next) => next());
-    app.use(function * (next){ this.body = 'generator'; });
-
-    return request(app.callback())
-      .get('/')
-      .expect(200)
-      .expect('generator');
-  });
-
   it('should throw error for non function', () => {
     const app = new Koa();
 
@@ -106,13 +59,8 @@ describe('app.use(fn)', () => {
     });
   });
 
-  it('should output deprecation message for generator functions', done => {
-    process.once('deprecation', message => {
-      assert(/Support for generators will be removed/.test(message));
-      done();
-    });
-
+  it('should throw error for legacy signature middleware', () => {
     const app = new Koa();
-    app.use(function * (){});
+    assert.throws(() => app.use(function * (){}), /old signature is not supported/);
   });
 });


### PR DESCRIPTION
~~Added a separate commit for added test and keeping the check with a throw instead.
If d89e72f is an excessive guard, I'll just revert/squash it pre-merge.~~