### PR TITLE
Add app.start method - a listen promise

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -72,11 +72,18 @@ module.exports = class Application extends Emitter {
    * @api public
    */
   start(...args) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const server = http.createServer(this.callback());
-      server.listen(...args);
 
-      server.once('listening', () => resolve(server));
+      function onerror(err) { reject(err); }
+
+      server.once('error', onerror);
+      server.once('listening', () => {
+        server.removeListener('error', onerror);
+        resolve(server);
+      });
+
+      server.listen(...args);
     });
   }
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -65,6 +65,22 @@ module.exports = class Application extends Emitter {
   }
 
   /**
+   * Eventually return a listening http server.
+   *
+   * @param {Mixed} ...
+   * @return {Promise<Server>}
+   * @api public
+   */
+  start(...args) {
+    return new Promise(resolve => {
+      const server = http.createServer(this.callback());
+      server.listen(...args);
+
+      server.once('listening', () => resolve(server));
+    });
+  }
+
+  /**
    * Return JSON representation.
    * We only bother showing settings.
    *

--- a/test/application/start.js
+++ b/test/application/start.js
@@ -3,21 +3,50 @@
 const assert = require('assert');
 const Koa = require('../..');
 const http = require('http');
+const EventEmitter = require('events');
 
 describe('app.start', () => {
-  it('should eventually return a listening http server', async () => {
-    const app = new Koa();
+  describe('when server starts successfully', () => {
+    it('should eventually return a listening http server', async () => {
+      const app = new Koa();
 
-    const server = await app.start();
+      const server = await app.start();
 
-    assert.equal(server instanceof http.Server, true);
-    assert.equal(server.listening, true);
+      assert.equal(server instanceof http.Server, true);
+      assert.equal(server.listening, true);
 
-    await new Promise((resolve, reject) => {
-      server.close(err => {
-        if (err) return reject(err);
-        resolve();
+      await new Promise((resolve, reject) => {
+        server.close(err => {
+          if (err) return reject(err);
+          resolve();
+        });
       });
+    });
+  });
+
+  describe('when server emits an error', () => {
+    const error = new Error('EADDRINUSE');
+
+    const originalCreateServer = http.createServer;
+    beforeEach(() => {
+      const server = new EventEmitter();
+      http.createServer = () => server;
+      server.listen = () => {
+        process.nextTick(() => server.emit('error', error));
+      };
+    });
+    afterEach(() => {
+      http.createServer = originalCreateServer;
+    });
+
+    it('should eventually throw an error', async () => {
+      const app = new Koa();
+
+      try {
+        await app.start();
+      } catch (e) {
+        assert.strictEqual(e, error);
+      }
     });
   });
 });

--- a/test/application/start.js
+++ b/test/application/start.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const Koa = require('../..');
+const http = require('http');
+
+describe('app.start', () => {
+  it('should eventually return a listening http server', async () => {
+    const app = new Koa();
+
+    const server = await app.start();
+
+    assert.equal(server instanceof http.Server, true);
+    assert.equal(server.listening, true);
+
+    await new Promise((resolve, reject) => {
+      server.close(err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hi, I've been interested in the project for quite some time. I've started using it on my new project and I had an issue with catching server errors on boot up, because `app.listen()` returns an `http.Server` that is in fact event emitter. Here is an example:
```js
const Koa = require('koa')
async function start () {
  const app = new Koa()
  // when there is a server listening on port 3000 throws unhandled 'error' event
  await new Promise((rs, rj) => app.listen(3000, err => err ? rj(err) : rs()))
}
start().catch(err => console.error(err))
```
My solution was to use `app.callback()`
```js
const http = require('http')
const Koa = require('koa')
async function start () {
  const app = new Koa()
  const server = http.createServer(app.callback())
  await Promise.race([
    new Promise((rs, rj) => server.once('error', rj)),
    new Promise((rs, rj) => server.listen(3000, err => err ? rj(err) : rs()))
  ])
}
start().catch(err => console.error(err))
```
So I thought it'd be nice to have a method on Koa application that guarantees to return a listening server.
```js
const server = await app.start(3000)
```
