### PR TITLE
Update Node engine to 7.6.0 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "supertest": "^3.0.0"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 7.6.0"
   },
   "files": [
     "lib"


### PR DESCRIPTION
The engine versions, Travis versions, and recommended version from the readme should be consistent.

From the readme:

> Koa requires **node v7.6.0** or higher for ES2015 and async function support.