### PR TITLE
Fix tests

### DIFF
--- a/test/request/whatwg-url.js
+++ b/test/request/whatwg-url.js
@@ -7,14 +7,15 @@ const assert = require('assert');
 describe('req.URL', () => {
   describe('should not throw when', () => {
     it('host is void', () => {
-      const req = request();
-      assert.doesNotThrow(() => req.URL, TypeError);
+      // Accessing the URL should not throw.
+      request().URL;
     });
 
     it('header.host is invalid', () => {
       const req = request();
       req.header.host = 'invalid host';
-      assert.doesNotThrow(() => req.URL, TypeError);
+      // Accessing the URL should not throw.
+      req.URL;
     });
   });
 

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -17,9 +17,7 @@ describe('res.status=', () => {
       });
 
       it('should not throw', () => {
-        assert.doesNotThrow(() => {
-          response().status = 403;
-        });
+        response().status = 403;
       });
     });
 
@@ -41,7 +39,7 @@ describe('res.status=', () => {
       });
 
       it('should not throw', () => {
-        assert.doesNotThrow(() => response().status = 700);
+        response().status = 700;
       });
     });
 

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -27,7 +27,7 @@ describe('res.status=', () => {
       it('should throw', () => {
         assert.throws(() => {
           response().status = 999;
-        }, 'invalid status code: 999');
+        }, /invalid status code: 999/);
       });
     });
 
@@ -59,7 +59,7 @@ describe('res.status=', () => {
 
   describe('when a status string', () => {
     it('should throw', () => {
-      assert.throws(() => response().status = 'forbidden', 'status code must be a number');
+      assert.throws(() => response().status = 'forbidden', /status code must be a number/);
     });
   });
 


### PR DESCRIPTION
This came up in [CITGM](https://github.com/nodejs/citgm) while improving `assert.throws` in Node.js. See https://github.com/nodejs/node/pull/19867 for more information.

The current tests never checked for the error message and instead, the error message would have been returned, just the same as if there would be no second argument at all.

This makes sure the error message is actually tested for.

Since I just looked at the code, I also added another commit to remove all `assert.doesNotThrow` calls. Those are always unnecessary. They do not provide any benefit since in case of an error it will just catch the error and rethrow.