### PR TITLE
Update fresh to ^0.5.2 to close vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "destroy": "^1.0.3",
     "error-inject": "~1.0.0",
     "escape-html": "~1.0.1",
-    "fresh": "^0.5.0",
+    "fresh": "^0.5.2",
     "http-assert": "^1.1.0",
     "http-errors": "^1.2.8",
     "is-generator-function": "^1.0.3",


### PR DESCRIPTION
@dlebedynskyi reports in #1085:
> fresh has Vulnerable Regular Expression issue.
https://snyk.io/vuln/npm:fresh:20170908
Current version listed in package.json is 0.5
it is advised to up update to 0.5.2 for fix.

This can be fixed by updating package.json