### PR TITLE
chore: update istanbul to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-standard": "^7.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.1.1",
-    "istanbul": "^0.4.0",
+    "istanbul": "^0.4.5",
     "jest": "^20.0.0",
     "supertest": "^3.0.0"
   },


### PR DESCRIPTION
Currently, istanbul is 0.4.0 and has minimatch@0.3.0.
minimatch@0.3.0 should be updated.

as you can see
```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```