### PR TITLE
refactor: use absolute equal for string comparison

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -181,7 +181,7 @@ ctx.body = await db.find('something');
 
 ### request.secure
 
-  Shorthand for `ctx.protocol == "https"` to check if a request was
+  Shorthand for `ctx.protocol === "https"` to check if a request was
   issued via TLS.
 
 ### request.ip

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -95,7 +95,7 @@ function logger(format) {
 const compose = require('koa-compose');
 
 async function random(ctx, next) {
-  if ('/random' == ctx.path) {
+  if ('/random' === ctx.path) {
     ctx.body = Math.floor(Math.random() * 10);
   } else {
     await next();
@@ -103,7 +103,7 @@ async function random(ctx, next) {
 };
 
 async function backwards(ctx, next) {
-  if ('/backwards' == ctx.path) {
+  if ('/backwards' === ctx.path) {
     ctx.body = 'sdrawkcab';
   } else {
     await next();
@@ -111,7 +111,7 @@ async function backwards(ctx, next) {
 }
 
 async function pi(ctx, next) {
-  if ('/pi' == ctx.path) {
+  if ('/pi' === ctx.path) {
     ctx.body = String(Math.PI);
   } else {
     await next();

--- a/lib/application.js
+++ b/lib/application.js
@@ -182,7 +182,7 @@ module.exports = class Application extends Emitter {
   onerror(err) {
     if (!(err instanceof Error)) throw new TypeError(util.format('non-error thrown: %j', err));
 
-    if (404 == err.status || err.expose) return;
+    if (404 === err.status || err.expose) return;
     if (this.silent) return;
 
     const msg = err.stack || err.toString();
@@ -213,7 +213,7 @@ function respond(ctx) {
     return res.end();
   }
 
-  if ('HEAD' == ctx.method) {
+  if ('HEAD' === ctx.method) {
     if (!res.headersSent && isJSON(body)) {
       ctx.length = Buffer.byteLength(JSON.stringify(body));
     }
@@ -232,7 +232,7 @@ function respond(ctx) {
 
   // responses
   if (Buffer.isBuffer(body)) return res.end(body);
-  if ('string' == typeof body) return res.end(body);
+  if ('string' === typeof body) return res.end(body);
   if (body instanceof Stream) return body.pipe(res);
 
   // body: json

--- a/lib/context.js
+++ b/lib/context.js
@@ -143,7 +143,7 @@ const proto = module.exports = {
     this.type = 'text';
 
     // ENOENT support
-    if ('ENOENT' == err.code) err.status = 404;
+    if ('ENOENT' === err.code) err.status = 404;
 
     // default to 500
     if ('number' != typeof err.status || !statuses[err.status]) err.status = 500;

--- a/lib/request.js
+++ b/lib/request.js
@@ -269,7 +269,7 @@ module.exports = {
   get hostname() {
     const host = this.host;
     if (!host) return '';
-    if ('[' == host[0]) return this.URL.hostname || ''; // IPv6
+    if ('[' === host[0]) return this.URL.hostname || ''; // IPv6
     return host.split(':')[0];
   },
 
@@ -313,7 +313,7 @@ module.exports = {
     if ('GET' != method && 'HEAD' != method) return false;
 
     // 2xx or 304 as per rfc2616 14.26
-    if ((s >= 200 && s < 300) || 304 == s) {
+    if ((s >= 200 && s < 300) || 304 === s) {
       return fresh(this.header, this.response.header);
     }
 
@@ -385,7 +385,7 @@ module.exports = {
 
   get length() {
     const len = this.get('Content-Length');
-    if (len == '') return;
+    if (len === '') return;
     return ~~len;
   },
 
@@ -411,14 +411,14 @@ module.exports = {
   /**
    * Short-hand for:
    *
-   *    this.protocol == 'https'
+   *    this.protocol === 'https'
    *
    * @return {Boolean}
    * @api public
    */
 
   get secure() {
-    return 'https' == this.protocol;
+    return 'https' === this.protocol;
   },
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -83,7 +83,7 @@ module.exports = {
   set status(code) {
     if (this.headerSent) return;
 
-    assert('number' == typeof code, 'status code must be a number');
+    assert('number' === typeof code, 'status code must be a number');
     assert(statuses[code], `invalid status code: ${code}`);
     this._explicitStatus = true;
     this.res.statusCode = code;
@@ -151,7 +151,7 @@ module.exports = {
     const setType = !this.header['content-type'];
 
     // string
-    if ('string' == typeof val) {
+    if ('string' === typeof val) {
       if (setType) this.type = /^\s*</.test(val) ? 'html' : 'text';
       this.length = Buffer.byteLength(val);
       return;
@@ -165,7 +165,7 @@ module.exports = {
     }
 
     // stream
-    if ('function' == typeof val.pipe) {
+    if ('function' === typeof val.pipe) {
       onFinish(this.res, destroy.bind(null, val));
       ensureErrorHandler(val, err => this.ctx.onerror(err));
 
@@ -205,7 +205,7 @@ module.exports = {
 
     if (null == len) {
       if (!body) return;
-      if ('string' == typeof body) return Buffer.byteLength(body);
+      if ('string' === typeof body) return Buffer.byteLength(body);
       if (Buffer.isBuffer(body)) return body.length;
       if (isJSON(body)) return Buffer.byteLength(JSON.stringify(body));
       return;
@@ -259,7 +259,7 @@ module.exports = {
 
   redirect(url, alt) {
     // location
-    if ('back' == url) url = this.ctx.get('Referrer') || alt || '/';
+    if ('back' === url) url = this.ctx.get('Referrer') || alt || '/';
     this.set('Location', url);
 
     // status
@@ -326,7 +326,7 @@ module.exports = {
    */
 
   set lastModified(val) {
-    if ('string' == typeof val) val = new Date(val);
+    if ('string' === typeof val) val = new Date(val);
     this.set('Last-Modified', val.toUTCString());
   },
 
@@ -438,7 +438,7 @@ module.exports = {
   set(field, val) {
     if (this.headerSent) return;
 
-    if (2 == arguments.length) {
+    if (2 === arguments.length) {
       if (Array.isArray(val)) val = val.map(v => typeof v === 'string' ? v : String(v));
       else if (typeof val !== 'string') val = String(val);
       this.res.setHeader(field, val);

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -10,7 +10,7 @@ describe('app', () => {
     const app = new Koa();
 
     app.use((ctx, next) => {
-      // triggers ctx.socket.writable == false
+      // triggers ctx.socket.writable === false
       ctx.socket.emit('error', new Error('boom'));
     });
 


### PR DESCRIPTION
## Summary

It's recommended to use `===` instead of `==` for value comparison. in koa, now `null` and `undefined` are considered the same, that makes sense, but not for strings.