### PR TITLE
Reduce unnecessary variable declarations

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -200,9 +200,9 @@ function respond(ctx) {
   // allow bypassing koa
   if (false === ctx.respond) return;
 
-  const res = ctx.res;
   if (!ctx.writable) return;
 
+  const res = ctx.res;
   let body = ctx.body;
   const code = ctx.status;
 


### PR DESCRIPTION
It is unnecessary to declare `res` if `ctx.writable === false`