### PR TITLE
remove cookies' detect secure for bug

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -160,8 +160,7 @@ const proto = module.exports = {
   get cookies() {
     if (!this[COOKIES]) {
       this[COOKIES] = new Cookies(this.req, this.res, {
-        keys: this.app.keys,
-        secure: this.request.secure
+        keys: this.app.keys
       });
     }
     return this[COOKIES];

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -89,7 +89,7 @@ describe('ctx.cookies', () => {
         const cookies = res.headers['set-cookie'];
         assert.equal(cookies.some(cookie => /^name=/.test(cookie)), true);
         assert.equal(cookies.some(cookie => /(,|^)name\.sig=/.test(cookie)), true);
-        assert.equal(cookies.every(cookie => /secure/.test(cookie)), true);
+        assert.equal(cookies.every(cookie => /secure/.test(cookie)), false);
       });
     });
   });


### PR DESCRIPTION

**Reproduce the bug:**

1. my web server support HTTP and HTTPS.
2. user visits HTTPS page.
    1. web server response the cookie `set-cookie: csrf_token=val; secure`.
    2. Chrome set cookie.
3. user visits new page(HTTP) in the same session.
    1. browser does not send the cookie(expected).
    2. web server response new cookie `set-cookie: csrf_token=val;`(expected).
    3. Chrome can not overwrite the cookie `csrf_token`(not my expected, but it is Specification) 

I think secure's default value should be false.

*Meybe secure detect is good idea, I suggest show in [document](https://koajs.com/#context)*

**[Specification](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-alone-01):**

> This document updates RFC6265 by removing the ability for a non-
   secure origin to set cookies with a 'secure' flag, and to overwrite
   cookies whose 'secure' flag is set.  This deprecation improves the
   isolation between HTTP and HTTPS origins, and reduces the risk of
   malicious interference.

[Chrome supported this Specification starting in Chrome 58](https://www.chromestatus.com/feature/4506322921848832)
