### PR TITLE
Error handling: try to stringify non-error throw if it is an object

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -5,6 +5,7 @@
  * Module dependencies.
  */
 
+const util = require('util');
 const createError = require('http-errors');
 const httpAssert = require('http-assert');
 const delegate = require('delegates');
@@ -105,7 +106,7 @@ const proto = module.exports = {
     // to node-style callbacks.
     if (null == err) return;
 
-    if (!(err instanceof Error)) err = new Error(`non-error thrown: ${err}`);
+    if (!(err instanceof Error)) err = new Error(util.format('non-error thrown: %j', err));
 
     let headerSent = false;
     if (this.headerSent || !this.writable) {

--- a/test/context/onerror.js
+++ b/test/context/onerror.js
@@ -185,5 +185,23 @@ describe('ctx.onerror(err)', () => {
 
       assert.equal(removed, 2);
     });
+
+    it('should stringify error if it is an object', done => {
+      const app = new Koa();
+
+      app.on('error', err => {
+        assert.equal(err, 'Error: non-error thrown: {"key":"value"}');
+        done();
+      });
+
+      app.use(async ctx => {
+        throw {key: 'value'}; // eslint-disable-line no-throw-literal
+      });
+
+      request(app.callback())
+        .get('/')
+        .expect(500)
+        .expect('Internal Server Error', () => {});
+    });
   });
 });


### PR DESCRIPTION
In case when object were thrown error message is really non helpful - you just see `non-error thrown: [object Object]` and stack trace is leads to Koa source. If someone throws an object - it is his fault that no stack trace would be provided, but seen the object itself is already a good start. A specially when it was not your code but some of the modules that you used

With this PR thrown objects would be converted to JSON