### PR TITLE
export HttpError from http-errors library

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -23,6 +23,7 @@ const http = require('http');
 const only = require('only');
 const convert = require('koa-convert');
 const deprecate = require('depd')('koa');
+const { HttpError } = require('http-errors');
 
 /**
  * Expose `Application` class.
@@ -247,3 +248,9 @@ function respond(ctx) {
   }
   res.end(body);
 }
+
+/**
+ * Make HttpError available to consumers of the library so that consumers don't
+ * have a direct dependency upon `http-errors`
+ */
+module.exports.HttpError = HttpError;

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -55,10 +55,10 @@ describe('app', () => {
   });
 
   it('should have a static property exporting `HttpError` from http-errors library', () => {
-    const createError = require('http-errors')
+    const createError = require('http-errors');
 
-    assert.notEqual(Koa.HttpError, undefined)
-    assert.deepStrictEqual(Koa.HttpError, createError.HttpError)
-    assert.throws(() => { throw new createError(500, 'test error') }, Koa.HttpError)
-  })
+    assert.notEqual(Koa.HttpError, undefined);
+    assert.deepStrictEqual(Koa.HttpError, createError.HttpError);
+    assert.throws(() => { throw createError(500, 'test error'); }, Koa.HttpError);
+  });
 });

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -53,4 +53,12 @@ describe('app', () => {
     process.env.NODE_ENV = NODE_ENV;
     assert.equal(app.env, 'development');
   });
+
+  it('should have a static property exporting `HttpError` from http-errors library', () => {
+    const createError = require('http-errors')
+
+    assert.notEqual(Koa.HttpError, undefined)
+    assert.deepStrictEqual(Koa.HttpError, createError.HttpError)
+    assert.throws(() => { throw new createError(500, 'test error') }, Koa.HttpError)
+  })
 });


### PR DESCRIPTION
Exporting `HttpError` from the library, following the brief discussion in #1156