### PR TITLE
fix: app.middleware -> app.middlewares

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -38,7 +38,7 @@ module.exports = class Application extends Emitter {
     super();
 
     this.proxy = false;
-    this.middleware = [];
+    this.middlewares = [];
     this.subdomainOffset = 2;
     this.env = process.env.NODE_ENV || 'development';
     this.context = Object.create(context);
@@ -111,7 +111,7 @@ module.exports = class Application extends Emitter {
       fn = convert(fn);
     }
     debug('use %s', fn._name || fn.name || '-');
-    this.middleware.push(fn);
+    this.middlewares.push(fn);
     return this;
   }
 
@@ -124,7 +124,7 @@ module.exports = class Application extends Emitter {
    */
 
   callback() {
-    const fn = compose(this.middleware);
+    const fn = compose(this.middlewares);
 
     if (!this.listenerCount('error')) this.on('error', this.onerror);
 


### PR DESCRIPTION
I think `middlewares` is more reasonable for an array property, but this change may bring incompatible changes.