### PR TITLE
fix: use non deprecated custom inspect

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -46,6 +46,9 @@ module.exports = class Application extends Emitter {
     this.context = Object.create(context);
     this.request = Object.create(request);
     this.response = Object.create(response);
+    if (util.inspect.custom) {
+      this[util.inspect.custom] = this.inspect;
+    }
   }
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -154,6 +154,16 @@ const proto = module.exports = {
 };
 
 /**
+ * Custom inspection implementation for newer Node.js versions.
+ *
+ * @return {Object}
+ * @api public
+ */
+if (util.inspect.custom) {
+  module.exports[util.inspect.custom] = module.exports.inspect;
+}
+
+/**
  * Response delegation.
  */
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,6 +14,7 @@ const qs = require('querystring');
 const typeis = require('type-is');
 const fresh = require('fresh');
 const only = require('only');
+const util = require('util');
 
 /**
  * Prototype.
@@ -664,3 +665,13 @@ module.exports = {
     ]);
   }
 };
+
+/**
+ * Custom inspection implementation for newer Node.js versions.
+ *
+ * @return {Object}
+ * @api public
+ */
+if (util.inspect.custom) {
+  module.exports[util.inspect.custom] = module.exports.inspect;
+}

--- a/lib/response.js
+++ b/lib/response.js
@@ -18,6 +18,7 @@ const assert = require('assert');
 const extname = require('path').extname;
 const vary = require('vary');
 const only = require('only');
+const util = require('util');
 
 /**
  * Prototype.
@@ -545,3 +546,13 @@ module.exports = {
     this.res.flushHeaders();
   }
 };
+
+/**
+ * Custom inspection implementation for newer Node.js versions.
+ *
+ * @return {Object}
+ * @api public
+ */
+if (util.inspect.custom) {
+  module.exports[util.inspect.custom] = module.exports.inspect;
+}

--- a/test/application/inspect.js
+++ b/test/application/inspect.js
@@ -2,13 +2,20 @@
 'use strict';
 
 const assert = require('assert');
+const util = require('util');
 const Koa = require('../..');
+const app = new Koa();
 
 describe('app.inspect()', () => {
   it('should work', () => {
-    const app = new Koa();
-    const util = require('util');
     const str = util.inspect(app);
     assert.equal("{ subdomainOffset: 2, proxy: false, env: 'test' }", str);
+  });
+
+  it('should return a json representation', () => {
+    assert.deepEqual(
+      { subdomainOffset: 2, proxy: false, env: 'test' },
+      app.inspect()
+    );
   });
 });

--- a/test/context/inspect.js
+++ b/test/context/inspect.js
@@ -3,6 +3,7 @@
 
 const prototype = require('../../lib/context');
 const assert = require('assert');
+const util = require('util');
 const context = require('../helpers/context');
 
 describe('ctx.inspect()', () => {
@@ -11,10 +12,12 @@ describe('ctx.inspect()', () => {
     const toJSON = ctx.toJSON(ctx);
 
     assert.deepEqual(toJSON, ctx.inspect());
+    assert.deepEqual(util.inspect(toJSON), util.inspect(ctx));
   });
 
   // console.log(require.cache) will call prototype.inspect()
   it('should not crash when called on the prototype', () => {
     assert.deepEqual(prototype, prototype.inspect());
+    assert.deepEqual(util.inspect(prototype.inspect()), util.inspect(prototype));
   });
 });

--- a/test/request/inspect.js
+++ b/test/request/inspect.js
@@ -3,6 +3,7 @@
 
 const request = require('../helpers/context').request;
 const assert = require('assert');
+const util = require('util');
 
 describe('req.inspect()', () => {
   describe('with no request.req present', () => {
@@ -10,7 +11,8 @@ describe('req.inspect()', () => {
       const req = request();
       req.method = 'GET';
       delete req.req;
-      assert(null == req.inspect());
+      assert(undefined === req.inspect());
+      assert('undefined' === util.inspect(req));
     });
   });
 
@@ -20,12 +22,15 @@ describe('req.inspect()', () => {
     req.url = 'example.com';
     req.header.host = 'example.com';
 
-    assert.deepEqual({
+    const expected = {
       method: 'GET',
       url: 'example.com',
       header: {
         host: 'example.com'
       }
-    }, req.inspect());
+    };
+
+    assert.deepEqual(req.inspect(), expected);
+    assert.deepEqual(util.inspect(req), util.inspect(expected));
   });
 });

--- a/test/response/inspect.js
+++ b/test/response/inspect.js
@@ -3,6 +3,7 @@
 
 const response = require('../helpers/context').response;
 const assert = require('assert');
+const util = require('util');
 
 describe('res.inspect()', () => {
   describe('with no response.res present', () => {
@@ -11,6 +12,7 @@ describe('res.inspect()', () => {
       res.body = 'hello';
       delete res.res;
       assert.equal(res.inspect(), null);
+      assert.equal(util.inspect(res), 'undefined');
     });
   });
 
@@ -18,14 +20,17 @@ describe('res.inspect()', () => {
     const res = response();
     res.body = 'hello';
 
-    assert.deepEqual({
-      body: 'hello',
+    const expected = {
       status: 200,
       message: 'OK',
       header: {
-        'content-length': '5',
-        'content-type': 'text/plain; charset=utf-8'
-      }
-    }, res.inspect());
+        'content-type': 'text/plain; charset=utf-8',
+        'content-length': '5'
+      },
+      body: 'hello'
+    };
+
+    assert.deepEqual(res.inspect(), expected);
+    assert.deepEqual(util.inspect(res), util.inspect(expected));
   });
 });


### PR DESCRIPTION
Custom inspection with the `inspect` property is deprecated and will
not work in Node.js 11 anymore. This fixes it by using the custom
inspect symbol where existent and falls back to the old style in case
it does not exist.