### PR TITLE
Change set status assert, use statuses when possible

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -83,8 +83,8 @@ module.exports = {
   set status(code) {
     if (this.headerSent) return;
 
-    assert('number' == typeof code, 'status code must be a number');
-    assert(statuses[code], `invalid status code: ${code}`);
+    assert(Number.isInteger(code), 'status code must be a number');
+    assert(code >= 100 && code <= 999, `invalid status code: ${code}`);
     this._explicitStatus = true;
     this.res.statusCode = code;
     if (this.req.httpVersionMajor < 2) this.res.statusMessage = statuses[code];

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -24,8 +24,8 @@ describe('res.status=', () => {
     describe('and invalid', () => {
       it('should throw', () => {
         assert.throws(() => {
-          response().status = 999;
-        }, /invalid status code: 999/);
+          response().status = 99;
+        }, /invalid status code: 99/);
       });
     });
 


### PR DESCRIPTION
Reference, #1119 #1042

This is a different approach to #1119 for allowing custom statuses. Instead of adding an API in Koa on top of statuses, just don't disallow anything unless it's a 3 digit integer.

This is a result from the fact that #1119 [got stale or never got any traction](https://github.com/koajs/koa/pull/1119#issuecomment-457650532), that statuses package can be ~~repopulated~~ added to by its design, [dead-horses comment](https://github.com/koajs/koa/issues/1042#issuecomment-455100429) about RFC and no real purpose to disallow custom statuses, and the fact that I personally dislike previous approaches.