### PR TITLE
Allow to app.use multiple middlewares at once

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -96,21 +96,25 @@ module.exports = class Application extends Emitter {
    *
    * Old-style middleware will be converted.
    *
-   * @param {Function} fn
+   * @param {Array} funcs
    * @return {Application} self
    * @api public
    */
 
-  use(fn) {
-    if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
-    if (isGeneratorFunction(fn)) {
-      deprecate('Support for generators will be removed in v3. ' +
-                'See the documentation for examples of how to convert old middleware ' +
-                'https://github.com/koajs/koa/blob/master/docs/migration.md');
-      fn = convert(fn);
+  use(...funcs) {
+    funcs = flatten(funcs);
+    for (let fn of funcs) {
+      if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
+      if (isGeneratorFunction(fn)) {
+        deprecate('Support for generators will be removed in v3. ' +
+                  'See the documentation for examples of how to convert old middleware ' +
+                  'https://github.com/koajs/koa/blob/master/docs/migration.md');
+        fn = convert(fn);
+      }
+      debug('use %s', fn._name || fn.name || '-');
+      this.middleware.push(fn);
     }
-    debug('use %s', fn._name || fn.name || '-');
-    this.middleware.push(fn);
+
     return this;
   }
 
@@ -246,4 +250,11 @@ function respond(ctx) {
     ctx.length = Buffer.byteLength(body);
   }
   res.end(body);
+}
+
+/**
+ * Flatten array
+ */
+function flatten(arr) {
+  return arr.reduce((acc, next) => acc.concat(Array.isArray(next) ? flatten(next) : next), []);
 }


### PR DESCRIPTION
Usage
```
app.use(foo, bar, baz)
app.use([foo], [bar, baz])
```