### PR TITLE
add bench for async/await

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -2,14 +2,22 @@
 all: middleware
 
 middleware:
-	@./run 1 $@
-	@./run 5 $@
-	@./run 10 $@
-	@./run 15 $@
-	@./run 20 $@
-	@./run 30 $@
-	@./run 50 $@
-	@./run 100 $@
+	@./run 1 false $@
+	@./run 5 false $@
+	@./run 10 false $@
+	@./run 15 false $@
+	@./run 20 false $@
+	@./run 30 false $@
+	@./run 50 false $@
+	@./run 100 false $@
+	@./run 1 true $@
+	@./run 5 true $@
+	@./run 10 true $@
+	@./run 15 true $@
+	@./run 20 true $@
+	@./run 30 true $@
+	@./run 50 true $@
+	@./run 100 true $@
 	@echo
 
 .PHONY: all middleware

--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -7,14 +7,24 @@ const app = new Koa();
 // number of middleware
 
 let n = parseInt(process.env.MW || '1', 10);
-console.log(`  ${n} middleware`);
+let useAsync = process.env.USE_ASYNC === 'true';
+
+console.log(`  ${n}${useAsync ? ' async' : ''} middleware`);
 
 while (n--) {
-  app.use((ctx, next) => next());
+  if (useAsync) {
+    app.use(async (ctx, next) => await next());
+  } else {
+    app.use((ctx, next) => next());
+  }
 }
 
 const body = Buffer.from('Hello World');
 
-app.use((ctx, next) => next().then(() => ctx.body = body));
+if (useAsync) {
+  app.use(async (ctx, next) => { await next(); ctx.body = body; });
+} else {
+  app.use((ctx, next) => next().then(() => ctx.body = body));
+}
 
 app.listen(3333);

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo
-MW=$1 node $2 &
+MW=$1 USE_ASYNC=$2 node $3 &
 pid=$!
 
 sleep 2


### PR DESCRIPTION
Add bench mark for async/await.
It will get the benchmark result after run `npm run bench`:
```
> koa@2.3.0 bench /Users/vincent/workspace/github/koa
> make -C benchmarks


  1 middleware
  10990.91

  5 middleware
  10840.53

  10 middleware
  10346.97

  15 middleware
  10583.24

  20 middleware
  10470.64

  30 middleware
  9704.60

  50 middleware
  10474.31

  100 middleware
  9840.64

  1 async middleware
  10117.00

  5 async middleware
  9967.02

  10 async middleware
  9472.44

  15 async middleware
  8081.88

  20 async middleware
  8474.22

  30 async middleware
  7557.38

  50 async middleware
  5732.09

  100 async middleware
  3859.72
```