### PR TITLE
ibu: replace ~~ with Math.trunc in res.length (option)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -211,7 +211,7 @@ module.exports = {
       return;
     }
 
-    return ~~len;
+    return Math.trunc(len);
   },
 
   /**


### PR DESCRIPTION
#1275 is fixed by this, though this implementation probably shouldn't be merged into master it can benefit whoever was suffering from the content length being too large to be notnoted.