### PR TITLE
Update babel setup

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,10 +12,10 @@ $ node my-koa-app.js
 
 ## Async Functions with Babel
 
-To use `async` functions in Koa in versions of node < 7.6, we recommend using [babel's require hook](http://babeljs.io/docs/usage/require/).
+To use `async` functions in Koa in versions of node < 7.6, we recommend using [babel's require hook](http://babeljs.io/docs/usage/babel-register/).
 
 ```js
-require('babel-core/register');
+require('babel-register');
 // require the rest of the app that needs to be transpiled after the hook
 const app = require('./app');
 ```


### PR DESCRIPTION
Based on https://github.com/babel/babel/pull/5132, `babel-core/register` is deprecated at babel `v7`. 
So, this pull request fixes babel setup documentation.

Related to #783 