### PR TITLE
HTTP requests processing prioritisation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,44 @@ And have your `.babelrc` setup:
 }
 ```
 
+## Performance
+
+By default, Koa is already fast enought for most common use cases.  
+However, we can optionally "energize" our HTTP server "reqs/s" throughput by executing the 
+requests handlers within the [setImmediate](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/) priority queue.  
+
+> *setImmediate()* is designed to execute a script once the current poll phase completes.  
+
+```js
+const app = new Koa();
+// this flag indicates Koa to run the requests handlers using setImmediate
+app.prioRequestsProcessing = true;
+```
+### Benchmarks
+> Use this feature if your process runs in a multicore CPU and your controllers logic does majorly I/O operations.
+
+Node version: v10.14.1  
+Laptop: MacBook Pro 2016, 2,7 GHz Intel Core i7, 16 GB 2133 MHz LPDDR3
+```bash
+wrk -t8 -c40 -d10s http://localhost:3000/hi
+```
+```js
+const Koa = require('koa')
+const app = new Koa()
+const router = require('koa-router')()
+
+router.get('/hi', async (ctx) => {
+  ctx.body = 'Hello World!'
+  ctx.status = 200
+})
+app.use(router.routes())
+app.listen(3000)
+
+```
+- With `app.prioRequestsProcessing = true;` = **37440.67 reqs/s**  
+- Without = 25711.95  
+
+Performance gain: **145%**
 ## Troubleshooting
 
 Check the [Troubleshooting Guide](docs/troubleshooting.md) or [Debugging Koa](docs/guide.md#debugging-koa) in

--- a/lib/application.js
+++ b/lib/application.js
@@ -44,6 +44,7 @@ module.exports = class Application extends Emitter {
     this.context = Object.create(context);
     this.request = Object.create(request);
     this.response = Object.create(response);
+    this.prioRequestsProcessing = false;
     if (util.inspect.custom) {
       this[util.inspect.custom] = this.inspect;
     }
@@ -128,10 +129,21 @@ module.exports = class Application extends Emitter {
 
     if (!this.listenerCount('error')) this.on('error', this.onerror);
 
-    const handleRequest = (req, res) => {
+    let handleRequest = (req, res) => {
       const ctx = this.createContext(req, res);
-      return this.handleRequest(ctx, fn);
+      this.handleRequest(ctx, fn);
     };
+
+    if (this.prioRequestsProcessing) {
+      debug('requests processing moved to "check" queue');
+      handleRequest = (req, res) => {
+        setImmediate(() => {
+          // processing requests using a high priority queue increases "reqs/second" throughput
+          const ctx = this.createContext(req, res);
+          this.handleRequest(ctx, fn);
+        });
+      };
+    }
 
     return handleRequest;
   }

--- a/test/application/prio-requests-processing.js
+++ b/test/application/prio-requests-processing.js
@@ -1,0 +1,20 @@
+
+'use strict';
+
+const request = require('supertest');
+const Koa = require('../../lib/application');
+
+describe('app.prioRequestsProcessing = true', () => {
+  const app = new Koa();
+  app.prioRequestsProcessing = true;
+
+  it('should process request', () => {
+    app.use((ctx, next) => {
+      ctx.status = 200;
+    });
+
+    return request(app.listen())
+      .get('/')
+      .expect(200);
+  });
+});


### PR DESCRIPTION
Allows Koa to optionally process HTTP requests using the "check" tasks queue, resulting in a bigger performance gain if running in multicore CPU runtimes.

- With `app.prioRequestsProcessing = true;` = **37440.67 reqs/s**  
- Without = 25711.95  