### PR TITLE
use the ability of `content-type` lib directly

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -367,16 +367,12 @@ module.exports = {
    */
 
   get charset() {
-    let type = this.get('Content-Type');
-    if (!type) return '';
-
     try {
-      type = contentType.parse(type);
+      const { parameters } = contentType.parse(this.req);
+      return parameters.charset || '';
     } catch (e) {
       return '';
     }
-
-    return type.parameters.charset || '';
   },
 
   /**


### PR DESCRIPTION
As we can see the doc of `content-type`: [https://github.com/jshttp/content-type#contenttypeparsereq](https://github.com/jshttp/content-type#contenttypeparsereq), it can deal with the original `req` directly and will also throw TypeError exception when `Content-Type` is missing or invalid. So in my opinion, we don't need `let type = this.get('Content-Type');` to get the type and `if (!type) return ''` to check if the type is unvalid.