### PR TITLE
respond as instance method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -146,7 +146,7 @@ module.exports = class Application extends Emitter {
     const res = ctx.res;
     res.statusCode = 404;
     const onerror = err => ctx.onerror(err);
-    const handleResponse = () => respond(ctx);
+    const handleResponse = () => this.respond(ctx);
     onFinished(res, onerror);
     return fnMiddleware(ctx).then(handleResponse).catch(onerror);
   }
@@ -190,59 +190,61 @@ module.exports = class Application extends Emitter {
     console.error(msg.replace(/^/gm, '  '));
     console.error();
   }
-};
 
-/**
- * Response helper.
- */
+  /**
+  * Response helper.
+  * @param {Context} ctx
+  * @api private
+  */
 
-function respond(ctx) {
-  // allow bypassing koa
-  if (false === ctx.respond) return;
+  respond(ctx) {
+    // allow bypassing koa
+    if (false === ctx.respond) return;
 
-  if (!ctx.writable) return;
+    if (!ctx.writable) return;
 
-  const res = ctx.res;
-  let body = ctx.body;
-  const code = ctx.status;
+    const res = ctx.res;
+    let body = ctx.body;
+    const code = ctx.status;
 
-  // ignore body
-  if (statuses.empty[code]) {
-    // strip headers
-    ctx.body = null;
-    return res.end();
-  }
-
-  if ('HEAD' == ctx.method) {
-    if (!res.headersSent && isJSON(body)) {
-      ctx.length = Buffer.byteLength(JSON.stringify(body));
+    // ignore body
+    if (statuses.empty[code]) {
+      // strip headers
+      ctx.body = null;
+      return res.end();
     }
-    return res.end();
-  }
 
-  // status body
-  if (null == body) {
-    if (ctx.req.httpVersionMajor >= 2) {
-      body = String(code);
-    } else {
-      body = ctx.message || String(code);
+    if ('HEAD' == ctx.method) {
+      if (!res.headersSent && isJSON(body)) {
+        ctx.length = Buffer.byteLength(JSON.stringify(body));
+      }
+      return res.end();
     }
+
+    // status body
+    if (null == body) {
+      if (ctx.req.httpVersionMajor >= 2) {
+        body = String(code);
+      } else {
+        body = ctx.message || String(code);
+      }
+      if (!res.headersSent) {
+        ctx.type = 'text';
+        ctx.length = Buffer.byteLength(body);
+      }
+      return res.end(body);
+    }
+
+    // responses
+    if (Buffer.isBuffer(body)) return res.end(body);
+    if ('string' == typeof body) return res.end(body);
+    if (body instanceof Stream) return body.pipe(res);
+
+    // body: json
+    body = JSON.stringify(body);
     if (!res.headersSent) {
-      ctx.type = 'text';
       ctx.length = Buffer.byteLength(body);
     }
-    return res.end(body);
+    res.end(body);
   }
-
-  // responses
-  if (Buffer.isBuffer(body)) return res.end(body);
-  if ('string' == typeof body) return res.end(body);
-  if (body instanceof Stream) return body.pipe(res);
-
-  // body: json
-  body = JSON.stringify(body);
-  if (!res.headersSent) {
-    ctx.length = Buffer.byteLength(body);
-  }
-  res.end(body);
-}
+};


### PR DESCRIPTION
Per https://github.com/koajs/koa/issues/1019, this PR moves `respond` into the Application class so it can be subclassed or overridden. A couple use cases off the top of my head:
- specialized handling of additional types that may be in ctx.body
- ability to instrument serialization time for exceptionally large responses
- escape hatch for some [gripes](https://github.com/koajs/koa/issues/998) about Koa's existing responder