### PR TITLE
Throw clearer errors.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,7 +14,7 @@ const escape = require('escape-html');
 const typeis = require('type-is').is;
 const statuses = require('statuses');
 const destroy = require('destroy');
-const assert = require('assert');
+const util = require('util');
 const extname = require('path').extname;
 const vary = require('vary');
 const only = require('only');
@@ -82,8 +82,8 @@ module.exports = {
   set status(code) {
     if (this.headerSent) return;
 
-    assert('number' == typeof code, 'status code must be a number');
-    assert(statuses[code], `invalid status code: ${code}`);
+    if ('number' !== typeof code) throw new TypeError(util.format('non-numeric status code: %j', code));
+    if (!statuses[code]) throw new RangeError(`invalid status code: ${code}`);
     this._explicitStatus = true;
     this.res.statusCode = code;
     if (this.req.httpVersionMajor < 2) this.res.statusMessage = statuses[code];

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -25,7 +25,7 @@ describe('res.status=', () => {
       it('should throw', () => {
         assert.throws(() => {
           response().status = 999;
-        }, /invalid status code: 999/);
+        }, RangeError, /invalid status code: 999/);
       });
     });
 
@@ -57,7 +57,7 @@ describe('res.status=', () => {
 
   describe('when a status string', () => {
     it('should throw', () => {
-      assert.throws(() => response().status = 'forbidden', /status code must be a number/);
+      assert.throws(() => response().status = 'forbidden', TypeError, /non-numeric status code: "forbidden"/);
     });
   });
 


### PR DESCRIPTION
For the same reason with [#1199](https://github.com/koajs/koa/pull/1199), AssertionError is not reading-friendly.