### PR TITLE
Update PR-welcoming badge url 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -323,4 +323,4 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 [gitter-url]: https://gitter.im/koajs/koa?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [#koajs]: https://webchat.freenode.net/?channels=#koajs
 [pr-welcoming-image]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
-[pr-welcoming-url]: https://github.com/koajs/koa
+[pr-welcoming-url]: https://github.com/koajs/koa/pull/new


### PR DESCRIPTION
## Current Issue

> Currently, the `PR welcoming` badge points to the repository itself which doesn't makes sense.

## Proposed solution

> Updated the link so that it points to creating a new PR.