### PR TITLE
Simplify processes in the getter `request.protocol`

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -397,11 +397,10 @@ module.exports = {
    */
 
   get protocol() {
-    const proxy = this.app.proxy;
     if (this.socket.encrypted) return 'https';
-    if (!proxy) return 'http';
-    const proto = this.get('X-Forwarded-Proto') || 'http';
-    return proto.split(/\s*,\s*/)[0];
+    if (!this.app.proxy) return 'http';
+    const proto = this.get('X-Forwarded-Proto');
+    return proto ? proto.split(/\s*,\s*/)[0] : 'http';
   },
 
   /**


### PR DESCRIPTION
- Assignment to `proxy` before the `if` block is unnecessary

- When `proto` is falsy then assigned 'http',  calling `split(...)` on the string is unnecessary