### PR TITLE
do not override already set content-type, fixes #1120

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -178,7 +178,7 @@ module.exports = {
 
     // json
     this.remove('Content-Length');
-    this.type = 'json';
+    if (setType) this.type = 'json';
   },
 
   /**

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -15,14 +15,14 @@ describe('res.body=', () => {
     });
 
     describe('when body is an object', () => {
-      it('should override as json', () => {
+      it('should not override as json', () => {
         const res = response();
 
         res.body = '<em>hey</em>';
         assert.equal('text/html; charset=utf-8', res.header['content-type']);
 
         res.body = { foo: 'bar' };
-        assert.equal('application/json; charset=utf-8', res.header['content-type']);
+        assert.equal('text/html; charset=utf-8', res.header['content-type']);
       });
     });
 


### PR DESCRIPTION
semver major, #1114

This could be done as semver minor - if an application setting is addd, e.g. `app.responsOverride = true` or something.