### PR TITLE
fix: use :authority header of http2 requests as host

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -252,6 +252,7 @@ module.exports = {
   get host() {
     const proxy = this.app.proxy;
     let host = proxy && this.get('X-Forwarded-Host');
+    if (this.req.httpVersionMajor >= 2) host = this.get(':authority');
     host = host || this.get('Host');
     if (!host) return '';
     return host.split(/\s*,\s*/)[0];

--- a/test/request/host.js
+++ b/test/request/host.js
@@ -18,6 +18,39 @@ describe('req.host', () => {
     });
   });
 
+  describe('when less then HTTP/2', () => {
+    it('should not use :authority header', () => {
+      const req = request({
+        'httpVersionMajor': 1,
+        'httpVersion': '1.1'
+      });
+      req.header[':authority'] = 'foo.com:3000';
+      req.header.host = 'bar.com:8000';
+      assert.equal(req.host, 'bar.com:8000');
+    });
+  });
+
+  describe('when HTTP/2', () => {
+    it('should use :authority header', () => {
+      const req = request({
+        'httpVersionMajor': 2,
+        'httpVersion': '2.0'
+      });
+      req.header[':authority'] = 'foo.com:3000';
+      req.header.host = 'bar.com:8000';
+      assert.equal(req.host, 'foo.com:3000');
+    });
+
+    it('should use host header as fallback', () => {
+      const req = request({
+        'httpVersionMajor': 2,
+        'httpVersion': '2.0'
+      });
+      req.header.host = 'bar.com:8000';
+      assert.equal(req.host, 'bar.com:8000');
+    });
+  });
+
   describe('when X-Forwarded-Host is present', () => {
     describe('and proxy is not trusted', () => {
       it('should be ignored', () => {


### PR DESCRIPTION
The now stable [http2 api](https://nodejs.org/api/http2.html#http2_headers_object) does not use the host header. The host can be found in the http2 [`:authority` header](https://http2.github.io/http2-spec/#rfc.section.8.1.2.3.p.1). Therefore koa should use this header instead.

This fixes the `host` property and all properties that depend on it for http2 requests. These dependent properties include the `hostname`, the `origin` and the `URL`. This will also fix #1174.