### PR TITLE
Add link to the license file 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -308,7 +308,7 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 
 # License
 
-  MIT
+  [MIT](https://github.com/koajs/koa/blob/master/LICENSE)
 
 [npm-image]: https://img.shields.io/npm/v/koa.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/koa


### PR DESCRIPTION
Presently, the `README` file has the license information in plain text `MIT`
I made it point to the `License` file which makes more sense 🤔 