### PR TITLE
use app.context.state in koa as app.locals in express

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -173,7 +173,7 @@ module.exports = class Application extends Emitter {
     });
     request.ip = request.ips[0] || req.socket.remoteAddress || '';
     context.accept = request.accept = accepts(req);
-    context.state = {};
+    context.state = context.state || {};
     return context;
   }
 


### PR DESCRIPTION
Once set, the value of app.context.state properties persist throughout the life of the application, in contrast with ctx.state properties that are valid only for the lifetime of the request.