### PR TITLE
allow bypassing compose by exposing fn (minor)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -39,6 +39,7 @@ module.exports = class Application extends Emitter {
   constructor() {
     super();
 
+    this.fn = undefined;
     this.proxy = false;
     this.middleware = [];
     this.subdomainOffset = 2;
@@ -123,7 +124,8 @@ module.exports = class Application extends Emitter {
    */
 
   callback() {
-    const fn = compose(this.middleware);
+    // Optional koa-compose bypass
+    const fn = this.fn || compose(this.middleware);
 
     if (!this.listeners('error').length) this.on('error', this.onerror);
 

--- a/test/application/fn.js
+++ b/test/application/fn.js
@@ -1,0 +1,34 @@
+
+'use strict';
+
+const request = require('supertest');
+const assert = require('assert');
+const Koa = require('../..');
+
+describe('app.fn = fn', () => {
+  it('should not middleware', async () => {
+    const app = new Koa();
+    const calls = [];
+
+    const mw1 = async ctx => calls.push('the');
+    const mw2 = async ctx => calls.push('future');
+    const mw3 = async ctx => calls.push('does');
+    const mw4 = async ctx => calls.push('not');
+    const mw5 = async ctx => calls.push('need');
+    const mw6 = async ctx => calls.push('compose');
+
+    app.fn = async ctx => {
+      await mw1(ctx);
+      await Promise.all([mw2(ctx), mw3(ctx), mw4(ctx), mw5(ctx)]);
+      await mw6(ctx);
+    };
+
+    const server = app.listen();
+
+    await request(server)
+      .get('/')
+      .expect(404);
+
+    assert(['the', 'future', 'does', 'not', 'need', 'compose'].map(k => calls.includes(k)));
+  });
+});


### PR DESCRIPTION
Am I the only one getting the feeling that koa-compose is unnecessary at this point?

For now expose `Application.fn`, but in a distant future perhaps remove koa-compose altogether?
By removing koa-compose Koa would:
  * Almost get its original signature back (`async ctx => {}`), `next()` would be obsolete.
  * Save a few closures
  * Simplify stack trace
  * Keep backwards compatibility (developers can compose themselves until ecosystem is up to par)
  * New USP: "parallel middleware" :)

Koa#next example:
```js
const compose = require('koa-compose') // batteries not included

// (ctx, next) signature mw
const legacyMw = compose([
  legacyMw1,
  legacyMw2
])

app.fn = ctx => {
  await mw1(ctx)
  await legacyMw(ctx)
  await Promise.all([
    mw2(ctx), // maybe redis session?
    mw3(ctx) // maybe microservice logger?
  ])
}
```

Obviously this can all be done today. Though that just raises the question again - is koa-compose really necessary? Maybe this time around a signature update is just too much though :)