### PR TITLE
http: allow passing server object, for future node http2

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -19,10 +19,19 @@ const accepts = require('accepts');
 const Emitter = require('events');
 const assert = require('assert');
 const Stream = require('stream');
-const http = require('http');
 const only = require('only');
 const convert = require('koa-convert');
 const deprecate = require('depd')('koa');
+
+function requireServer(server = 'http') {
+  if ('http' == server) {
+    return require('http');
+  } else if ('http2' == server) {
+    return require('http2');
+  } else {
+    return server;
+  }
+}
 
 /**
  * Expose `Application` class.
@@ -36,12 +45,13 @@ module.exports = class Application extends Emitter {
    * @api public
    */
 
-  constructor() {
+  constructor(args = {}) {
     super();
 
     this.proxy = false;
     this.middleware = [];
     this.subdomainOffset = 2;
+    this.server = requireServer(args.server);
     this.env = process.env.NODE_ENV || 'development';
     this.context = Object.create(context);
     this.request = Object.create(request);
@@ -60,7 +70,7 @@ module.exports = class Application extends Emitter {
 
   listen(...args) {
     debug('listen');
-    const server = http.createServer(this.callback());
+    const server = this.server.createServer(this.callback());
     return server.listen(...args);
   }
 


### PR DESCRIPTION
Just trying to get this ball rolling because there's some activity in closed issue #477.

This is what I'm purposing to allow user space to experiment with http2 without breaking backwards compatibility.

Purposed API would become:

```js
const http2 = require('http2')
const Koa = require('koa')
const app = new Koa({ server: http2 })
```

I could move the require into the construction if args.server is falsey to avoid loading the library at all if http2 is chosen - not sure about the implications of doing so. I'd still have to be done during initialisation of a Koa application so my two cents would be to do it. Not sure how Koa team feels about a require in a constructor thought :)
```js
constructor() {
  super()
  ...
  this.server = args.server || require('http');
  ...
}
```

**PS** I am embarrassingly ignorant about http2, and the node implementation.