### PR TITLE
better demonstrate middleware flow

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -78,6 +78,14 @@ app.listen(3000);
 const Koa = require('koa');
 const app = new Koa();
 
+// logger
+
+app.use(async (ctx, next) => {
+  await next();
+  const rt = ctx.response.get('X-Response-Time');
+  console.log(`${ctx.method} ${ctx.url} - ${rt}`);
+});
+
 // x-response-time
 
 app.use(async (ctx, next) => {
@@ -85,15 +93,6 @@ app.use(async (ctx, next) => {
   await next();
   const ms = Date.now() - start;
   ctx.set('X-Response-Time', `${ms}ms`);
-});
-
-// logger
-
-app.use(async (ctx, next) => {
-  const start = Date.now();
-  await next();
-  const ms = Date.now() - start;
-  console.log(`${ctx.method} ${ctx.url} - ${ms}`);
 });
 
 // response


### PR DESCRIPTION
The way this example is written makes it seem like middleware can't act on the context changes of other middleware.  This updates the logger middleware to use the calculated response time value from the response time middleware instead of calculating it itself.