### PR TITLE
Throw a TypeError instead of a AssertionError

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -17,7 +17,7 @@ const statuses = require('statuses');
 const Cookies = require('cookies');
 const accepts = require('accepts');
 const Emitter = require('events');
-const assert = require('assert');
+const util = require('util');
 const Stream = require('stream');
 const http = require('http');
 const only = require('only');
@@ -185,7 +185,7 @@ module.exports = class Application extends Emitter {
    */
 
   onerror(err) {
-    assert(err instanceof Error, `non-error thrown: ${err}`);
+    if (!(err instanceof Error)) throw new TypeError(util.format('non-error thrown: %j', err));
 
     if (404 == err.status || err.expose) return;
     if (this.silent) return;

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -3,7 +3,6 @@
 
 const assert = require('assert');
 const Koa = require('../..');
-const AssertionError = require('assert').AssertionError;
 
 describe('app.onerror(err)', () => {
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('app.onerror(err)', () => {
 
     assert.throws(() => {
       app.onerror('foo');
-    }, AssertionError, 'non-error thrown: foo');
+    }, TypeError, 'non-error thrown: foo');
   });
 
   it('should do nothing if status is 404', () => {


### PR DESCRIPTION
Cuz AssertionError is not reading-friendly, you could not directly get where the error is emitted.
![image](https://user-images.githubusercontent.com/17722900/40699767-eb1cac86-6408-11e8-8723-b4d46e45021c.png)
As TypeError seems better.
![image](https://user-images.githubusercontent.com/17722900/40713348-4ddc14dc-6432-11e8-9447-4179193fc536.png)



