### PR TITLE
pref: use typeof instead of instanceof in stream send mode

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -233,7 +233,7 @@ function respond(ctx) {
   // responses
   if (Buffer.isBuffer(body)) return res.end(body);
   if ('string' == typeof body) return res.end(body);
-  if (body instanceof Stream) return body.pipe(res);
+  if (typeof body.pipe === 'function') return body.pipe(res);
 
   // body: json
   body = JSON.stringify(body);

--- a/lib/application.js
+++ b/lib/application.js
@@ -16,7 +16,6 @@ const request = require('./request');
 const statuses = require('statuses');
 const Emitter = require('events');
 const util = require('util');
-const Stream = require('stream');
 const http = require('http');
 const only = require('only');
 const convert = require('koa-convert');


### PR DESCRIPTION
- use `typeof` instead of `instanceof`, `typeof` has higher performance than `instanceof`
- benchmark: [typof-vs-instanceof](https://jsperf.com/typof-vs-instanceof/1) 
![image](https://user-images.githubusercontent.com/5475069/42674932-4742f336-86a4-11e8-8d5a-3f96d177eec6.png)



