### PR TITLE
fix: parse port in x-forwarded-for (#827)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -433,21 +433,28 @@ module.exports = {
   get ips() {
     const proxy = this.app.proxy;
     const val = this.get(this.app.proxyIpHeader);
-    let ips = proxy && val
-      ? val.split(/\s*,\s*/)
-          .map(host => {
-            let normalizedHost = host;
-            if (net.isIPv6(host)) {
-              normalizedHost = `[${host}]`;
-            }
+    let ips = [];
 
-            return parse(`http://${normalizedHost}`).hostname;
-          })
-          .filter(ip => !!ip)
-      : [];
+    if (proxy && val) {
+      ips = val.split(/\s*,\s*/)
+        .map(host => {
+          let normalizedHost = host;
+
+          if (net.isIPv6(host)) {
+            normalizedHost = `[${host}]`;
+          }
+
+          const hostname = new URL(`http://${normalizedHost}`).hostname;
+
+          return hostname.replace(/(^\[|\]$)/g, '');
+        })
+        .filter(ip => !!ip);
+    }
+
     if (this.app.maxIpsCount > 0) {
       ips = ips.slice(-this.app.maxIpsCount);
     }
+
     return ips;
   },
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -433,6 +433,15 @@ module.exports = {
     const val = this.get('X-Forwarded-For');
     return proxy && val
       ? val.split(/\s*,\s*/)
+          .map(host => {
+            let normalizedHost = host;
+            if (net.isIPv6(host)) {
+              normalizedHost = `[${host}]`;
+            }
+
+            return parse(`http://${normalizedHost}`).hostname;
+          })
+          .filter(ip => !!ip)
       : [];
   },
 

--- a/test/request/ips.js
+++ b/test/request/ips.js
@@ -23,5 +23,23 @@ describe('req.ips', () => {
         assert.deepEqual(req.ips, ['127.0.0.1', '127.0.0.2']);
       });
     });
+
+    describe('and contains IPv4', () => {
+      it('should not return port', () => {
+        const req = request();
+        req.app.proxy = true;
+        req.header['x-forwarded-for'] = '127.0.0.1:80,127.0.0.2';
+        assert.deepEqual(req.ips, ['127.0.0.1', '127.0.0.2']);
+      });
+    });
+
+    describe('and contains IPv6', () => {
+      it('should parse correctly', () => {
+        const req = request();
+        req.app.proxy = true;
+        req.header['x-forwarded-for'] = '::1';
+        assert.deepEqual(req.ips, ['::1']);
+      });
+    });
   });
 });


### PR DESCRIPTION
Parses out IPs even if a port is sent in x-forwarded-for for IPv4.  Probably fails if port is sent with an IPv6 address, but works otherwise.

fixes #827 