### PR TITLE
improve consistency in api code examples

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -12,7 +12,7 @@
   snippet:
 
 ```js
-app.use(async (ctx, next) => {
+app.use(async ctx => {
   ctx; // is the Context
   ctx.request; // is a koa Request
   ctx.response; // is a koa Response

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -52,7 +52,7 @@ You can also use the [env preset](http://babeljs.io/docs/plugins/preset-env/) wi
 const Koa = require('koa');
 const app = new Koa();
 
-app.use(ctx => {
+app.use(async ctx => {
   ctx.body = 'Hello World';
 });
 
@@ -80,7 +80,7 @@ const app = new Koa();
 
 // x-response-time
 
-app.use(async function (ctx, next) {
+app.use(async (ctx, next) => {
   const start = Date.now();
   await next();
   const ms = Date.now() - start;
@@ -89,7 +89,7 @@ app.use(async function (ctx, next) {
 
 // logger
 
-app.use(async function (ctx, next) {
+app.use(async (ctx, next) => {
   const start = Date.now();
   await next();
   const ms = Date.now() - start;
@@ -98,7 +98,7 @@ app.use(async function (ctx, next) {
 
 // response
 
-app.use(ctx => {
+app.use(async ctx => {
   ctx.body = 'Hello World';
 });
 
@@ -195,7 +195,7 @@ ctx.cookies.set('name', 'tobi', { signed: true });
 ```js
 app.context.db = db();
 
-app.use(async (ctx) => {
+app.use(async ctx => {
   console.log(ctx.db);
 });
 ```
@@ -212,17 +212,17 @@ Note:
   To perform custom error-handling logic such as centralized logging you can add an "error" event listener:
 
 ```js
-app.on('error', err =>
+app.on('error', err => {
   log.error('server error', err)
-);
+});
 ```
 
   If an error is in the req/res cycle and it is _not_ possible to respond to the client, the `Context` instance is also passed:
 
 ```js
-app.on('error', (err, ctx) =>
+app.on('error', (err, ctx) => {
   log.error('server error', err, ctx)
-);
+});
 ```
 
   When an error occurs _and_ it is still possible to respond to the client, aka no data has been written to the socket, Koa will respond

--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -61,7 +61,7 @@ ctx.request.origin
   Get full request URL, include `protocol`, `host` and `url`.
 
 ```js
-ctx.request.href
+ctx.request.href;
 // => http://example.com/foo/bar?q=1
 ```
 
@@ -112,7 +112,7 @@ ctx.request.href
   Get request `Content-Type` void of parameters such as "charset".
 
 ```js
-const ct = ctx.request.type
+const ct = ctx.request.type;
 // => "image/png"
 ```
 
@@ -121,7 +121,7 @@ const ct = ctx.request.type
   Get request charset when present, or `undefined`:
 
 ```js
-ctx.request.charset
+ctx.request.charset;
 // => "utf-8"
 ```
 
@@ -146,7 +146,7 @@ ctx.request.charset
   setter does _not_ support nested objects.
 
 ```js
-ctx.query = { next: '/login' }
+ctx.query = { next: '/login' };
 ```
 
 ### request.fresh

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -150,7 +150,7 @@ If `response.status` has not been set, Koa will automatically set the status to 
 ```js
 const PassThrough = require('stream').PassThrough;
 
-app.use(function * (next) {
+app.use(async ctx => {
   ctx.body = someHTTPStream.on('error', ctx.onerror).pipe(PassThrough());
 });
 ```
@@ -234,8 +234,8 @@ ctx.type = 'png';
 ```js
 const minify = require('html-minifier');
 
-app.use(function * minifyHTML(next) {
-  await next;
+app.use(async (ctx, next) => {
+  await next();
 
   if (!ctx.response.is('html')) return;
 


### PR DESCRIPTION
Fix some minor inconsistencies in the docs:

* Use arrow functions throughout
* Consistent brace/semicolon/parens style
* Only accept `next` as a parameter if it needs to be called
* Use `async` functions throughout

Let me know if you'd like me to revert an  of these.