### PR TITLE
run coverage using --runInBand, fixes #1109

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/application.js",
   "scripts": {
     "test": "jest",
-    "test-cov": "npm run test -- --coverage",
+    "test-cov": "jest --coverage --runInBand --forceExit",
     "lint": "eslint benchmarks lib test",
     "bench": "make -C benchmarks",
     "authors": "git log --format='%aN <%aE>' | sort -u > AUTHORS"


### PR DESCRIPTION
Ref https://github.com/facebook/jest/issues/1874
Fixes https://github.com/koajs/koa/issues/1109

The gist: Jest seems to be writing to cache from two different child processes. It's slower, but doesn't really affect Koa.

I'm expecting this to solve flaky travis tests