### PR TITLE
docs: capitalize K in word koa

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-<img src="/docs/logo.png" alt="koa middleware framework for nodejs"/>
+<img src="/docs/logo.png" alt="Koa middleware framework for nodejs"/>
 
   [![gitter][gitter-image]][gitter-url]
   [![NPM version][npm-image]][npm-url]
@@ -22,7 +22,7 @@ Koa requires __node v7.6.0__ or higher for ES2015 and async function support.
 $ npm install koa
 ```
 
-## Hello koa
+## Hello Koa
 
 ```js
 const Koa = require('koa');
@@ -38,8 +38,8 @@ app.listen(3000);
 
 ## Getting started
 
- - [Kick-Off-Koa](https://github.com/koajs/kick-off-koa) - An intro to koa via a set of self-guided workshops.
- - [Workshop](https://github.com/koajs/workshop) - A workshop to learn the basics of koa, Express' spiritual successor.
+ - [Kick-Off-Koa](https://github.com/koajs/kick-off-koa) - An intro to Koa via a set of self-guided workshops.
+ - [Workshop](https://github.com/koajs/workshop) - A workshop to learn the basics of Koa, Express' spiritual successor.
  - [Introduction Screencast](http://knowthen.com/episode-3-koajs-quickstart-guide/) - An introduction to installing and getting started with Koa
 
 

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -14,8 +14,8 @@
 ```js
 app.use(async ctx => {
   ctx; // is the Context
-  ctx.request; // is a koa Request
-  ctx.response; // is a koa Response
+  ctx.request; // is a Koa Request
+  ctx.response; // is a Koa Response
 });
 ```
 
@@ -44,11 +44,11 @@ app.use(async ctx => {
 
 ### ctx.request
 
-  A koa `Request` object.
+  A Koa `Request` object.
 
 ### ctx.response
 
-  A koa `Response` object.
+  A Koa `Response` object.
 
 ### ctx.state
 
@@ -68,7 +68,7 @@ ctx.state.user = await User.find(id);
 
  - `signed` the cookie requested should be signed
 
-koa uses the [cookies](https://github.com/jed/cookies) module where options are simply passed.
+Koa uses the [cookies](https://github.com/jed/cookies) module where options are simply passed.
 
 ### ctx.cookies.set(name, value, [options])
 
@@ -83,7 +83,7 @@ koa uses the [cookies](https://github.com/jed/cookies) module where options are 
  - `httpOnly` server-accessible cookie, __true__ by default
  - `overwrite` a boolean indicating whether to overwrite previously set cookies of the same name (__false__ by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
 
-koa uses the [cookies](https://github.com/jed/cookies) module where options are simply passed.
+Koa uses the [cookies](https://github.com/jed/cookies) module where options are simply passed.
 
 ### ctx.throw([status], [msg], [properties])
 
@@ -118,7 +118,7 @@ throw err;
 ctx.throw(401, 'access_denied', { user: user });
 ```
 
-koa uses [http-errors](https://github.com/jshttp/http-errors) to create errors.
+Koa uses [http-errors](https://github.com/jshttp/http-errors) to create errors.
 
 ### ctx.assert(value, [status], [msg], [properties])
 
@@ -130,7 +130,7 @@ koa uses [http-errors](https://github.com/jshttp/http-errors) to create errors.
 ctx.assert(ctx.state.user, 401, 'User not found. Please login!');
 ```
 
-koa uses [http-assert](https://github.com/jshttp/http-assert) for assertions.
+Koa uses [http-assert](https://github.com/jshttp/http-assert) for assertions.
 
 ### ctx.respond
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -154,7 +154,7 @@ https.createServer(app.callback()).listen(3001);
 
   Return a callback function suitable for the `http.createServer()`
   method to handle a request.
-  You may also use this callback function to mount your koa app in a
+  You may also use this callback function to mount your Koa app in a
   Connect/Express app.
 
 ## app.use(function)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -26,7 +26,7 @@ app.use(responseTime);
   while any code after is the "bubble" phase. This crude gif illustrates how async function allow us
   to properly utilize stack flow to implement request and response flows:
 
-![koa middleware](/docs/middleware.gif)
+![Koa middleware](/docs/middleware.gif)
 
    1. Create a date to track response time
    2. Await control to the next middleware
@@ -203,7 +203,7 @@ app.use(async function (ctx, next) {
   Koa along with many of the libraries it's built with support the __DEBUG__ environment variable from [debug](https://github.com/visionmedia/debug) which provides simple conditional logging.
 
   For example
-  to see all koa-specific debugging information just pass `DEBUG=koa*` and upon boot you'll see the list of middleware used, among other things.
+  to see all Koa-specific debugging information just pass `DEBUG=koa*` and upon boot you'll see the list of middleware used, among other things.
 
 ```
 $ DEBUG=koa* node --harmony examples/simple

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -90,6 +90,6 @@ THIS DOCUMENT IS IN PROGRESS. THIS PARAGRAPH SHALL BE REMOVED WHEN THIS DOCUMENT
   Since Express comes with its own routing, but Koa does not have
   any in-built routing, but there are third party libraries available
   koa-router and koa-route for routing.
-  Similarly just like we have helmet for security in Express, For koa
-  we have koa-helmet available and the list goes on for koa third
+  Similarly just like we have helmet for security in Express, for Koa
+  we have koa-helmet available and the list goes on for Koa third
   party available libraries.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,7 +29,7 @@ You don't have to use asynchronous functions - you just have to pass a function 
 A regular function that returns a promise works too!
 
 The signature has changed to pass `Context` via an explicit parameter, `ctx` above, instead of via
-`this`.  The context passing change makes koa more compatible with es6 arrow functions, which capture `this`.
+`this`.  The context passing change makes Koa more compatible with es6 arrow functions, which capture `this`.
 
 ## Using v1.x Middleware in v2.x
 
@@ -75,7 +75,7 @@ Upgrading your middleware may require some work. One migration path is to update
 
 1. Wrap all your current middleware in `koa-convert`
 2. Test
-3. `npm outdated` to see which koa middleware is outdated
+3. `npm outdated` to see which Koa middleware is outdated
 4. Update one outdated middleware, remove using `koa-convert`
 5. Test
 6. Repeat steps 3-5 until you're done


### PR DESCRIPTION
It's Koa.

I think we should have a consistent branding, especially in official docs, hence I have capitalized all K's in word **k**oa (in docs), package names and variables in docs remain untouched of course.