### PR TITLE
Set request protocol to https when "X-AppEngine-HTTPS" header is "on"

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -390,7 +390,8 @@ module.exports = {
    * is enabled the "X-Forwarded-Proto" header
    * field will be trusted. If you're running behind
    * a reverse proxy that supplies https for you this
-   * may be enabled.
+   * may be enabled. "X-AppEngine-HTTPS" is respected
+   * for deployment on Google Cloud Platform.
    *
    * @return {String}
    * @api public
@@ -399,6 +400,7 @@ module.exports = {
   get protocol() {
     const proxy = this.app.proxy;
     if (this.socket.encrypted) return 'https';
+    if (this.get('X-AppEngine-HTTPS') === 'on') return 'https';
     if (!proxy) return 'http';
     const proto = this.get('X-Forwarded-Proto') || 'http';
     return proto.split(/\s*,\s*/)[0];

--- a/test/request/protocol.js
+++ b/test/request/protocol.js
@@ -51,4 +51,22 @@ describe('req.protocol', () => {
       });
     });
   });
+
+  describe('when X-AppEngine-HTTPS is set', () => {
+    it('should return "https"', () => {
+      const req = request();
+      req.req.socket = {};
+      req.header['x-appengine-https'] = 'on';
+      assert.equal(req.protocol, 'https');
+    });
+
+    describe('and X-AppEngine-HTTPS is empty', () => {
+      it('should return "http"', () => {
+        const req = request();
+        req.req.socket = {};
+        req.header['x-appengine-https'] = '';
+        assert.equal(req.protocol, 'http');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Supports deployment on Google Cloud Platform, specifically Google Cloud Functions, which does *not* set the `X-Forwarded-Proto` header.

Note, this does not require `app.proxy` to be true.