### PR TITLE
Adding a headers setter to match the request api in the response api

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -63,6 +63,21 @@ module.exports = {
   },
 
   /**
+   * Set an object of header fields.
+   *
+   * Examples:
+   *
+   *    this.headers({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
+   *
+   * @param {Object|Array} headers
+   * @api public
+   */
+
+  set headers(headers) {
+    return this.set(headers);
+  },
+
+  /**
    * Get response status code.
    *
    * @return {Number}

--- a/test/response/headers.js
+++ b/test/response/headers.js
@@ -4,11 +4,23 @@
 const assert = require('assert');
 const response = require('../helpers/context').response;
 
-describe('res.header', () => {
+describe('res.headers', () => {
   it('should return the response header object', () => {
     const res = response();
     res.set('X-Foo', 'bar');
     assert.deepEqual(res.headers, { 'x-foo': 'bar' });
+  });
+
+  it('should set multiple header fields', () => {
+    const res = response();
+
+    res.headers = {
+      foo: '1',
+      bar: '2'
+    };
+
+    assert.equal(res.headers.foo, '1');
+    assert.equal(res.headers.bar, '2');
   });
 
   describe('when res._headers not present', () => {


### PR DESCRIPTION
Hi,

In a matter of consistency, I wish to be able to use a headers setter on the response, like I would on a request.

Thanks

PS: Koa is amazing, thank you guys 