### PR TITLE
a tiny optimization

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -154,7 +154,7 @@ const proto = module.exports = {
     const msg = err.expose ? err.message : code;
     this.status = err.status;
     this.length = Buffer.byteLength(msg);
-    this.res.end(msg);
+    res.end(msg);
   },
 
   get cookies() {


### PR DESCRIPTION
`res` has been cached at line 130 `const { res } = this;`, so just use it rather `this.res`.