### PR TITLE
tools: remove --fix to catch lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --forceExit",
     "test-cov": "npm run test -- --coverage",
-    "lint": "eslint benchmarks lib test --fix",
+    "lint": "eslint benchmarks lib test",
     "bench": "make -C benchmarks"
   },
   "repository": "koajs/koa",


### PR DESCRIPTION
Since `--fix` always runs, lint on travis does not non-zero exit unless it's "unfixable".