### PR TITLE
fix: redirect failed when not match rfc7230

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -260,7 +260,17 @@ module.exports = {
   redirect(url, alt) {
     // location
     if ('back' == url) url = this.ctx.get('Referrer') || alt || '/';
-    this.set('Location', url);
+    const encodedUrl = encodeURI(url);
+
+    // header field should match rfc7230
+    //
+    // This regex is referred from
+    // https://github.com/nodejs/node/blob/862389b0aacfd41770c3fa6f692aed11c2a4b3ed/lib/_http_common.js#L245
+    assert(
+      !encodedUrl.match(/[^\t\x20-\x7e\x80-\xff]/),
+      'Location should match rfc7230 (https://tools.ietf.org/' +
+      'html/rfc7230#section-3.2.6).');
+    this.set('Location', encodedUrl);
 
     // status
     if (!statuses.redirect[this.status]) this.status = 302;

--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -12,6 +12,13 @@ describe('ctx.redirect(url)', () => {
     assert.equal(ctx.status, 302);
   });
 
+  it('should redirect to the given url with escape', () => {
+    const ctx = context();
+    ctx.redirect('http://google.com/search?q=你好世界');
+    assert.equal(ctx.response.header.location, 'http://google.com/search?q=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C');
+    assert.equal(ctx.status, 302);
+  });
+
   describe('with "back"', () => {
     it('should redirect to Referrer', () => {
       const ctx = context();


### PR DESCRIPTION
When I write:

```js
ctx.redirect('你好世界');
```

Node.js will throw an error due to https://github.com/nodejs/node/blob/862389b0aacfd41770c3fa6f692aed11c2a4b3ed/lib/_http_common.js#L245.

This PR is to encode the uri to match [rfc7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).

> Needs backward.