### PR TITLE
update devDependencies and fix discovered issues

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -13,7 +13,7 @@ console.log(`  ${n}${useAsync ? ' async' : ''} middleware`);
 
 while (n--) {
   if (useAsync) {
-    app.use(async (ctx, next) => await next());
+    app.use(async(ctx, next) => next());
   } else {
     app.use((ctx, next) => next());
   }
@@ -22,7 +22,7 @@ while (n--) {
 const body = Buffer.from('Hello World');
 
 if (useAsync) {
-  app.use(async (ctx, next) => { await next(); ctx.body = body; });
+  app.use(async(ctx, next) => { await next(); ctx.body = body; });
 } else {
   app.use((ctx, next) => next().then(() => ctx.body = body));
 }

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -130,7 +130,7 @@ Koa doesn't guard against everything that could be put as a response body -- a f
 app.use(async (ctx, next) => {
   await next()
 
-  ctx.assert.equal('object', typeof ctx, 500, 'some dev did something wrong')
+  ctx.assert.strictEqual('object', typeof ctx, 500, 'some dev did something wrong')
 })
 ```
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -180,7 +180,11 @@ module.exports = class Application extends Emitter {
    */
 
   onerror(err) {
-    if (!(err instanceof Error)) throw new TypeError(util.format('non-error thrown: %j', err));
+    // the jest vm may cause instanceof checks to fail e.g. fs ENOENT
+    // https://github.com/facebook/jest/issues/2549
+    if (!(err instanceof Error) && err.constructor.name !== 'Error') {
+      throw new TypeError(util.format('non-error thrown: %j', err));
+    }
 
     if (404 == err.status || err.expose) return;
     if (this.silent) return;

--- a/lib/context.js
+++ b/lib/context.js
@@ -110,7 +110,11 @@ const proto = module.exports = {
     // to node-style callbacks.
     if (null == err) return;
 
-    if (!(err instanceof Error)) err = new Error(util.format('non-error thrown: %j', err));
+    // the jest vm may cause instanceof checks to fail e.g. fs ENOENT
+    // https://github.com/facebook/jest/issues/2549
+    if (!(err instanceof Error) && err.constructor.name !== 'Error') {
+      err = new TypeError(util.format('non-error thrown: %j', err));
+    }
 
     let headerSent = false;
     if (this.headerSent || !this.writable) {
@@ -120,10 +124,10 @@ const proto = module.exports = {
     // delegate
     this.app.emit('error', err, this);
 
-    // nothing we can do here other
-    // than delegate to the app-level
-    // handler and log.
+    // the headers were sent but the body probably was not,
+    // so the connection is in an unknown state and should be closed
     if (headerSent) {
+      this.req.destroy();
       return;
     }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -48,7 +48,7 @@ module.exports = {
     const { res } = this;
     return typeof res.getHeaders === 'function'
       ? res.getHeaders()
-      : res._headers || {};  // Node < 7.7
+      : res._headers || {}; // Node < 7.7
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -48,13 +48,15 @@
     "vary": "^1.1.2"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^5.16.0",
     "eslint-config-koa": "^2.0.0",
-    "eslint-config-standard": "^7.0.1",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^2.1.1",
-    "jest": "^20.0.0",
-    "supertest": "^3.1.0"
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "jest": "^24.7.1",
+    "supertest": "^4.0.2"
   },
   "engines": {
     "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"

--- a/test/application/context.js
+++ b/test/application/context.js
@@ -12,7 +12,7 @@ describe('app.context', () => {
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
-      assert.equal(ctx.msg, 'hello');
+      assert.strictEqual(ctx.msg, 'hello');
       ctx.status = 204;
     });
 
@@ -23,7 +23,7 @@ describe('app.context', () => {
 
   it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
-      assert.equal(ctx.msg, undefined);
+      assert.strictEqual(ctx.msg, undefined);
       ctx.status = 204;
     });
 

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -15,7 +15,7 @@ describe('app', () => {
     });
 
     app.on('error', err => {
-      assert.equal(err.message, 'boom');
+      assert.strictEqual(err.message, 'boom');
       done();
     });
 
@@ -51,6 +51,6 @@ describe('app', () => {
     process.env.NODE_ENV = '';
     const app = new Koa();
     process.env.NODE_ENV = NODE_ENV;
-    assert.equal(app.env, 'development');
+    assert.strictEqual(app.env, 'development');
   });
 });

--- a/test/application/inspect.js
+++ b/test/application/inspect.js
@@ -9,11 +9,11 @@ const app = new Koa();
 describe('app.inspect()', () => {
   it('should work', () => {
     const str = util.inspect(app);
-    assert.equal("{ subdomainOffset: 2, proxy: false, env: 'test' }", str);
+    assert.strictEqual("{ subdomainOffset: 2, proxy: false, env: 'test' }", str);
   });
 
   it('should return a json representation', () => {
-    assert.deepEqual(
+    assert.deepStrictEqual(
       { subdomainOffset: 2, proxy: false, env: 'test' },
       app.inspect()
     );

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -29,7 +29,7 @@ describe('app.onerror(err)', () => {
 
     app.onerror(err);
 
-    assert.deepEqual(console.error.mock.calls, []);
+    assert.deepStrictEqual([...console.error.mock.calls], []);
   });
 
   it('should do nothing if .silent', () => {
@@ -39,7 +39,7 @@ describe('app.onerror(err)', () => {
 
     app.onerror(err);
 
-    assert.deepEqual(console.error.mock.calls, []);
+    assert.deepStrictEqual([...console.error.mock.calls], []);
   });
 
   it('should log the error to stderr', () => {
@@ -52,10 +52,10 @@ describe('app.onerror(err)', () => {
     app.onerror(err);
 
     const stderr = console.error.mock.calls.join('\n');
-    assert.deepEqual(stderr, '\n  Foo\n');
+    assert.deepStrictEqual(stderr, '\n  Foo\n');
   });
 
-  it('should use err.toString() instad of err.stack', () => {
+  it('should use err.toString() instead of err.stack', () => {
     const app = new Koa();
     app.env = 'dev';
 
@@ -65,6 +65,6 @@ describe('app.onerror(err)', () => {
     app.onerror(err);
 
     const stderr = console.error.mock.calls.join('\n');
-    assert.equal(stderr, '\n  Error: mock stack null\n');
+    assert.strictEqual(stderr, '\n  Error: mock stack null\n');
   });
 });

--- a/test/application/request.js
+++ b/test/application/request.js
@@ -12,7 +12,7 @@ describe('app.request', () => {
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
-      assert.equal(ctx.request.message, 'hello');
+      assert.strictEqual(ctx.request.message, 'hello');
       ctx.status = 204;
     });
 
@@ -23,7 +23,7 @@ describe('app.request', () => {
 
   it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
-      assert.equal(ctx.request.message, undefined);
+      assert.strictEqual(ctx.request.message, undefined);
       ctx.status = 204;
     });
 

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -32,9 +32,7 @@ describe('app.respond', () => {
         });
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect('lol');
@@ -53,9 +51,7 @@ describe('app.respond', () => {
         ctx.set('foo', 'bar');
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect('lol')
@@ -77,9 +73,7 @@ describe('app.respond', () => {
         ctx.status = 201;
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect('lol');
@@ -87,7 +81,7 @@ describe('app.respond', () => {
   });
 
   describe('when this.type === null', () => {
-    it('should not send Content-Type header', async () => {
+    it('should not send Content-Type header', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -95,86 +89,76 @@ describe('app.respond', () => {
         ctx.type = null;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(200);
 
-      assert.equal(res.headers.hasOwnProperty('Content-Type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('Content-Type'), false);
     });
   });
 
   describe('when HEAD is used', () => {
-    it('should not respond with the body', async () => {
+    it('should not respond with the body', async() => {
       const app = new Koa();
 
       app.use(ctx => {
         ctx.body = 'Hello';
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .head('/')
         .expect(200);
 
-      assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
-      assert.equal(res.headers['content-length'], '5');
+      assert.strictEqual(res.headers['content-type'], 'text/plain; charset=utf-8');
+      assert.strictEqual(res.headers['content-length'], '5');
       assert(!res.text);
     });
 
-    it('should keep json headers', async () => {
+    it('should keep json headers', async() => {
       const app = new Koa();
 
       app.use(ctx => {
         ctx.body = { hello: 'world' };
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .head('/')
         .expect(200);
 
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
-      assert.equal(res.headers['content-length'], '17');
+      assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8');
+      assert.strictEqual(res.headers['content-length'], '17');
       assert(!res.text);
     });
 
-    it('should keep string headers', async () => {
+    it('should keep string headers', async() => {
       const app = new Koa();
 
       app.use(ctx => {
         ctx.body = 'hello world';
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .head('/')
         .expect(200);
 
-      assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
-      assert.equal(res.headers['content-length'], '11');
+      assert.strictEqual(res.headers['content-type'], 'text/plain; charset=utf-8');
+      assert.strictEqual(res.headers['content-length'], '11');
       assert(!res.text);
     });
 
-    it('should keep buffer headers', async () => {
+    it('should keep buffer headers', async() => {
       const app = new Koa();
 
       app.use(ctx => {
         ctx.body = Buffer.from('hello world');
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .head('/')
         .expect(200);
 
-      assert.equal(res.headers['content-type'], 'application/octet-stream');
-      assert.equal(res.headers['content-length'], '11');
+      assert.strictEqual(res.headers['content-type'], 'application/octet-stream');
+      assert.strictEqual(res.headers['content-length'], '11');
       assert(!res.text);
     });
 
@@ -185,9 +169,7 @@ describe('app.respond', () => {
 
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .head('/')
         .expect(404);
     });
@@ -199,9 +181,7 @@ describe('app.respond', () => {
         ctx.body = '';
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .head('/')
         .expect(200);
     });
@@ -214,9 +194,7 @@ describe('app.respond', () => {
         ctx.type = 'application/javascript';
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .head('/')
         .expect('content-type', /application\/javascript/)
         .expect(200);
@@ -227,9 +205,7 @@ describe('app.respond', () => {
     it('should 404', () => {
       const app = new Koa();
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(404);
     });
@@ -249,9 +225,7 @@ describe('app.respond', () => {
 
       app.on('error', err => { throw err; });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200);
     });
@@ -272,9 +246,7 @@ describe('app.respond', () => {
         });
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect('HelloGoodbye');
@@ -290,9 +262,7 @@ describe('app.respond', () => {
           ctx.status = 400;
         });
 
-        const server = app.listen();
-
-        return request(server)
+        return request(app.callback())
           .get('/')
           .expect(400)
           .expect('Content-Length', '11')
@@ -301,64 +271,58 @@ describe('app.respond', () => {
     });
 
     describe('with status=204', () => {
-      it('should respond without a body', async () => {
+      it('should respond without a body', async() => {
         const app = new Koa();
 
         app.use(ctx => {
           ctx.status = 204;
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect(204)
           .expect('');
 
-        assert.equal(res.headers.hasOwnProperty('content-type'), false);
+        assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
       });
     });
 
     describe('with status=205', () => {
-      it('should respond without a body', async () => {
+      it('should respond without a body', async() => {
         const app = new Koa();
 
         app.use(ctx => {
           ctx.status = 205;
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect(205)
           .expect('');
 
-        assert.equal(res.headers.hasOwnProperty('content-type'), false);
+        assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
       });
     });
 
     describe('with status=304', () => {
-      it('should respond without a body', async () => {
+      it('should respond without a body', async() => {
         const app = new Koa();
 
         app.use(ctx => {
           ctx.status = 304;
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect(304)
           .expect('');
 
-        assert.equal(res.headers.hasOwnProperty('content-type'), false);
+        assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
       });
     });
 
     describe('with custom status=700', () => {
-      it('should respond with the associated status message', async () => {
+      it('should respond with the associated status message', async() => {
         const app = new Koa();
         statuses['700'] = 'custom status';
 
@@ -366,19 +330,17 @@ describe('app.respond', () => {
           ctx.status = 700;
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect(700)
           .expect('custom status');
 
-        assert.equal(res.res.statusMessage, 'custom status');
+        assert.strictEqual(res.res.statusMessage, 'custom status');
       });
     });
 
     describe('with custom statusMessage=ok', () => {
-      it('should respond with the custom status message', async () => {
+      it('should respond with the custom status message', async() => {
         const app = new Koa();
 
         app.use(ctx => {
@@ -386,14 +348,12 @@ describe('app.respond', () => {
           ctx.message = 'ok';
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect(200)
           .expect('ok');
 
-        assert.equal(res.res.statusMessage, 'ok');
+        assert.strictEqual(res.res.statusMessage, 'ok');
       });
     });
 
@@ -405,9 +365,7 @@ describe('app.respond', () => {
           ctx.res.statusCode = 701;
         });
 
-        const server = app.listen();
-
-        return request(server)
+        return request(app.callback())
           .get('/')
           .expect(701)
           .expect('701');
@@ -416,24 +374,22 @@ describe('app.respond', () => {
   });
 
   describe('when .body is a null', () => {
-    it('should respond 204 by default', async () => {
+    it('should respond 204 by default', async() => {
       const app = new Koa();
 
       app.use(ctx => {
         ctx.body = null;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(204)
         .expect('');
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
     });
 
-    it('should respond 204 with status=200', async () => {
+    it('should respond 204 with status=200', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -441,17 +397,15 @@ describe('app.respond', () => {
         ctx.body = null;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(204)
         .expect('');
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
     });
 
-    it('should respond 205 with status=205', async () => {
+    it('should respond 205 with status=205', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -459,17 +413,15 @@ describe('app.respond', () => {
         ctx.body = null;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(205)
         .expect('');
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
     });
 
-    it('should respond 304 with status=304', async () => {
+    it('should respond 304 with status=304', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -477,14 +429,12 @@ describe('app.respond', () => {
         ctx.body = null;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(304)
         .expect('');
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
     });
   });
 
@@ -496,9 +446,7 @@ describe('app.respond', () => {
         ctx.body = 'Hello';
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect('Hello');
     });
@@ -512,9 +460,7 @@ describe('app.respond', () => {
         ctx.body = Buffer.from('Hello');
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect(Buffer.from('Hello'));
@@ -522,7 +468,7 @@ describe('app.respond', () => {
   });
 
   describe('when .body is a Stream', () => {
-    it('should respond', async () => {
+    it('should respond', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -530,18 +476,16 @@ describe('app.respond', () => {
         ctx.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8');
 
       const pkg = require('../../package');
-      assert.equal(res.headers.hasOwnProperty('content-length'), false);
-      assert.deepEqual(res.body, pkg);
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
+      assert.deepStrictEqual(res.body, pkg);
     });
 
-    it('should strip content-length when overwriting', async () => {
+    it('should strip content-length when overwriting', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -550,18 +494,16 @@ describe('app.respond', () => {
         ctx.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8');
 
       const pkg = require('../../package');
-      assert.equal(res.headers.hasOwnProperty('content-length'), false);
-      assert.deepEqual(res.body, pkg);
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
+      assert.deepStrictEqual(res.body, pkg);
     });
 
-    it('should keep content-length if not overwritten', async () => {
+    it('should keep content-length if not overwritten', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -570,19 +512,17 @@ describe('app.respond', () => {
         ctx.set('Content-Type', 'application/json; charset=utf-8');
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8');
 
       const pkg = require('../../package');
-      assert.equal(res.headers.hasOwnProperty('content-length'), true);
-      assert.deepEqual(res.body, pkg);
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), true);
+      assert.deepStrictEqual(res.body, pkg);
     });
 
     it('should keep content-length if overwritten with the same stream',
-      async () => {
+      async() => {
         const app = new Koa();
 
         app.use(ctx => {
@@ -593,18 +533,16 @@ describe('app.respond', () => {
           ctx.set('Content-Type', 'application/json; charset=utf-8');
         });
 
-        const server = app.listen();
-
-        const res = await request(server)
+        const res = await request(app.callback())
           .get('/')
           .expect('Content-Type', 'application/json; charset=utf-8');
 
         const pkg = require('../../package');
-        assert.equal(res.headers.hasOwnProperty('content-length'), true);
-        assert.deepEqual(res.body, pkg);
+        assert.strictEqual(res.headers.hasOwnProperty('content-length'), true);
+        assert.deepStrictEqual(res.body, pkg);
       });
 
-    it('should handle errors', done => {
+    it('should handle errors', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -612,13 +550,10 @@ describe('app.respond', () => {
         ctx.body = fs.createReadStream('does not exist');
       });
 
-      const server = app.listen();
-
-      request(server)
+      await request(app.callback())
         .get('/')
         .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(404)
-        .end(done);
+        .expect(404);
     });
 
     it('should handle errors when no content status', () => {
@@ -629,9 +564,7 @@ describe('app.respond', () => {
         ctx.body = fs.createReadStream('does not exist');
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(204);
     });
@@ -645,9 +578,7 @@ describe('app.respond', () => {
         ctx.body = fs.createReadStream('does not exist');
       });
 
-      const server = app.listen();
-
-      request(server)
+      request(app.callback())
         .get('/')
         .expect(404)
         .end(done);
@@ -662,9 +593,7 @@ describe('app.respond', () => {
         ctx.body = { hello: 'world' };
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect('{"hello":"world"}');
@@ -680,7 +609,7 @@ describe('app.respond', () => {
       });
 
       app.on('error', err => {
-        assert.equal(err.message, 'boom');
+        assert.strictEqual(err.message, 'boom');
         done();
       });
 
@@ -729,9 +658,7 @@ describe('app.respond', () => {
         throw new Error('boom!');
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(500, 'Internal Server Error');
     });
@@ -751,9 +678,7 @@ describe('app.respond', () => {
         throw new Error('boom!');
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200, 'Got error');
     });
@@ -769,15 +694,13 @@ describe('app.respond', () => {
         ctx.status = 200;
       });
 
-      const server = app.listen();
-
-      return request(server)
+      return request(app.callback())
         .get('/')
         .expect(200)
         .expect('hello');
     });
 
-    it('should 204', async () => {
+    it('should 204', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -787,13 +710,11 @@ describe('app.respond', () => {
         ctx.status = 204;
       });
 
-      const server = app.listen();
-
-      const res = await request(server)
+      const res = await request(app.callback())
         .get('/')
         .expect(204);
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
     });
   });
 });

--- a/test/application/response.js
+++ b/test/application/response.js
@@ -13,7 +13,7 @@ describe('app.response', () => {
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
-      assert.equal(ctx.response.msg, 'hello');
+      assert.strictEqual(ctx.response.msg, 'hello');
       ctx.status = 204;
     });
 
@@ -24,7 +24,7 @@ describe('app.response', () => {
 
   it('should not affect the original prototype', () => {
     app2.use((ctx, next) => {
-      assert.equal(ctx.response.msg, undefined);
+      assert.strictEqual(ctx.response.msg, undefined);
       ctx.status = 204;
     });
 
@@ -33,7 +33,7 @@ describe('app.response', () => {
       .expect(204);
   });
 
-  it('should not include status message in body for http2', async () => {
+  it('should not include status message in body for http2', async() => {
     app3.use((ctx, next) => {
       ctx.req.httpVersionMajor = 2;
       ctx.status = 404;
@@ -41,6 +41,6 @@ describe('app.response', () => {
     const response = await request(app3.listen())
       .get('/')
       .expect(404);
-    assert.equal(response.text, '404');
+    assert.strictEqual(response.text, '404');
   });
 });

--- a/test/application/toJSON.js
+++ b/test/application/toJSON.js
@@ -9,7 +9,7 @@ describe('app.toJSON()', () => {
     const app = new Koa();
     const obj = app.toJSON();
 
-    assert.deepEqual({
+    assert.deepStrictEqual({
       subdomainOffset: 2,
       proxy: false,
       env: 'test'

--- a/test/application/use.js
+++ b/test/application/use.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const Koa = require('../..');
 
 describe('app.use(fn)', () => {
-  it('should compose middleware', async () => {
+  it('should compose middleware', async() => {
     const app = new Koa();
     const calls = [];
 
@@ -31,16 +31,14 @@ describe('app.use(fn)', () => {
       });
     });
 
-    const server = app.listen();
-
-    await request(server)
+    await request(app.callback())
       .get('/')
       .expect(404);
 
-    assert.deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+    assert.deepStrictEqual(calls, [1, 2, 3, 4, 5, 6]);
   });
 
-  it('should compose mixed middleware', async () => {
+  it('should compose mixed middleware', async() => {
     process.once('deprecation', () => {}); // silence deprecation message
     const app = new Koa();
     const calls = [];
@@ -65,20 +63,18 @@ describe('app.use(fn)', () => {
       });
     });
 
-    const server = app.listen();
-
-    await request(server)
+    await request(app.callback())
       .get('/')
       .expect(404);
 
-    assert.deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+    assert.deepStrictEqual(calls, [1, 2, 3, 4, 5, 6]);
   });
 
   // https://github.com/koajs/koa/pull/530#issuecomment-148138051
   it('should catch thrown errors in non-async functions', () => {
     const app = new Koa();
 
-    app.use(ctx => ctx.throw('Not Found', 404));
+    app.use(ctx => ctx.throw(404, 'Not Found'));
 
     return request(app.callback())
       .get('/')

--- a/test/context/assert.js
+++ b/test/context/assert.js
@@ -12,7 +12,7 @@ describe('ctx.assert(value, status)', () => {
       ctx.assert(false, 404);
       throw new Error('asdf');
     } catch (err) {
-      assert.equal(err.status, 404);
+      assert.strictEqual(err.status, 404);
       assert.strictEqual(err.expose, true);
     }
   });

--- a/test/context/cookies.js
+++ b/test/context/cookies.js
@@ -7,7 +7,7 @@ const Koa = require('../..');
 
 describe('ctx.cookies', () => {
   describe('ctx.cookies.set()', () => {
-    it('should set an unsigned cookie', async () => {
+    it('should set an unsigned cookie', async() => {
       const app = new Koa();
 
       app.use((ctx, next) => {
@@ -22,7 +22,7 @@ describe('ctx.cookies', () => {
         .expect(204);
 
       const cookie = res.headers['set-cookie'].some(cookie => /^name=/.test(cookie));
-      assert.equal(cookie, true);
+      assert.strictEqual(cookie, true);
     });
 
     describe('with .signed', () => {
@@ -44,7 +44,7 @@ describe('ctx.cookies', () => {
         });
       });
 
-      it('should send a signed cookie', async () => {
+      it('should send a signed cookie', async() => {
         const app = new Koa();
 
         app.keys = ['a', 'b'];
@@ -62,13 +62,13 @@ describe('ctx.cookies', () => {
 
         const cookies = res.headers['set-cookie'];
 
-        assert.equal(cookies.some(cookie => /^name=/.test(cookie)), true);
-        assert.equal(cookies.some(cookie => /(,|^)name\.sig=/.test(cookie)), true);
+        assert.strictEqual(cookies.some(cookie => /^name=/.test(cookie)), true);
+        assert.strictEqual(cookies.some(cookie => /(,|^)name\.sig=/.test(cookie)), true);
       });
     });
 
     describe('with secure', () => {
-      it('should get secure from request', async () => {
+      it('should get secure from request', async() => {
         const app = new Koa();
 
         app.proxy = true;
@@ -87,15 +87,15 @@ describe('ctx.cookies', () => {
           .expect(204);
 
         const cookies = res.headers['set-cookie'];
-        assert.equal(cookies.some(cookie => /^name=/.test(cookie)), true);
-        assert.equal(cookies.some(cookie => /(,|^)name\.sig=/.test(cookie)), true);
-        assert.equal(cookies.every(cookie => /secure/.test(cookie)), true);
+        assert.strictEqual(cookies.some(cookie => /^name=/.test(cookie)), true);
+        assert.strictEqual(cookies.some(cookie => /(,|^)name\.sig=/.test(cookie)), true);
+        assert.strictEqual(cookies.every(cookie => /secure/.test(cookie)), true);
       });
     });
   });
 
   describe('ctx.cookies=', () => {
-    it('should override cookie work', async () => {
+    it('should override cookie work', async() => {
       const app = new Koa();
 
       app.use((ctx, next) => {

--- a/test/context/inspect.js
+++ b/test/context/inspect.js
@@ -11,13 +11,13 @@ describe('ctx.inspect()', () => {
     const ctx = context();
     const toJSON = ctx.toJSON(ctx);
 
-    assert.deepEqual(toJSON, ctx.inspect());
-    assert.deepEqual(util.inspect(toJSON), util.inspect(ctx));
+    assert.deepStrictEqual(toJSON, ctx.inspect());
+    assert.deepStrictEqual(util.inspect(toJSON), util.inspect(ctx));
   });
 
   // console.log(require.cache) will call prototype.inspect()
   it('should not crash when called on the prototype', () => {
-    assert.deepEqual(prototype, prototype.inspect());
-    assert.deepEqual(util.inspect(prototype.inspect()), util.inspect(prototype));
+    assert.deepStrictEqual(prototype, prototype.inspect());
+    assert.deepStrictEqual(util.inspect(prototype.inspect()), util.inspect(prototype));
   });
 });

--- a/test/context/state.js
+++ b/test/context/state.js
@@ -10,7 +10,7 @@ describe('ctx.state', () => {
     const app = new Koa();
 
     app.use(ctx => {
-      assert.deepEqual(ctx.state, {});
+      assert.deepStrictEqual(ctx.state, {});
     });
 
     const server = app.listen();

--- a/test/context/throw.js
+++ b/test/context/throw.js
@@ -11,8 +11,8 @@ describe('ctx.throw(msg)', () => {
     try {
       ctx.throw('boom');
     } catch (err) {
-      assert.equal(err.status, 500);
-      assert.equal(err.expose, false);
+      assert.strictEqual(err.status, 500);
+      assert.strictEqual(err.expose, false);
     }
   });
 });
@@ -25,9 +25,9 @@ describe('ctx.throw(err)', () => {
     try {
       ctx.throw(err);
     } catch (err) {
-      assert.equal(err.status, 500);
-      assert.equal(err.message, 'test');
-      assert.equal(err.expose, false);
+      assert.strictEqual(err.status, 500);
+      assert.strictEqual(err.message, 'test');
+      assert.strictEqual(err.expose, false);
     }
   });
 });
@@ -40,9 +40,9 @@ describe('ctx.throw(err, status)', () => {
     try {
       ctx.throw(error, 422);
     } catch (err) {
-      assert.equal(err.status, 422);
-      assert.equal(err.message, 'test');
-      assert.equal(err.expose, true);
+      assert.strictEqual(err.status, 422);
+      assert.strictEqual(err.message, 'test');
+      assert.strictEqual(err.expose, true);
     }
   });
 });
@@ -55,9 +55,9 @@ describe('ctx.throw(status, err)', () => {
     try {
       ctx.throw(422, error);
     } catch (err) {
-      assert.equal(err.status, 422);
-      assert.equal(err.message, 'test');
-      assert.equal(err.expose, true);
+      assert.strictEqual(err.status, 422);
+      assert.strictEqual(err.message, 'test');
+      assert.strictEqual(err.expose, true);
     }
   });
 });
@@ -69,9 +69,9 @@ describe('ctx.throw(msg, status)', () => {
     try {
       ctx.throw('name required', 400);
     } catch (err) {
-      assert.equal(err.message, 'name required');
-      assert.equal(err.status, 400);
-      assert.equal(err.expose, true);
+      assert.strictEqual(err.message, 'name required');
+      assert.strictEqual(err.status, 400);
+      assert.strictEqual(err.expose, true);
     }
   });
 });
@@ -83,9 +83,9 @@ describe('ctx.throw(status, msg)', () => {
     try {
       ctx.throw(400, 'name required');
     } catch (err) {
-      assert.equal(err.message, 'name required');
-      assert.equal(400, err.status);
-      assert.equal(true, err.expose);
+      assert.strictEqual(err.message, 'name required');
+      assert.strictEqual(400, err.status);
+      assert.strictEqual(true, err.expose);
     }
   });
 });
@@ -97,9 +97,9 @@ describe('ctx.throw(status)', () => {
     try {
       ctx.throw(400);
     } catch (err) {
-      assert.equal(err.message, 'Bad Request');
-      assert.equal(err.status, 400);
-      assert.equal(err.expose, true);
+      assert.strictEqual(err.message, 'Bad Request');
+      assert.strictEqual(err.status, 400);
+      assert.strictEqual(err.expose, true);
     }
   });
 
@@ -112,8 +112,8 @@ describe('ctx.throw(status)', () => {
         err.status = -1;
         ctx.throw(err);
       } catch (err) {
-        assert.equal(err.message, 'some error');
-        assert.equal(err.expose, false);
+        assert.strictEqual(err.message, 'some error');
+        assert.strictEqual(err.expose, false);
       }
     });
   });
@@ -126,10 +126,10 @@ describe('ctx.throw(status, msg, props)', () => {
     try {
       ctx.throw(400, 'msg', { prop: true });
     } catch (err) {
-      assert.equal(err.message, 'msg');
-      assert.equal(err.status, 400);
-      assert.equal(err.expose, true);
-      assert.equal(err.prop, true);
+      assert.strictEqual(err.message, 'msg');
+      assert.strictEqual(err.status, 400);
+      assert.strictEqual(err.expose, true);
+      assert.strictEqual(err.prop, true);
     }
   });
 
@@ -143,10 +143,10 @@ describe('ctx.throw(status, msg, props)', () => {
           status: -1
         });
       } catch (err) {
-        assert.equal(err.message, 'msg');
-        assert.equal(err.status, 400);
-        assert.equal(err.expose, true);
-        assert.equal(err.prop, true);
+        assert.strictEqual(err.message, 'msg');
+        assert.strictEqual(err.status, 400);
+        assert.strictEqual(err.expose, true);
+        assert.strictEqual(err.prop, true);
       }
     });
   });
@@ -159,10 +159,10 @@ describe('ctx.throw(msg, props)', () => {
     try {
       ctx.throw('msg', { prop: true });
     } catch (err) {
-      assert.equal(err.message, 'msg');
-      assert.equal(err.status, 500);
-      assert.equal(err.expose, false);
-      assert.equal(err.prop, true);
+      assert.strictEqual(err.message, 'msg');
+      assert.strictEqual(err.status, 500);
+      assert.strictEqual(err.expose, false);
+      assert.strictEqual(err.prop, true);
     }
   });
 });
@@ -174,10 +174,10 @@ describe('ctx.throw(status, props)', () => {
     try {
       ctx.throw(400, { prop: true });
     } catch (err) {
-      assert.equal(err.message, 'Bad Request');
-      assert.equal(err.status, 400);
-      assert.equal(err.expose, true);
-      assert.equal(err.prop, true);
+      assert.strictEqual(err.message, 'Bad Request');
+      assert.strictEqual(err.status, 400);
+      assert.strictEqual(err.expose, true);
+      assert.strictEqual(err.prop, true);
     }
   });
 });
@@ -189,10 +189,10 @@ describe('ctx.throw(err, props)', () => {
     try {
       ctx.throw(new Error('test'), { prop: true });
     } catch (err) {
-      assert.equal(err.message, 'test');
-      assert.equal(err.status, 500);
-      assert.equal(err.expose, false);
-      assert.equal(err.prop, true);
+      assert.strictEqual(err.message, 'test');
+      assert.strictEqual(err.status, 500);
+      assert.strictEqual(err.expose, false);
+      assert.strictEqual(err.prop, true);
     }
   });
 });

--- a/test/context/toJSON.js
+++ b/test/context/toJSON.js
@@ -18,7 +18,7 @@ describe('ctx.toJSON()', () => {
     const req = obj.request;
     const res = obj.response;
 
-    assert.deepEqual({
+    assert.deepStrictEqual({
       method: 'POST',
       url: '/items',
       header: {
@@ -26,7 +26,7 @@ describe('ctx.toJSON()', () => {
       }
     }, req);
 
-    assert.deepEqual({
+    assert.deepStrictEqual({
       status: 200,
       message: 'OK',
       header: {

--- a/test/request/accept.js
+++ b/test/request/accept.js
@@ -17,11 +17,11 @@ describe('ctx.accept=', () => {
   it('should replace the accept object', () => {
     const ctx = context();
     ctx.req.headers.accept = 'text/plain';
-    assert.deepEqual(ctx.accepts(), ['text/plain']);
+    assert.deepStrictEqual(ctx.accepts(), ['text/plain']);
 
     const request = context.request();
     request.req.headers.accept = 'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
     ctx.accept = Accept(request.req);
-    assert.deepEqual(ctx.accepts(), ['text/html', 'text/plain', 'image/jpeg', 'application/*']);
+    assert.deepStrictEqual(ctx.accepts(), ['text/html', 'text/plain', 'image/jpeg', 'application/*']);
   });
 });

--- a/test/request/accepts.js
+++ b/test/request/accepts.js
@@ -10,7 +10,7 @@ describe('ctx.accepts(types)', () => {
       it('should return all accepted types', () => {
         const ctx = context();
         ctx.req.headers.accept = 'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
-        assert.deepEqual(ctx.accepts(), ['text/html', 'text/plain', 'image/jpeg', 'application/*']);
+        assert.deepStrictEqual(ctx.accepts(), ['text/html', 'text/plain', 'image/jpeg', 'application/*']);
       });
     });
   });
@@ -20,14 +20,14 @@ describe('ctx.accepts(types)', () => {
       it('should return false', () => {
         const ctx = context();
         ctx.req.headers.accept = 'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
-        assert.equal(ctx.accepts('image/png', 'image/tiff'), false);
+        assert.strictEqual(ctx.accepts('image/png', 'image/tiff'), false);
       });
     });
 
     describe('when Accept is not populated', () => {
       it('should return the first type', () => {
         const ctx = context();
-        assert.equal(ctx.accepts('text/html', 'text/plain', 'image/jpeg', 'application/*'), 'text/html');
+        assert.strictEqual(ctx.accepts('text/html', 'text/plain', 'image/jpeg', 'application/*'), 'text/html');
       });
     });
   });
@@ -36,11 +36,11 @@ describe('ctx.accepts(types)', () => {
     it('should convert to mime types', () => {
       const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
-      assert.equal(ctx.accepts('html'), 'html');
-      assert.equal(ctx.accepts('.html'), '.html');
-      assert.equal(ctx.accepts('txt'), 'txt');
-      assert.equal(ctx.accepts('.txt'), '.txt');
-      assert.equal(ctx.accepts('png'), false);
+      assert.strictEqual(ctx.accepts('html'), 'html');
+      assert.strictEqual(ctx.accepts('.html'), '.html');
+      assert.strictEqual(ctx.accepts('txt'), 'txt');
+      assert.strictEqual(ctx.accepts('.txt'), '.txt');
+      assert.strictEqual(ctx.accepts('png'), false);
     });
   });
 
@@ -48,8 +48,8 @@ describe('ctx.accepts(types)', () => {
     it('should return the first match', () => {
       const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
-      assert.equal(ctx.accepts(['png', 'text', 'html']), 'text');
-      assert.equal(ctx.accepts(['png', 'html']), 'html');
+      assert.strictEqual(ctx.accepts(['png', 'text', 'html']), 'text');
+      assert.strictEqual(ctx.accepts(['png', 'html']), 'html');
     });
   });
 
@@ -57,8 +57,8 @@ describe('ctx.accepts(types)', () => {
     it('should return the first match', () => {
       const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
-      assert.equal(ctx.accepts('png', 'text', 'html'), 'text');
-      assert.equal(ctx.accepts('png', 'html'), 'html');
+      assert.strictEqual(ctx.accepts('png', 'text', 'html'), 'text');
+      assert.strictEqual(ctx.accepts('png', 'html'), 'html');
     });
   });
 
@@ -66,8 +66,8 @@ describe('ctx.accepts(types)', () => {
     it('should return the type', () => {
       const ctx = context();
       ctx.req.headers.accept = 'text/plain, text/html';
-      assert.equal(ctx.accepts('text/html'), 'text/html');
-      assert.equal(ctx.accepts('text/plain'), 'text/plain');
+      assert.strictEqual(ctx.accepts('text/html'), 'text/html');
+      assert.strictEqual(ctx.accepts('text/plain'), 'text/plain');
     });
   });
 
@@ -75,9 +75,9 @@ describe('ctx.accepts(types)', () => {
     it('should return the type', () => {
       const ctx = context();
       ctx.req.headers.accept = 'application/json, */*';
-      assert.equal(ctx.accepts('text/html'), 'text/html');
-      assert.equal(ctx.accepts('text/plain'), 'text/plain');
-      assert.equal(ctx.accepts('image/png'), 'image/png');
+      assert.strictEqual(ctx.accepts('text/html'), 'text/html');
+      assert.strictEqual(ctx.accepts('text/plain'), 'text/plain');
+      assert.strictEqual(ctx.accepts('image/png'), 'image/png');
     });
   });
 
@@ -85,10 +85,10 @@ describe('ctx.accepts(types)', () => {
     it('should return the type', () => {
       const ctx = context();
       ctx.req.headers.accept = 'application/json, text/*';
-      assert.equal(ctx.accepts('text/html'), 'text/html');
-      assert.equal(ctx.accepts('text/plain'), 'text/plain');
-      assert.equal(ctx.accepts('image/png'), false);
-      assert.equal(ctx.accepts('png'), false);
+      assert.strictEqual(ctx.accepts('text/html'), 'text/html');
+      assert.strictEqual(ctx.accepts('text/plain'), 'text/plain');
+      assert.strictEqual(ctx.accepts('image/png'), false);
+      assert.strictEqual(ctx.accepts('png'), false);
     });
   });
 });

--- a/test/request/acceptsCharsets.js
+++ b/test/request/acceptsCharsets.js
@@ -10,7 +10,7 @@ describe('ctx.acceptsCharsets()', () => {
       it('should return accepted types', () => {
         const ctx = context();
         ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
-        assert.deepEqual(ctx.acceptsCharsets(), ['utf-8', 'utf-7', 'iso-8859-1']);
+        assert.deepStrictEqual(ctx.acceptsCharsets(), ['utf-8', 'utf-7', 'iso-8859-1']);
       });
     });
   });
@@ -21,7 +21,7 @@ describe('ctx.acceptsCharsets()', () => {
         it('should return the best fit', () => {
           const ctx = context();
           ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
-          assert.equal(ctx.acceptsCharsets('utf-7', 'utf-8'), 'utf-8');
+          assert.strictEqual(ctx.acceptsCharsets('utf-7', 'utf-8'), 'utf-8');
         });
       });
 
@@ -29,7 +29,7 @@ describe('ctx.acceptsCharsets()', () => {
         it('should return false', () => {
           const ctx = context();
           ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
-          assert.equal(ctx.acceptsCharsets('utf-16'), false);
+          assert.strictEqual(ctx.acceptsCharsets('utf-16'), false);
         });
       });
     });
@@ -37,7 +37,7 @@ describe('ctx.acceptsCharsets()', () => {
     describe('when Accept-Charset is not populated', () => {
       it('should return the first type', () => {
         const ctx = context();
-        assert.equal(ctx.acceptsCharsets('utf-7', 'utf-8'), 'utf-7');
+        assert.strictEqual(ctx.acceptsCharsets('utf-7', 'utf-8'), 'utf-7');
       });
     });
   });
@@ -46,7 +46,7 @@ describe('ctx.acceptsCharsets()', () => {
     it('should return the best fit', () => {
       const ctx = context();
       ctx.req.headers['accept-charset'] = 'utf-8, iso-8859-1;q=0.2, utf-7;q=0.5';
-      assert.equal(ctx.acceptsCharsets(['utf-7', 'utf-8']), 'utf-8');
+      assert.strictEqual(ctx.acceptsCharsets(['utf-7', 'utf-8']), 'utf-8');
     });
   });
 });

--- a/test/request/acceptsEncodings.js
+++ b/test/request/acceptsEncodings.js
@@ -10,16 +10,16 @@ describe('ctx.acceptsEncodings()', () => {
       it('should return accepted types', () => {
         const ctx = context();
         ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
-        assert.deepEqual(ctx.acceptsEncodings(), ['gzip', 'compress', 'identity']);
-        assert.equal(ctx.acceptsEncodings('gzip', 'compress'), 'gzip');
+        assert.deepStrictEqual(ctx.acceptsEncodings(), ['gzip', 'compress', 'identity']);
+        assert.strictEqual(ctx.acceptsEncodings('gzip', 'compress'), 'gzip');
       });
     });
 
     describe('when Accept-Encoding is not populated', () => {
       it('should return identity', () => {
         const ctx = context();
-        assert.deepEqual(ctx.acceptsEncodings(), ['identity']);
-        assert.equal(ctx.acceptsEncodings('gzip', 'deflate', 'identity'), 'identity');
+        assert.deepStrictEqual(ctx.acceptsEncodings(), ['identity']);
+        assert.strictEqual(ctx.acceptsEncodings('gzip', 'deflate', 'identity'), 'identity');
       });
     });
   });
@@ -28,8 +28,8 @@ describe('ctx.acceptsEncodings()', () => {
     it('should return the best fit', () => {
       const ctx = context();
       ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
-      assert.equal(ctx.acceptsEncodings('compress', 'gzip'), 'gzip');
-      assert.equal(ctx.acceptsEncodings('gzip', 'compress'), 'gzip');
+      assert.strictEqual(ctx.acceptsEncodings('compress', 'gzip'), 'gzip');
+      assert.strictEqual(ctx.acceptsEncodings('gzip', 'compress'), 'gzip');
     });
   });
 
@@ -37,7 +37,7 @@ describe('ctx.acceptsEncodings()', () => {
     it('should return the best fit', () => {
       const ctx = context();
       ctx.req.headers['accept-encoding'] = 'gzip, compress;q=0.2';
-      assert.equal(ctx.acceptsEncodings(['compress', 'gzip']), 'gzip');
+      assert.strictEqual(ctx.acceptsEncodings(['compress', 'gzip']), 'gzip');
     });
   });
 });

--- a/test/request/acceptsLanguages.js
+++ b/test/request/acceptsLanguages.js
@@ -10,7 +10,7 @@ describe('ctx.acceptsLanguages(langs)', () => {
       it('should return accepted types', () => {
         const ctx = context();
         ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
-        assert.deepEqual(ctx.acceptsLanguages(), ['es', 'pt', 'en']);
+        assert.deepStrictEqual(ctx.acceptsLanguages(), ['es', 'pt', 'en']);
       });
     });
   });
@@ -21,7 +21,7 @@ describe('ctx.acceptsLanguages(langs)', () => {
         it('should return the best fit', () => {
           const ctx = context();
           ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
-          assert.equal(ctx.acceptsLanguages('es', 'en'), 'es');
+          assert.strictEqual(ctx.acceptsLanguages('es', 'en'), 'es');
         });
       });
 
@@ -29,7 +29,7 @@ describe('ctx.acceptsLanguages(langs)', () => {
         it('should return false', () => {
           const ctx = context();
           ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
-          assert.equal(ctx.acceptsLanguages('fr', 'au'), false);
+          assert.strictEqual(ctx.acceptsLanguages('fr', 'au'), false);
         });
       });
     });
@@ -37,7 +37,7 @@ describe('ctx.acceptsLanguages(langs)', () => {
     describe('when Accept-Language is not populated', () => {
       it('should return the first type', () => {
         const ctx = context();
-        assert.equal(ctx.acceptsLanguages('es', 'en'), 'es');
+        assert.strictEqual(ctx.acceptsLanguages('es', 'en'), 'es');
       });
     });
   });
@@ -46,7 +46,7 @@ describe('ctx.acceptsLanguages(langs)', () => {
     it('should return the best fit', () => {
       const ctx = context();
       ctx.req.headers['accept-language'] = 'en;q=0.8, es, pt';
-      assert.equal(ctx.acceptsLanguages(['es', 'en']), 'es');
+      assert.strictEqual(ctx.acceptsLanguages(['es', 'en']), 'es');
     });
   });
 });

--- a/test/request/charset.js
+++ b/test/request/charset.js
@@ -24,13 +24,13 @@ describe('req.charset', () => {
     it('should return the charset', () => {
       const req = request();
       req.header['content-type'] = 'text/plain; charset=utf-8';
-      assert.equal(req.charset, 'utf-8');
+      assert.strictEqual(req.charset, 'utf-8');
     });
 
     it('should return "" if content-type is invalid', () => {
       const req = request();
       req.header['content-type'] = 'application/json; application/text; charset=utf-8';
-      assert.equal(req.charset, '');
+      assert.strictEqual(req.charset, '');
     });
   });
 });

--- a/test/request/fresh.js
+++ b/test/request/fresh.js
@@ -9,7 +9,7 @@ describe('ctx.fresh', () => {
     it('should return false', () => {
       const ctx = context();
       ctx.req.method = 'POST';
-      assert.equal(ctx.fresh, false);
+      assert.strictEqual(ctx.fresh, false);
     });
   });
 
@@ -20,7 +20,7 @@ describe('ctx.fresh', () => {
       ctx.req.method = 'GET';
       ctx.req.headers['if-none-match'] = '123';
       ctx.set('ETag', '123');
-      assert.equal(ctx.fresh, false);
+      assert.strictEqual(ctx.fresh, false);
     });
   });
 
@@ -32,7 +32,7 @@ describe('ctx.fresh', () => {
         ctx.req.method = 'GET';
         ctx.req.headers['if-none-match'] = '123';
         ctx.set('ETag', '123');
-        assert.equal(ctx.fresh, true);
+        assert.strictEqual(ctx.fresh, true);
       });
     });
 
@@ -43,7 +43,7 @@ describe('ctx.fresh', () => {
         ctx.req.method = 'GET';
         ctx.req.headers['if-none-match'] = '123';
         ctx.set('ETag', 'hey');
-        assert.equal(ctx.fresh, false);
+        assert.strictEqual(ctx.fresh, false);
       });
     });
   });

--- a/test/request/get.js
+++ b/test/request/get.js
@@ -9,10 +9,10 @@ describe('ctx.get(name)', () => {
     const ctx = context();
     ctx.req.headers.host = 'http://google.com';
     ctx.req.headers.referer = 'http://google.com';
-    assert.equal(ctx.get('HOST'), 'http://google.com');
-    assert.equal(ctx.get('Host'), 'http://google.com');
-    assert.equal(ctx.get('host'), 'http://google.com');
-    assert.equal(ctx.get('referer'), 'http://google.com');
-    assert.equal(ctx.get('referrer'), 'http://google.com');
+    assert.strictEqual(ctx.get('HOST'), 'http://google.com');
+    assert.strictEqual(ctx.get('Host'), 'http://google.com');
+    assert.strictEqual(ctx.get('host'), 'http://google.com');
+    assert.strictEqual(ctx.get('referer'), 'http://google.com');
+    assert.strictEqual(ctx.get('referrer'), 'http://google.com');
   });
 });

--- a/test/request/header.js
+++ b/test/request/header.js
@@ -7,12 +7,12 @@ const request = require('../helpers/context').request;
 describe('req.header', () => {
   it('should return the request header object', () => {
     const req = request();
-    assert.deepEqual(req.header, req.req.headers);
+    assert.deepStrictEqual(req.header, req.req.headers);
   });
 
   it('should set the request header object', () => {
     const req = request();
-    req.header = {'X-Custom-Headerfield': 'Its one header, with headerfields'};
-    assert.deepEqual(req.header, req.req.headers);
+    req.header = { 'X-Custom-Headerfield': 'Its one header, with headerfields' };
+    assert.deepStrictEqual(req.header, req.req.headers);
   });
 });

--- a/test/request/headers.js
+++ b/test/request/headers.js
@@ -7,12 +7,12 @@ const request = require('../helpers/context').request;
 describe('req.headers', () => {
   it('should return the request header object', () => {
     const req = request();
-    assert.deepEqual(req.headers, req.req.headers);
+    assert.deepStrictEqual(req.headers, req.req.headers);
   });
 
   it('should set the request header object', () => {
     const req = request();
-    req.headers = {'X-Custom-Headerfield': 'Its one header, with headerfields'};
-    assert.deepEqual(req.headers, req.req.headers);
+    req.headers = { 'X-Custom-Headerfield': 'Its one header, with headerfields' };
+    assert.deepStrictEqual(req.headers, req.req.headers);
   });
 });

--- a/test/request/host.js
+++ b/test/request/host.js
@@ -8,13 +8,13 @@ describe('req.host', () => {
   it('should return host with port', () => {
     const req = request();
     req.header.host = 'foo.com:3000';
-    assert.equal(req.host, 'foo.com:3000');
+    assert.strictEqual(req.host, 'foo.com:3000');
   });
 
   describe('with no host present', () => {
     it('should return ""', () => {
       const req = request();
-      assert.equal(req.host, '');
+      assert.strictEqual(req.host, '');
     });
   });
 
@@ -26,7 +26,7 @@ describe('req.host', () => {
       });
       req.header[':authority'] = 'foo.com:3000';
       req.header.host = 'bar.com:8000';
-      assert.equal(req.host, 'bar.com:8000');
+      assert.strictEqual(req.host, 'bar.com:8000');
     });
   });
 
@@ -38,7 +38,7 @@ describe('req.host', () => {
       });
       req.header[':authority'] = 'foo.com:3000';
       req.header.host = 'bar.com:8000';
-      assert.equal(req.host, 'foo.com:3000');
+      assert.strictEqual(req.host, 'foo.com:3000');
     });
 
     it('should use host header as fallback', () => {
@@ -47,7 +47,7 @@ describe('req.host', () => {
         'httpVersion': '2.0'
       });
       req.header.host = 'bar.com:8000';
-      assert.equal(req.host, 'bar.com:8000');
+      assert.strictEqual(req.host, 'bar.com:8000');
     });
   });
 
@@ -57,7 +57,7 @@ describe('req.host', () => {
         const req = request();
         req.header['x-forwarded-host'] = 'bar.com';
         req.header.host = 'foo.com';
-        assert.equal(req.host, 'foo.com');
+        assert.strictEqual(req.host, 'foo.com');
       });
 
       it('should be ignored on HTTP/2', () => {
@@ -68,7 +68,7 @@ describe('req.host', () => {
         req.header['x-forwarded-host'] = 'proxy.com:8080';
         req.header[':authority'] = 'foo.com:3000';
         req.header.host = 'bar.com:8000';
-        assert.equal(req.host, 'foo.com:3000');
+        assert.strictEqual(req.host, 'foo.com:3000');
       });
     });
 
@@ -78,7 +78,7 @@ describe('req.host', () => {
         req.app.proxy = true;
         req.header['x-forwarded-host'] = 'bar.com, baz.com';
         req.header.host = 'foo.com';
-        assert.equal(req.host, 'bar.com');
+        assert.strictEqual(req.host, 'bar.com');
       });
 
       it('should be used on HTTP/2', () => {
@@ -90,7 +90,7 @@ describe('req.host', () => {
         req.header['x-forwarded-host'] = 'proxy.com:8080';
         req.header[':authority'] = 'foo.com:3000';
         req.header.host = 'bar.com:8000';
-        assert.equal(req.host, 'proxy.com:8080');
+        assert.strictEqual(req.host, 'proxy.com:8080');
       });
     });
   });

--- a/test/request/hostname.js
+++ b/test/request/hostname.js
@@ -8,13 +8,13 @@ describe('req.hostname', () => {
   it('should return hostname void of port', () => {
     const req = request();
     req.header.host = 'foo.com:3000';
-    assert.equal(req.hostname, 'foo.com');
+    assert.strictEqual(req.hostname, 'foo.com');
   });
 
   describe('with no host present', () => {
     it('should return ""', () => {
       const req = request();
-      assert.equal(req.hostname, '');
+      assert.strictEqual(req.hostname, '');
     });
   });
 
@@ -22,31 +22,31 @@ describe('req.hostname', () => {
     it('should parse localhost void of port', () => {
       const req = request();
       req.header.host = '[::1]';
-      assert.equal(req.hostname, '[::1]');
+      assert.strictEqual(req.hostname, '[::1]');
     });
 
     it('should parse localhost with port 80', () => {
       const req = request();
       req.header.host = '[::1]:80';
-      assert.equal(req.hostname, '[::1]');
+      assert.strictEqual(req.hostname, '[::1]');
     });
 
     it('should parse localhost with non special schema port', () => {
       const req = request();
       req.header.host = '[::1]:1337';
-      assert.equal(req.hostname, '[::1]');
+      assert.strictEqual(req.hostname, '[::1]');
     });
 
     it('should reduce IPv6 with non special schema port, as hostname', () => {
       const req = request();
       req.header.host = '[2001:cdba:0000:0000:0000:0000:3257:9652]:1337';
-      assert.equal(req.hostname, '[2001:cdba::3257:9652]');
+      assert.strictEqual(req.hostname, '[2001:cdba::3257:9652]');
     });
 
     it('should return empty string when invalid', () => {
       const req = request();
       req.header.host = '[invalidIPv6]';
-      assert.equal(req.hostname, '');
+      assert.strictEqual(req.hostname, '');
     });
   });
 
@@ -56,7 +56,7 @@ describe('req.hostname', () => {
         const req = request();
         req.header['x-forwarded-host'] = 'bar.com';
         req.header.host = 'foo.com';
-        assert.equal(req.hostname, 'foo.com');
+        assert.strictEqual(req.hostname, 'foo.com');
       });
     });
 
@@ -66,7 +66,7 @@ describe('req.hostname', () => {
         req.app.proxy = true;
         req.header['x-forwarded-host'] = 'bar.com, baz.com';
         req.header.host = 'foo.com';
-        assert.equal(req.hostname, 'bar.com');
+        assert.strictEqual(req.hostname, 'bar.com');
       });
     });
   });

--- a/test/request/href.js
+++ b/test/request/href.js
@@ -19,10 +19,10 @@ describe('ctx.href', () => {
       __proto__: Stream.Readable.prototype
     };
     const ctx = context(req);
-    assert.equal(ctx.href, 'http://localhost/users/1?next=/dashboard');
+    assert.strictEqual(ctx.href, 'http://localhost/users/1?next=/dashboard');
     // change it also work
     ctx.url = '/foo/users/1?next=/dashboard';
-    assert.equal(ctx.href, 'http://localhost/users/1?next=/dashboard');
+    assert.strictEqual(ctx.href, 'http://localhost/users/1?next=/dashboard');
   });
 
   it('should work with `GET http://example.com/foo`', done => {
@@ -37,12 +37,12 @@ describe('ctx.href', () => {
         path: 'http://example.com/foo',
         port: address.port
       }, res => {
-        assert.equal(res.statusCode, 200);
+        assert.strictEqual(res.statusCode, 200);
         let buf = '';
         res.setEncoding('utf8');
         res.on('data', s => buf += s);
         res.on('end', () => {
-          assert.equal(buf, 'http://example.com/foo');
+          assert.strictEqual(buf, 'http://example.com/foo');
           done();
         });
       });

--- a/test/request/idempotent.js
+++ b/test/request/idempotent.js
@@ -11,7 +11,7 @@ describe('ctx.idempotent', () => {
       function check(method){
         const req = request();
         req.method = method;
-        assert.equal(req.idempotent, true);
+        assert.strictEqual(req.idempotent, true);
       }
     });
   });
@@ -20,7 +20,7 @@ describe('ctx.idempotent', () => {
     it('should return false', () => {
       const req = request();
       req.method = 'POST';
-      assert.equal(req.idempotent, false);
+      assert.strictEqual(req.idempotent, false);
     });
   });
 });

--- a/test/request/inspect.js
+++ b/test/request/inspect.js
@@ -30,7 +30,7 @@ describe('req.inspect()', () => {
       }
     };
 
-    assert.deepEqual(req.inspect(), expected);
-    assert.deepEqual(util.inspect(req), util.inspect(expected));
+    assert.deepStrictEqual(req.inspect(), expected);
+    assert.deepStrictEqual(util.inspect(req), util.inspect(expected));
   });
 });

--- a/test/request/ip.js
+++ b/test/request/ip.js
@@ -15,7 +15,7 @@ describe('req.ip', () => {
       req.headers['x-forwarded-for'] = '127.0.0.1';
       req.socket.remoteAddress = '127.0.0.2';
       const request = Request(req, undefined, app);
-      assert.equal(request.ip, '127.0.0.1');
+      assert.strictEqual(request.ip, '127.0.0.1');
     });
   });
 
@@ -24,7 +24,7 @@ describe('req.ip', () => {
       const req = { socket: new Stream.Duplex() };
       req.socket.remoteAddress = '127.0.0.2';
       const request = Request(req);
-      assert.equal(request.ip, '127.0.0.2');
+      assert.strictEqual(request.ip, '127.0.0.2');
     });
 
     describe('with req.socket.remoteAddress not present', () => {
@@ -34,7 +34,7 @@ describe('req.ip', () => {
           get: () => undefined, // So that the helper doesn't override it with a reasonable value
           set: () => {}
         });
-        assert.equal(Request({ socket }).ip, '');
+        assert.strictEqual(Request({ socket }).ip, '');
       });
     });
   });
@@ -43,17 +43,17 @@ describe('req.ip', () => {
     const req = { socket: new Stream.Duplex() };
     req.socket.remoteAddress = '127.0.0.2';
     const request = Request(req);
-    assert.equal(request.ip, '127.0.0.2');
+    assert.strictEqual(request.ip, '127.0.0.2');
     req.socket.remoteAddress = '127.0.0.1';
-    assert.equal(request.ip, '127.0.0.2');
+    assert.strictEqual(request.ip, '127.0.0.2');
   });
 
   it('should reset ip work', () => {
     const req = { socket: new Stream.Duplex() };
     req.socket.remoteAddress = '127.0.0.2';
     const request = Request(req);
-    assert.equal(request.ip, '127.0.0.2');
+    assert.strictEqual(request.ip, '127.0.0.2');
     request.ip = '127.0.0.1';
-    assert.equal(request.ip, '127.0.0.1');
+    assert.strictEqual(request.ip, '127.0.0.1');
   });
 });

--- a/test/request/ips.js
+++ b/test/request/ips.js
@@ -11,7 +11,7 @@ describe('req.ips', () => {
         const req = request();
         req.app.proxy = false;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
-        assert.deepEqual(req.ips, []);
+        assert.deepStrictEqual(req.ips, []);
       });
     });
 
@@ -20,7 +20,7 @@ describe('req.ips', () => {
         const req = request();
         req.app.proxy = true;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
-        assert.deepEqual(req.ips, ['127.0.0.1', '127.0.0.2']);
+        assert.deepStrictEqual(req.ips, ['127.0.0.1', '127.0.0.2']);
       });
     });
   });

--- a/test/request/is.js
+++ b/test/request/is.js
@@ -10,16 +10,16 @@ describe('ctx.is(type)', () => {
     ctx.header['content-type'] = 'text/html; charset=utf-8';
     ctx.header['transfer-encoding'] = 'chunked';
 
-    assert.equal(ctx.is('text/*'), 'text/html');
+    assert.strictEqual(ctx.is('text/*'), 'text/html');
   });
 
   describe('when no body is given', () => {
     it('should return null', () => {
       const ctx = context();
 
-      assert.equal(ctx.is(), null);
-      assert.equal(ctx.is('image/*'), null);
-      assert.equal(ctx.is('image/*', 'text/*'), null);
+      assert.strictEqual(ctx.is(), null);
+      assert.strictEqual(ctx.is('image/*'), null);
+      assert.strictEqual(ctx.is('image/*', 'text/*'), null);
     });
   });
 
@@ -28,9 +28,9 @@ describe('ctx.is(type)', () => {
       const ctx = context();
       ctx.header['transfer-encoding'] = 'chunked';
 
-      assert.equal(ctx.is(), false);
-      assert.equal(ctx.is('image/*'), false);
-      assert.equal(ctx.is('text/*', 'image/*'), false);
+      assert.strictEqual(ctx.is(), false);
+      assert.strictEqual(ctx.is('image/*'), false);
+      assert.strictEqual(ctx.is('text/*', 'image/*'), false);
     });
   });
 
@@ -40,7 +40,7 @@ describe('ctx.is(type)', () => {
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
-      assert.equal(ctx.is(), 'image/png');
+      assert.strictEqual(ctx.is(), 'image/png');
     });
   });
 
@@ -50,17 +50,17 @@ describe('ctx.is(type)', () => {
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
-      assert.equal(ctx.is('png'), 'png');
-      assert.equal(ctx.is('.png'), '.png');
-      assert.equal(ctx.is('image/png'), 'image/png');
-      assert.equal(ctx.is('image/*'), 'image/png');
-      assert.equal(ctx.is('*/png'), 'image/png');
+      assert.strictEqual(ctx.is('png'), 'png');
+      assert.strictEqual(ctx.is('.png'), '.png');
+      assert.strictEqual(ctx.is('image/png'), 'image/png');
+      assert.strictEqual(ctx.is('image/*'), 'image/png');
+      assert.strictEqual(ctx.is('*/png'), 'image/png');
 
-      assert.equal(ctx.is('jpeg'), false);
-      assert.equal(ctx.is('.jpeg'), false);
-      assert.equal(ctx.is('image/jpeg'), false);
-      assert.equal(ctx.is('text/*'), false);
-      assert.equal(ctx.is('*/jpeg'), false);
+      assert.strictEqual(ctx.is('jpeg'), false);
+      assert.strictEqual(ctx.is('.jpeg'), false);
+      assert.strictEqual(ctx.is('image/jpeg'), false);
+      assert.strictEqual(ctx.is('text/*'), false);
+      assert.strictEqual(ctx.is('*/jpeg'), false);
     });
   });
 
@@ -70,22 +70,22 @@ describe('ctx.is(type)', () => {
       ctx.header['content-type'] = 'image/png';
       ctx.header['transfer-encoding'] = 'chunked';
 
-      assert.equal(ctx.is('png'), 'png');
-      assert.equal(ctx.is('.png'), '.png');
-      assert.equal(ctx.is('text/*', 'image/*'), 'image/png');
-      assert.equal(ctx.is('image/*', 'text/*'), 'image/png');
-      assert.equal(ctx.is('image/*', 'image/png'), 'image/png');
-      assert.equal(ctx.is('image/png', 'image/*'), 'image/png');
+      assert.strictEqual(ctx.is('png'), 'png');
+      assert.strictEqual(ctx.is('.png'), '.png');
+      assert.strictEqual(ctx.is('text/*', 'image/*'), 'image/png');
+      assert.strictEqual(ctx.is('image/*', 'text/*'), 'image/png');
+      assert.strictEqual(ctx.is('image/*', 'image/png'), 'image/png');
+      assert.strictEqual(ctx.is('image/png', 'image/*'), 'image/png');
 
-      assert.equal(ctx.is(['text/*', 'image/*']), 'image/png');
-      assert.equal(ctx.is(['image/*', 'text/*']), 'image/png');
-      assert.equal(ctx.is(['image/*', 'image/png']), 'image/png');
-      assert.equal(ctx.is(['image/png', 'image/*']), 'image/png');
+      assert.strictEqual(ctx.is(['text/*', 'image/*']), 'image/png');
+      assert.strictEqual(ctx.is(['image/*', 'text/*']), 'image/png');
+      assert.strictEqual(ctx.is(['image/*', 'image/png']), 'image/png');
+      assert.strictEqual(ctx.is(['image/png', 'image/*']), 'image/png');
 
-      assert.equal(ctx.is('jpeg'), false);
-      assert.equal(ctx.is('.jpeg'), false);
-      assert.equal(ctx.is('text/*', 'application/*'), false);
-      assert.equal(ctx.is('text/html', 'text/plain', 'application/json; charset=utf-8'), false);
+      assert.strictEqual(ctx.is('jpeg'), false);
+      assert.strictEqual(ctx.is('.jpeg'), false);
+      assert.strictEqual(ctx.is('text/*', 'application/*'), false);
+      assert.strictEqual(ctx.is('text/html', 'text/plain', 'application/json; charset=utf-8'), false);
     });
   });
 
@@ -95,9 +95,9 @@ describe('ctx.is(type)', () => {
       ctx.header['content-type'] = 'application/x-www-form-urlencoded';
       ctx.header['transfer-encoding'] = 'chunked';
 
-      assert.equal(ctx.is('urlencoded'), 'urlencoded');
-      assert.equal(ctx.is('json', 'urlencoded'), 'urlencoded');
-      assert.equal(ctx.is('urlencoded', 'json'), 'urlencoded');
+      assert.strictEqual(ctx.is('urlencoded'), 'urlencoded');
+      assert.strictEqual(ctx.is('json', 'urlencoded'), 'urlencoded');
+      assert.strictEqual(ctx.is('urlencoded', 'json'), 'urlencoded');
     });
   });
 });

--- a/test/request/length.js
+++ b/test/request/length.js
@@ -8,11 +8,11 @@ describe('ctx.length', () => {
   it('should return length in content-length', () => {
     const req = request();
     req.header['content-length'] = '10';
-    assert.equal(req.length, 10);
+    assert.strictEqual(req.length, 10);
   });
 
   it('with no content-length present', () => {
     const req = request();
-    assert.equal(req.length, undefined);
+    assert.strictEqual(req.length, undefined);
   });
 });

--- a/test/request/origin.js
+++ b/test/request/origin.js
@@ -17,9 +17,9 @@ describe('ctx.origin', () => {
       __proto__: Stream.Readable.prototype
     };
     const ctx = context(req);
-    assert.equal(ctx.origin, 'http://localhost');
+    assert.strictEqual(ctx.origin, 'http://localhost');
     // change it also work
     ctx.url = '/foo/users/1?next=/dashboard';
-    assert.equal(ctx.origin, 'http://localhost');
+    assert.strictEqual(ctx.origin, 'http://localhost');
   });
 });

--- a/test/request/path.js
+++ b/test/request/path.js
@@ -9,7 +9,7 @@ describe('ctx.path', () => {
   it('should return the pathname', () => {
     const ctx = context();
     ctx.url = '/login?next=/dashboard';
-    assert.equal(ctx.path, '/login');
+    assert.strictEqual(ctx.path, '/login');
   });
 });
 
@@ -19,22 +19,22 @@ describe('ctx.path=', () => {
     ctx.url = '/login?next=/dashboard';
 
     ctx.path = '/logout';
-    assert.equal(ctx.path, '/logout');
-    assert.equal(ctx.url, '/logout?next=/dashboard');
+    assert.strictEqual(ctx.path, '/logout');
+    assert.strictEqual(ctx.url, '/logout?next=/dashboard');
   });
 
   it('should change .url but not .originalUrl', () => {
     const ctx = context({ url: '/login' });
     ctx.path = '/logout';
-    assert.equal(ctx.url, '/logout');
-    assert.equal(ctx.originalUrl, '/login');
-    assert.equal(ctx.request.originalUrl, '/login');
+    assert.strictEqual(ctx.url, '/logout');
+    assert.strictEqual(ctx.originalUrl, '/login');
+    assert.strictEqual(ctx.request.originalUrl, '/login');
   });
 
   it('should not affect parseurl', () => {
     const ctx = context({ url: '/login?foo=bar' });
     ctx.path = '/login';
     const url = parseurl(ctx.req);
-    assert.equal(url.path, '/login?foo=bar');
+    assert.strictEqual(url.path, '/login?foo=bar');
   });
 });

--- a/test/request/protocol.js
+++ b/test/request/protocol.js
@@ -9,7 +9,7 @@ describe('req.protocol', () => {
     it('should return "https"', () => {
       const req = request();
       req.req.socket = { encrypted: true };
-      assert.equal(req.protocol, 'https');
+      assert.strictEqual(req.protocol, 'https');
     });
   });
 
@@ -17,7 +17,7 @@ describe('req.protocol', () => {
     it('should return "http"', () => {
       const req = request();
       req.req.socket = {};
-      assert.equal(req.protocol, 'http');
+      assert.strictEqual(req.protocol, 'http');
     });
   });
 
@@ -28,7 +28,7 @@ describe('req.protocol', () => {
         req.app.proxy = true;
         req.req.socket = {};
         req.header['x-forwarded-proto'] = 'https, http';
-        assert.equal(req.protocol, 'https');
+        assert.strictEqual(req.protocol, 'https');
       });
 
       describe('and X-Forwarded-Proto is empty', () => {
@@ -37,7 +37,7 @@ describe('req.protocol', () => {
           req.app.proxy = true;
           req.req.socket = {};
           req.header['x-forwarded-proto'] = '';
-          assert.equal(req.protocol, 'http');
+          assert.strictEqual(req.protocol, 'http');
         });
       });
     });
@@ -47,7 +47,7 @@ describe('req.protocol', () => {
         const req = request();
         req.req.socket = {};
         req.header['x-forwarded-proto'] = 'https, http';
-        assert.equal(req.protocol, 'http');
+        assert.strictEqual(req.protocol, 'http');
       });
     });
   });

--- a/test/request/query.js
+++ b/test/request/query.js
@@ -8,19 +8,19 @@ describe('ctx.query', () => {
   describe('when missing', () => {
     it('should return an empty object', () => {
       const ctx = context({ url: '/' });
-      assert.deepEqual(ctx.query, {});
+      assert.deepStrictEqual(ctx.query, Object.create(null));
     });
 
     it('should return the same object each time it\'s accessed', () => {
       const ctx = context({ url: '/' });
       ctx.query.a = '2';
-      assert.equal(ctx.query.a, '2');
+      assert.strictEqual(ctx.query.a, '2');
     });
   });
 
   it('should return a parsed query-string', () => {
     const ctx = context({ url: '/?page=2' });
-    assert.equal(ctx.query.page, '2');
+    assert.strictEqual(ctx.query.page, '2');
   });
 });
 
@@ -28,16 +28,16 @@ describe('ctx.query=', () => {
   it('should stringify and replace the querystring and search', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.query = { page: 2, color: 'blue' };
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.querystring, 'page=2&color=blue');
-    assert.equal(ctx.search, '?page=2&color=blue');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.querystring, 'page=2&color=blue');
+    assert.strictEqual(ctx.search, '?page=2&color=blue');
   });
 
   it('should change .url but not .originalUrl', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.query = { page: 2 };
-    assert.equal(ctx.url, '/store/shoes?page=2');
-    assert.equal(ctx.originalUrl, '/store/shoes');
-    assert.equal(ctx.request.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2');
+    assert.strictEqual(ctx.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.request.originalUrl, '/store/shoes');
   });
 });

--- a/test/request/querystring.js
+++ b/test/request/querystring.js
@@ -8,14 +8,14 @@ const parseurl = require('parseurl');
 describe('ctx.querystring', () => {
   it('should return the querystring', () => {
     const ctx = context({ url: '/store/shoes?page=2&color=blue' });
-    assert.equal(ctx.querystring, 'page=2&color=blue');
+    assert.strictEqual(ctx.querystring, 'page=2&color=blue');
   });
 
   describe('when ctx.req not present', () => {
     it('should return an empty string', () => {
       const ctx = context();
       ctx.request.req = null;
-      assert.equal(ctx.querystring, '');
+      assert.strictEqual(ctx.querystring, '');
     });
   });
 });
@@ -24,31 +24,31 @@ describe('ctx.querystring=', () => {
   it('should replace the querystring', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.querystring, 'page=2&color=blue');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.querystring, 'page=2&color=blue');
   });
 
   it('should update ctx.search and ctx.query', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.search, '?page=2&color=blue');
-    assert.equal(ctx.query.page, '2');
-    assert.equal(ctx.query.color, 'blue');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.search, '?page=2&color=blue');
+    assert.strictEqual(ctx.query.page, '2');
+    assert.strictEqual(ctx.query.color, 'blue');
   });
 
   it('should change .url but not .originalUrl', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.querystring = 'page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.originalUrl, '/store/shoes');
-    assert.equal(ctx.request.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.request.originalUrl, '/store/shoes');
   });
 
   it('should not affect parseurl', () => {
     const ctx = context({ url: '/login?foo=bar' });
     ctx.querystring = 'foo=bar';
     const url = parseurl(ctx.req);
-    assert.equal(url.path, '/login?foo=bar');
+    assert.strictEqual(url.path, '/login?foo=bar');
   });
 });

--- a/test/request/search.js
+++ b/test/request/search.js
@@ -8,31 +8,31 @@ describe('ctx.search=', () => {
   it('should replace the search', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.search, '?page=2&color=blue');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.search, '?page=2&color=blue');
   });
 
   it('should update ctx.querystring and ctx.query', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.querystring, 'page=2&color=blue');
-    assert.equal(ctx.query.page, '2');
-    assert.equal(ctx.query.color, 'blue');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.querystring, 'page=2&color=blue');
+    assert.strictEqual(ctx.query.page, '2');
+    assert.strictEqual(ctx.query.color, 'blue');
   });
 
   it('should change .url but not .originalUrl', () => {
     const ctx = context({ url: '/store/shoes' });
     ctx.search = '?page=2&color=blue';
-    assert.equal(ctx.url, '/store/shoes?page=2&color=blue');
-    assert.equal(ctx.originalUrl, '/store/shoes');
-    assert.equal(ctx.request.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.url, '/store/shoes?page=2&color=blue');
+    assert.strictEqual(ctx.originalUrl, '/store/shoes');
+    assert.strictEqual(ctx.request.originalUrl, '/store/shoes');
   });
 
   describe('when missing', () => {
     it('should return ""', () => {
       const ctx = context({ url: '/store/shoes' });
-      assert.equal(ctx.search, '');
+      assert.strictEqual(ctx.search, '');
     });
   });
 });

--- a/test/request/secure.js
+++ b/test/request/secure.js
@@ -8,6 +8,6 @@ describe('req.secure', () => {
   it('should return true when encrypted', () => {
     const req = request();
     req.req.socket = { encrypted: true };
-    assert.equal(req.secure, true);
+    assert.strictEqual(req.secure, true);
   });
 });

--- a/test/request/stale.js
+++ b/test/request/stale.js
@@ -11,7 +11,7 @@ describe('req.stale', () => {
     ctx.method = 'GET';
     ctx.req.headers['if-none-match'] = '"123"';
     ctx.set('ETag', '"123"');
-    assert.equal(ctx.fresh, true);
-    assert.equal(ctx.stale, false);
+    assert.strictEqual(ctx.fresh, true);
+    assert.strictEqual(ctx.stale, false);
   });
 });

--- a/test/request/subdomains.js
+++ b/test/request/subdomains.js
@@ -9,20 +9,20 @@ describe('req.subdomains', () => {
     const req = request();
     req.header.host = 'tobi.ferrets.example.com';
     req.app.subdomainOffset = 2;
-    assert.deepEqual(req.subdomains, ['ferrets', 'tobi']);
+    assert.deepStrictEqual(req.subdomains, ['ferrets', 'tobi']);
 
     req.app.subdomainOffset = 3;
-    assert.deepEqual(req.subdomains, ['tobi']);
+    assert.deepStrictEqual(req.subdomains, ['tobi']);
   });
 
   it('should work with no host present', () => {
     const req = request();
-    assert.deepEqual(req.subdomains, []);
+    assert.deepStrictEqual(req.subdomains, []);
   });
 
   it('should check if the host is an ip address, even with a port', () => {
     const req = request();
     req.header.host = '127.0.0.1:3000';
-    assert.deepEqual(req.subdomains, []);
+    assert.deepStrictEqual(req.subdomains, []);
   });
 });

--- a/test/request/type.js
+++ b/test/request/type.js
@@ -8,11 +8,11 @@ describe('req.type', () => {
   it('should return type void of parameters', () => {
     const req = request();
     req.header['content-type'] = 'text/html; charset=utf-8';
-    assert.equal(req.type, 'text/html');
+    assert.strictEqual(req.type, 'text/html');
   });
 
   it('with no host present', () => {
     const req = request();
-    assert.equal(req.type, '');
+    assert.strictEqual(req.type, '');
   });
 });

--- a/test/response/append.js
+++ b/test/response/append.js
@@ -9,7 +9,7 @@ describe('ctx.append(name, val)', () => {
     const ctx = context();
     ctx.append('x-foo', 'bar1');
     ctx.append('x-foo', 'bar2');
-    assert.deepEqual(ctx.response.header['x-foo'], ['bar1', 'bar2']);
+    assert.deepStrictEqual(ctx.response.header['x-foo'], ['bar1', 'bar2']);
   });
 
   it('should accept array of values', () => {
@@ -17,7 +17,7 @@ describe('ctx.append(name, val)', () => {
 
     ctx.append('Set-Cookie', ['foo=bar', 'fizz=buzz']);
     ctx.append('Set-Cookie', 'hi=again');
-    assert.deepEqual(ctx.response.header['set-cookie'], ['foo=bar', 'fizz=buzz', 'hi=again']);
+    assert.deepStrictEqual(ctx.response.header['set-cookie'], ['foo=bar', 'fizz=buzz', 'hi=again']);
   });
 
   it('should get reset by res.set(field, val)', () => {
@@ -28,7 +28,7 @@ describe('ctx.append(name, val)', () => {
 
     ctx.set('Link', '<http://127.0.0.1/>');
 
-    assert.equal(ctx.response.header.link, '<http://127.0.0.1/>');
+    assert.strictEqual(ctx.response.header.link, '<http://127.0.0.1/>');
   });
 
   it('should work with res.set(field, val) first', () => {
@@ -37,6 +37,6 @@ describe('ctx.append(name, val)', () => {
     ctx.set('Link', '<http://localhost/>');
     ctx.append('Link', '<http://localhost:80/>');
 
-    assert.deepEqual(ctx.response.header.link, ['<http://localhost/>', '<http://localhost:80/>']);
+    assert.deepStrictEqual(ctx.response.header.link, ['<http://localhost/>', '<http://localhost:80/>']);
   });
 });

--- a/test/response/attachment.js
+++ b/test/response/attachment.js
@@ -12,7 +12,7 @@ describe('ctx.attachment([filename])', () => {
       const ctx = context();
       ctx.attachment('path/to/tobi.png');
       const str = 'attachment; filename="tobi.png"';
-      assert.equal(ctx.response.header['content-disposition'], str);
+      assert.strictEqual(ctx.response.header['content-disposition'], str);
     });
   });
 
@@ -20,7 +20,7 @@ describe('ctx.attachment([filename])', () => {
     it('should not set filename param', () => {
       const ctx = context();
       ctx.attachment();
-      assert.equal(ctx.response.header['content-disposition'], 'attachment');
+      assert.strictEqual(ctx.response.header['content-disposition'], 'attachment');
     });
   });
 
@@ -29,7 +29,7 @@ describe('ctx.attachment([filename])', () => {
       const ctx = context();
       ctx.attachment('path/to/include-no-ascii-char-中文名-ok.png');
       const str = 'attachment; filename="include-no-ascii-char-???-ok.png"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.png';
-      assert.equal(ctx.response.header['content-disposition'], str);
+      assert.strictEqual(ctx.response.header['content-disposition'], str);
     });
 
     it('should work with http client', () => {
@@ -37,13 +37,13 @@ describe('ctx.attachment([filename])', () => {
 
       app.use((ctx, next) => {
         ctx.attachment('path/to/include-no-ascii-char-中文名-ok.json');
-        ctx.body = {foo: 'bar'};
+        ctx.body = { foo: 'bar' };
       });
 
       return request(app.callback())
         .get('/')
         .expect('content-disposition', 'attachment; filename="include-no-ascii-char-???-ok.json"; filename*=UTF-8\'\'include-no-ascii-char-%E4%B8%AD%E6%96%87%E5%90%8D-ok.json')
-        .expect({foo: 'bar'})
+        .expect({ foo: 'bar' })
         .expect(200);
     });
   });
@@ -61,7 +61,7 @@ describe('contentDisposition(filename, options)', () => {
     it('should default to true', () => {
       const ctx = context();
       ctx.attachment('€ rates.pdf');
-      assert.equal(ctx.response.header['content-disposition'],
+      assert.strictEqual(ctx.response.header['content-disposition'],
         'attachment; filename="? rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf');
     });
 
@@ -69,14 +69,14 @@ describe('contentDisposition(filename, options)', () => {
       it('should not generate ISO-8859-1 fallback', () => {
         const ctx = context();
         ctx.attachment('£ and € rates.pdf', { fallback: false });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename*=UTF-8\'\'%C2%A3%20and%20%E2%82%AC%20rates.pdf');
       });
 
       it('should keep ISO-8859-1 filename', () => {
         const ctx = context();
         ctx.attachment('£ rates.pdf', { fallback: false });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="£ rates.pdf"');
       });
     });
@@ -85,14 +85,14 @@ describe('contentDisposition(filename, options)', () => {
       it('should generate ISO-8859-1 fallback', () => {
         const ctx = context();
         ctx.attachment('£ and € rates.pdf', { fallback: true });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="£ and ? rates.pdf"; filename*=UTF-8\'\'%C2%A3%20and%20%E2%82%AC%20rates.pdf');
       });
 
       it('should pass through ISO-8859-1 filename', () => {
         const ctx = context();
         ctx.attachment('£ rates.pdf', { fallback: true });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="£ rates.pdf"');
       });
     });
@@ -107,35 +107,35 @@ describe('contentDisposition(filename, options)', () => {
       it('should use as ISO-8859-1 fallback', () => {
         const ctx = context();
         ctx.attachment('£ and € rates.pdf', { fallback: '£ and EURO rates.pdf' });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="£ and EURO rates.pdf"; filename*=UTF-8\'\'%C2%A3%20and%20%E2%82%AC%20rates.pdf');
       });
 
       it('should use as fallback even when filename is ISO-8859-1', () => {
         const ctx = context();
         ctx.attachment('"£ rates".pdf', { fallback: '£ rates.pdf' });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="£ rates.pdf"; filename*=UTF-8\'\'%22%C2%A3%20rates%22.pdf');
       });
 
       it('should do nothing if equal to filename', () => {
         const ctx = context();
         ctx.attachment('plans.pdf', { fallback: 'plans.pdf' });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="plans.pdf"');
       });
 
       it('should use the basename of the string', () => {
         const ctx = context();
         ctx.attachment('€ rates.pdf', { fallback: '/path/to/EURO rates.pdf' });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf');
       });
 
       it('should do nothing without filename option', () => {
         const ctx = context();
         ctx.attachment(undefined, { fallback: 'plans.pdf' });
-        assert.equal(ctx.response.header['content-disposition'],
+        assert.strictEqual(ctx.response.header['content-disposition'],
           'attachment');
       });
     });
@@ -145,7 +145,7 @@ describe('contentDisposition(filename, options)', () => {
     it('should default to attachment', () => {
       const ctx = context();
       ctx.attachment();
-      assert.equal(ctx.response.header['content-disposition'],
+      assert.strictEqual(ctx.response.header['content-disposition'],
         'attachment');
     });
 
@@ -164,21 +164,21 @@ describe('contentDisposition(filename, options)', () => {
     it('should create a header with inline type', () => {
       const ctx = context();
       ctx.attachment(undefined, { type: 'inline' });
-      assert.equal(ctx.response.header['content-disposition'],
+      assert.strictEqual(ctx.response.header['content-disposition'],
         'inline');
     });
 
     it('should create a header with inline type & filename', () => {
       const ctx = context();
       ctx.attachment('plans.pdf', { type: 'inline' });
-      assert.equal(ctx.response.header['content-disposition'],
+      assert.strictEqual(ctx.response.header['content-disposition'],
         'inline; filename="plans.pdf"');
     });
 
     it('should normalize type', () => {
       const ctx = context();
       ctx.attachment(undefined, { type: 'INLINE' });
-      assert.equal(ctx.response.header['content-disposition'],
+      assert.strictEqual(ctx.response.header['content-disposition'],
         'inline');
     });
   });

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -11,7 +11,7 @@ describe('res.body=', () => {
       const res = response();
       res.type = 'png';
       res.body = Buffer.from('something');
-      assert.equal('image/png', res.header['content-type']);
+      assert.strictEqual('image/png', res.header['content-type']);
     });
 
     describe('when body is an object', () => {
@@ -19,10 +19,10 @@ describe('res.body=', () => {
         const res = response();
 
         res.body = '<em>hey</em>';
-        assert.equal('text/html; charset=utf-8', res.header['content-type']);
+        assert.strictEqual('text/html; charset=utf-8', res.header['content-type']);
 
         res.body = { foo: 'bar' };
-        assert.equal('application/json; charset=utf-8', res.header['content-type']);
+        assert.strictEqual('application/json; charset=utf-8', res.header['content-type']);
       });
     });
 
@@ -30,7 +30,7 @@ describe('res.body=', () => {
       const res = response();
       res.type = 'html';
       res.body = 'something';
-      assert.equal(res.length, 9);
+      assert.strictEqual(res.length, 9);
     });
   });
 
@@ -38,20 +38,20 @@ describe('res.body=', () => {
     it('should default to text', () => {
       const res = response();
       res.body = 'Tobi';
-      assert.equal('text/plain; charset=utf-8', res.header['content-type']);
+      assert.strictEqual('text/plain; charset=utf-8', res.header['content-type']);
     });
 
     it('should set length', () => {
       const res = response();
       res.body = 'Tobi';
-      assert.equal('4', res.header['content-length']);
+      assert.strictEqual('4', res.header['content-length']);
     });
 
     describe('and contains a non-leading <', () => {
       it('should default to text', () => {
         const res = response();
         res.body = 'aklsdjf < klajsdlfjasd';
-        assert.equal('text/plain; charset=utf-8', res.header['content-type']);
+        assert.strictEqual('text/plain; charset=utf-8', res.header['content-type']);
       });
     });
   });
@@ -60,14 +60,14 @@ describe('res.body=', () => {
     it('should default to html', () => {
       const res = response();
       res.body = '<h1>Tobi</h1>';
-      assert.equal('text/html; charset=utf-8', res.header['content-type']);
+      assert.strictEqual('text/html; charset=utf-8', res.header['content-type']);
     });
 
     it('should set length', () => {
       const string = '<h1>Tobi</h1>';
       const res = response();
       res.body = string;
-      assert.equal(res.length, Buffer.byteLength(string));
+      assert.strictEqual(res.length, Buffer.byteLength(string));
     });
 
     it('should set length when body is overridden', () => {
@@ -75,14 +75,14 @@ describe('res.body=', () => {
       const res = response();
       res.body = string;
       res.body = string + string;
-      assert.equal(res.length, 2 * Buffer.byteLength(string));
+      assert.strictEqual(res.length, 2 * Buffer.byteLength(string));
     });
 
     describe('when it contains leading whitespace', () => {
       it('should default to html', () => {
         const res = response();
         res.body = '    <h1>Tobi</h1>';
-        assert.equal('text/html; charset=utf-8', res.header['content-type']);
+        assert.strictEqual('text/html; charset=utf-8', res.header['content-type']);
       });
     });
   });
@@ -98,7 +98,7 @@ describe('res.body=', () => {
 
       const res = response();
       res.body = '<?xml version="1.0" encoding="UTF-8"?>\n<俄语>данные</俄语>';
-      assert.equal('text/html; charset=utf-8', res.header['content-type']);
+      assert.strictEqual('text/html; charset=utf-8', res.header['content-type']);
     });
   });
 
@@ -106,7 +106,7 @@ describe('res.body=', () => {
     it('should default to an octet stream', () => {
       const res = response();
       res.body = fs.createReadStream('LICENSE');
-      assert.equal('application/octet-stream', res.header['content-type']);
+      assert.strictEqual('application/octet-stream', res.header['content-type']);
     });
   });
 
@@ -114,13 +114,13 @@ describe('res.body=', () => {
     it('should default to an octet stream', () => {
       const res = response();
       res.body = Buffer.from('hey');
-      assert.equal('application/octet-stream', res.header['content-type']);
+      assert.strictEqual('application/octet-stream', res.header['content-type']);
     });
 
     it('should set length', () => {
       const res = response();
       res.body = Buffer.from('Tobi');
-      assert.equal('4', res.header['content-length']);
+      assert.strictEqual('4', res.header['content-length']);
     });
   });
 
@@ -128,7 +128,7 @@ describe('res.body=', () => {
     it('should default to json', () => {
       const res = response();
       res.body = { foo: 'bar' };
-      assert.equal('application/json; charset=utf-8', res.header['content-type']);
+      assert.strictEqual('application/json; charset=utf-8', res.header['content-type']);
     });
   });
 });

--- a/test/response/etag.js
+++ b/test/response/etag.js
@@ -8,19 +8,19 @@ describe('res.etag=', () => {
   it('should not modify an etag with quotes', () => {
     const res = response();
     res.etag = '"asdf"';
-    assert.equal(res.header.etag, '"asdf"');
+    assert.strictEqual(res.header.etag, '"asdf"');
   });
 
   it('should not modify a weak etag', () => {
     const res = response();
     res.etag = 'W/"asdf"';
-    assert.equal(res.header.etag, 'W/"asdf"');
+    assert.strictEqual(res.header.etag, 'W/"asdf"');
   });
 
   it('should add quotes around an etag if necessary', () => {
     const res = response();
     res.etag = 'asdf';
-    assert.equal(res.header.etag, '"asdf"');
+    assert.strictEqual(res.header.etag, '"asdf"');
   });
 });
 
@@ -28,6 +28,6 @@ describe('res.etag', () => {
   it('should return etag', () => {
     const res = response();
     res.etag = '"asdf"';
-    assert.equal(res.etag, '"asdf"');
+    assert.strictEqual(res.etag, '"asdf"');
   });
 });

--- a/test/response/header.js
+++ b/test/response/header.js
@@ -11,17 +11,17 @@ describe('res.header', () => {
     const res = response();
     res.set('X-Foo', 'bar');
     res.set('X-Number', 200);
-    assert.deepEqual(res.header, { 'x-foo': 'bar', 'x-number': '200' });
+    assert.deepStrictEqual(res.header, { 'x-foo': 'bar', 'x-number': '200' });
   });
 
   it('should use res.getHeaders() accessor when available', () => {
     const res = response();
     res.res._headers = null;
     res.res.getHeaders = () => ({ 'x-foo': 'baz' });
-    assert.deepEqual(res.header, { 'x-foo': 'baz' });
+    assert.deepStrictEqual(res.header, { 'x-foo': 'baz' });
   });
 
-  it('should return the response header object when no mocks are in use', async () => {
+  it('should return the response header object when no mocks are in use', async() => {
     const app = new Koa();
     let header;
 
@@ -33,14 +33,14 @@ describe('res.header', () => {
     await request(app.callback())
       .get('/');
 
-    assert.deepEqual(header, { 'x-foo': '42' });
+    assert.deepStrictEqual(header, { 'x-foo': '42' });
   });
 
   describe('when res._headers not present', () => {
     it('should return empty object', () => {
       const res = response();
       res.res._headers = null;
-      assert.deepEqual(res.header, {});
+      assert.deepStrictEqual(res.header, {});
     });
   });
 });

--- a/test/response/headers.js
+++ b/test/response/headers.js
@@ -8,14 +8,14 @@ describe('res.header', () => {
   it('should return the response header object', () => {
     const res = response();
     res.set('X-Foo', 'bar');
-    assert.deepEqual(res.headers, { 'x-foo': 'bar' });
+    assert.deepStrictEqual(res.headers, { 'x-foo': 'bar' });
   });
 
   describe('when res._headers not present', () => {
     it('should return empty object', () => {
       const res = response();
       res.res._headers = null;
-      assert.deepEqual(res.headers, {});
+      assert.deepStrictEqual(res.headers, {});
     });
   });
 });

--- a/test/response/inspect.js
+++ b/test/response/inspect.js
@@ -7,12 +7,12 @@ const util = require('util');
 
 describe('res.inspect()', () => {
   describe('with no response.res present', () => {
-    it('should return null', () => {
+    it('should return undefined', () => {
       const res = response();
       res.body = 'hello';
       delete res.res;
-      assert.equal(res.inspect(), null);
-      assert.equal(util.inspect(res), 'undefined');
+      assert.strictEqual(res.inspect(), undefined);
+      assert.strictEqual(util.inspect(res), 'undefined');
     });
   });
 
@@ -30,7 +30,7 @@ describe('res.inspect()', () => {
       body: 'hello'
     };
 
-    assert.deepEqual(res.inspect(), expected);
-    assert.deepEqual(util.inspect(res), util.inspect(expected));
+    assert.deepStrictEqual(res.inspect(), expected);
+    assert.deepStrictEqual(util.inspect(res), util.inspect(expected));
   });
 });

--- a/test/response/is.js
+++ b/test/response/is.js
@@ -9,15 +9,15 @@ describe('response.is(type)', () => {
     const res = context().response;
     res.type = 'text/html; charset=utf-8';
 
-    assert.equal(res.is('text/*'), 'text/html');
+    assert.strictEqual(res.is('text/*'), 'text/html');
   });
 
   describe('when no type is set', () => {
     it('should return false', () => {
       const res = context().response;
 
-      assert.equal(res.is(), false);
-      assert.equal(res.is('html'), false);
+      assert.strictEqual(res.is(), false);
+      assert.strictEqual(res.is('html'), false);
     });
   });
 
@@ -26,7 +26,7 @@ describe('response.is(type)', () => {
       const res = context().response;
       res.type = 'text/html; charset=utf-8';
 
-      assert.equal(res.is(), 'text/html');
+      assert.strictEqual(res.is(), 'text/html');
     });
   });
 
@@ -35,17 +35,17 @@ describe('response.is(type)', () => {
       const res = context().response;
       res.type = 'image/png';
 
-      assert.equal(res.is('png'), 'png');
-      assert.equal(res.is('.png'), '.png');
-      assert.equal(res.is('image/png'), 'image/png');
-      assert.equal(res.is('image/*'), 'image/png');
-      assert.equal(res.is('*/png'), 'image/png');
+      assert.strictEqual(res.is('png'), 'png');
+      assert.strictEqual(res.is('.png'), '.png');
+      assert.strictEqual(res.is('image/png'), 'image/png');
+      assert.strictEqual(res.is('image/*'), 'image/png');
+      assert.strictEqual(res.is('*/png'), 'image/png');
 
-      assert.equal(res.is('jpeg'), false);
-      assert.equal(res.is('.jpeg'), false);
-      assert.equal(res.is('image/jpeg'), false);
-      assert.equal(res.is('text/*'), false);
-      assert.equal(res.is('*/jpeg'), false);
+      assert.strictEqual(res.is('jpeg'), false);
+      assert.strictEqual(res.is('.jpeg'), false);
+      assert.strictEqual(res.is('image/jpeg'), false);
+      assert.strictEqual(res.is('text/*'), false);
+      assert.strictEqual(res.is('*/jpeg'), false);
     });
   });
 
@@ -54,22 +54,22 @@ describe('response.is(type)', () => {
       const res = context().response;
       res.type = 'image/png';
 
-      assert.equal(res.is('png'), 'png');
-      assert.equal(res.is('.png'), '.png');
-      assert.equal(res.is('text/*', 'image/*'), 'image/png');
-      assert.equal(res.is('image/*', 'text/*'), 'image/png');
-      assert.equal(res.is('image/*', 'image/png'), 'image/png');
-      assert.equal(res.is('image/png', 'image/*'), 'image/png');
+      assert.strictEqual(res.is('png'), 'png');
+      assert.strictEqual(res.is('.png'), '.png');
+      assert.strictEqual(res.is('text/*', 'image/*'), 'image/png');
+      assert.strictEqual(res.is('image/*', 'text/*'), 'image/png');
+      assert.strictEqual(res.is('image/*', 'image/png'), 'image/png');
+      assert.strictEqual(res.is('image/png', 'image/*'), 'image/png');
 
-      assert.equal(res.is(['text/*', 'image/*']), 'image/png');
-      assert.equal(res.is(['image/*', 'text/*']), 'image/png');
-      assert.equal(res.is(['image/*', 'image/png']), 'image/png');
-      assert.equal(res.is(['image/png', 'image/*']), 'image/png');
+      assert.strictEqual(res.is(['text/*', 'image/*']), 'image/png');
+      assert.strictEqual(res.is(['image/*', 'text/*']), 'image/png');
+      assert.strictEqual(res.is(['image/*', 'image/png']), 'image/png');
+      assert.strictEqual(res.is(['image/png', 'image/*']), 'image/png');
 
-      assert.equal(res.is('jpeg'), false);
-      assert.equal(res.is('.jpeg'), false);
-      assert.equal(res.is('text/*', 'application/*'), false);
-      assert.equal(res.is('text/html', 'text/plain', 'application/json; charset=utf-8'), false);
+      assert.strictEqual(res.is('jpeg'), false);
+      assert.strictEqual(res.is('.jpeg'), false);
+      assert.strictEqual(res.is('text/*', 'application/*'), false);
+      assert.strictEqual(res.is('text/html', 'text/plain', 'application/json; charset=utf-8'), false);
     });
   });
 
@@ -78,9 +78,9 @@ describe('response.is(type)', () => {
       const res = context().response;
       res.type = 'application/x-www-form-urlencoded';
 
-      assert.equal(res.is('urlencoded'), 'urlencoded');
-      assert.equal(res.is('json', 'urlencoded'), 'urlencoded');
-      assert.equal(res.is('urlencoded', 'json'), 'urlencoded');
+      assert.strictEqual(res.is('urlencoded'), 'urlencoded');
+      assert.strictEqual(res.is('json', 'urlencoded'), 'urlencoded');
+      assert.strictEqual(res.is('urlencoded', 'json'), 'urlencoded');
     });
   });
 });

--- a/test/response/last-modified.js
+++ b/test/response/last-modified.js
@@ -9,14 +9,14 @@ describe('res.lastModified', () => {
     const res = response();
     const date = new Date();
     res.lastModified = date;
-    assert.equal(res.header['last-modified'], date.toUTCString());
+    assert.strictEqual(res.header['last-modified'], date.toUTCString());
   });
 
   it('should work with date strings', () => {
     const res = response();
     const date = new Date();
     res.lastModified = date.toString();
-    assert.equal(res.header['last-modified'], date.toUTCString());
+    assert.strictEqual(res.header['last-modified'], date.toUTCString());
   });
 
   it('should get the header as a Date', () => {
@@ -24,13 +24,13 @@ describe('res.lastModified', () => {
     const res = response();
     const date = new Date();
     res.lastModified = date;
-    assert.equal((res.lastModified.getTime() / 1000), Math.floor(date.getTime() / 1000));
+    assert.strictEqual((res.lastModified.getTime() / 1000), Math.floor(date.getTime() / 1000));
   });
 
   describe('when lastModified not set', () => {
     it('should get undefined', () => {
       const res = response();
-      assert.equal(res.lastModified, undefined);
+      assert.strictEqual(res.lastModified, undefined);
     });
   });
 });

--- a/test/response/length.js
+++ b/test/response/length.js
@@ -10,7 +10,7 @@ describe('res.length', () => {
     it('should return a number', () => {
       const res = response();
       res.header['content-length'] = '120';
-      assert.equal(res.length, 120);
+      assert.strictEqual(res.length, 120);
     });
   });
 });
@@ -20,7 +20,7 @@ describe('res.length', () => {
     it('should return a number', () => {
       const res = response();
       res.set('Content-Length', '1024');
-      assert.equal(res.length, 1024);
+      assert.strictEqual(res.length, 1024);
     });
   });
 
@@ -31,37 +31,37 @@ describe('res.length', () => {
 
         res.body = 'foo';
         res.remove('Content-Length');
-        assert.equal(res.length, 3);
+        assert.strictEqual(res.length, 3);
 
         res.body = 'foo';
-        assert.equal(res.length, 3);
+        assert.strictEqual(res.length, 3);
 
         res.body = Buffer.from('foo bar');
         res.remove('Content-Length');
-        assert.equal(res.length, 7);
+        assert.strictEqual(res.length, 7);
 
         res.body = Buffer.from('foo bar');
-        assert.equal(res.length, 7);
+        assert.strictEqual(res.length, 7);
 
         res.body = { hello: 'world' };
         res.remove('Content-Length');
-        assert.equal(res.length, 17);
+        assert.strictEqual(res.length, 17);
 
         res.body = { hello: 'world' };
-        assert.equal(res.length, 17);
+        assert.strictEqual(res.length, 17);
 
         res.body = fs.createReadStream('package.json');
-        assert.equal(res.length, undefined);
+        assert.strictEqual(res.length, undefined);
 
         res.body = null;
-        assert.equal(res.length, undefined);
+        assert.strictEqual(res.length, undefined);
       });
     });
 
     describe('and .body is not', () => {
       it('should return undefined', () => {
         const res = response();
-        assert.equal(res.length, undefined);
+        assert.strictEqual(res.length, undefined);
       });
     });
   });

--- a/test/response/message.js
+++ b/test/response/message.js
@@ -8,14 +8,14 @@ describe('res.message', () => {
   it('should return the response status message', () => {
     const res = response();
     res.status = 200;
-    assert.equal(res.message, 'OK');
+    assert.strictEqual(res.message, 'OK');
   });
 
   describe('when res.message not present', () => {
     it('should look up in statuses', () => {
       const res = response();
       res.res.statusCode = 200;
-      assert.equal(res.message, 'OK');
+      assert.strictEqual(res.message, 'OK');
     });
   });
 });
@@ -25,7 +25,7 @@ describe('res.message=', () => {
     const res = response();
     res.status = 200;
     res.message = 'ok';
-    assert.equal(res.res.statusMessage, 'ok');
-    assert.equal(res.inspect().message, 'ok');
+    assert.strictEqual(res.res.statusMessage, 'ok');
+    assert.strictEqual(res.inspect().message, 'ok');
   });
 });

--- a/test/response/redirect.js
+++ b/test/response/redirect.js
@@ -8,8 +8,8 @@ describe('ctx.redirect(url)', () => {
   it('should redirect to the given url', () => {
     const ctx = context();
     ctx.redirect('http://google.com');
-    assert.equal(ctx.response.header.location, 'http://google.com');
-    assert.equal(ctx.status, 302);
+    assert.strictEqual(ctx.response.header.location, 'http://google.com');
+    assert.strictEqual(ctx.status, 302);
   });
 
   describe('with "back"', () => {
@@ -17,26 +17,26 @@ describe('ctx.redirect(url)', () => {
       const ctx = context();
       ctx.req.headers.referrer = '/login';
       ctx.redirect('back');
-      assert.equal(ctx.response.header.location, '/login');
+      assert.strictEqual(ctx.response.header.location, '/login');
     });
 
     it('should redirect to Referer', () => {
       const ctx = context();
       ctx.req.headers.referer = '/login';
       ctx.redirect('back');
-      assert.equal(ctx.response.header.location, '/login');
+      assert.strictEqual(ctx.response.header.location, '/login');
     });
 
     it('should default to alt', () => {
       const ctx = context();
       ctx.redirect('back', '/index.html');
-      assert.equal(ctx.response.header.location, '/index.html');
+      assert.strictEqual(ctx.response.header.location, '/index.html');
     });
 
     it('should default redirect to /', () => {
       const ctx = context();
       ctx.redirect('back');
-      assert.equal(ctx.response.header.location, '/');
+      assert.strictEqual(ctx.response.header.location, '/');
     });
   });
 
@@ -46,8 +46,8 @@ describe('ctx.redirect(url)', () => {
       const url = 'http://google.com';
       ctx.header.accept = 'text/html';
       ctx.redirect(url);
-      assert.equal(ctx.response.header['content-type'], 'text/html; charset=utf-8');
-      assert.equal(ctx.body, `Redirecting to <a href="${url}">${url}</a>.`);
+      assert.strictEqual(ctx.response.header['content-type'], 'text/html; charset=utf-8');
+      assert.strictEqual(ctx.body, `Redirecting to <a href="${url}">${url}</a>.`);
     });
 
     it('should escape the url', () => {
@@ -56,8 +56,8 @@ describe('ctx.redirect(url)', () => {
       ctx.header.accept = 'text/html';
       ctx.redirect(url);
       url = escape(url);
-      assert.equal(ctx.response.header['content-type'], 'text/html; charset=utf-8');
-      assert.equal(ctx.body, `Redirecting to <a href="${url}">${url}</a>.`);
+      assert.strictEqual(ctx.response.header['content-type'], 'text/html; charset=utf-8');
+      assert.strictEqual(ctx.body, `Redirecting to <a href="${url}">${url}</a>.`);
     });
   });
 
@@ -67,7 +67,7 @@ describe('ctx.redirect(url)', () => {
       const url = 'http://google.com';
       ctx.header.accept = 'text/plain';
       ctx.redirect(url);
-      assert.equal(ctx.body, `Redirecting to ${url}.`);
+      assert.strictEqual(ctx.body, `Redirecting to ${url}.`);
     });
   });
 
@@ -78,8 +78,8 @@ describe('ctx.redirect(url)', () => {
       ctx.status = 301;
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
-      assert.equal(ctx.status, 301);
-      assert.equal(ctx.body, `Redirecting to ${url}.`);
+      assert.strictEqual(ctx.status, 301);
+      assert.strictEqual(ctx.body, `Redirecting to ${url}.`);
     });
   });
 
@@ -90,8 +90,8 @@ describe('ctx.redirect(url)', () => {
       ctx.status = 304;
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
-      assert.equal(ctx.status, 302);
-      assert.equal(ctx.body, `Redirecting to ${url}.`);
+      assert.strictEqual(ctx.status, 302);
+      assert.strictEqual(ctx.body, `Redirecting to ${url}.`);
     });
   });
 
@@ -102,9 +102,9 @@ describe('ctx.redirect(url)', () => {
       const url = 'http://google.com';
       ctx.header.accept = 'text/plain';
       ctx.redirect('http://google.com');
-      assert.equal(ctx.status, 302);
-      assert.equal(ctx.body, `Redirecting to ${url}.`);
-      assert.equal(ctx.type, 'text/plain');
+      assert.strictEqual(ctx.status, 302);
+      assert.strictEqual(ctx.body, `Redirecting to ${url}.`);
+      assert.strictEqual(ctx.type, 'text/plain');
     });
   });
 });

--- a/test/response/remove.js
+++ b/test/response/remove.js
@@ -9,6 +9,6 @@ describe('ctx.remove(name)', () => {
     const ctx = context();
     ctx.set('x-foo', 'bar');
     ctx.remove('x-foo');
-    assert.deepEqual(ctx.response.header, {});
+    assert.deepStrictEqual(ctx.response.header, {});
   });
 });

--- a/test/response/set.js
+++ b/test/response/set.js
@@ -8,25 +8,25 @@ describe('ctx.set(name, val)', () => {
   it('should set a field value', () => {
     const ctx = context();
     ctx.set('x-foo', 'bar');
-    assert.equal(ctx.response.header['x-foo'], 'bar');
+    assert.strictEqual(ctx.response.header['x-foo'], 'bar');
   });
 
   it('should coerce number to string', () => {
     const ctx = context();
     ctx.set('x-foo', 5);
-    assert.equal(ctx.response.header['x-foo'], '5');
+    assert.strictEqual(ctx.response.header['x-foo'], '5');
   });
 
   it('should coerce undefined to string', () => {
     const ctx = context();
     ctx.set('x-foo', undefined);
-    assert.equal(ctx.response.header['x-foo'], 'undefined');
+    assert.strictEqual(ctx.response.header['x-foo'], 'undefined');
   });
 
   it('should set a field value of array', () => {
     const ctx = context();
     ctx.set('x-foo', ['foo', 'bar']);
-    assert.deepEqual(ctx.response.header['x-foo'], [ 'foo', 'bar' ]);
+    assert.deepStrictEqual(ctx.response.header['x-foo'], [ 'foo', 'bar' ]);
   });
 });
 
@@ -39,7 +39,7 @@ describe('ctx.set(object)', () => {
       bar: '2'
     });
 
-    assert.equal(ctx.response.header.foo, '1');
-    assert.equal(ctx.response.header.bar, '2');
+    assert.strictEqual(ctx.response.header.foo, '1');
+    assert.strictEqual(ctx.response.header.bar, '2');
   });
 });

--- a/test/response/socket.js
+++ b/test/response/socket.js
@@ -8,6 +8,6 @@ const Stream = require('stream');
 describe('res.socket', () => {
   it('should return the request socket object', () => {
     const res = response();
-    assert.equal(res.socket instanceof Stream, true);
+    assert.strictEqual(res.socket instanceof Stream, true);
   });
 });

--- a/test/response/status.js
+++ b/test/response/status.js
@@ -13,7 +13,7 @@ describe('res.status=', () => {
       it('should set the status', () => {
         const res = response();
         res.status = 403;
-        assert.equal(res.status, 403);
+        assert.strictEqual(res.status, 403);
       });
 
       it('should not throw', () => {
@@ -35,7 +35,7 @@ describe('res.status=', () => {
       it('should set the status', () => {
         const res = response();
         res.status = 700;
-        assert.equal(res.status, 700);
+        assert.strictEqual(res.status, 700);
       });
 
       it('should not throw', () => {
@@ -62,7 +62,7 @@ describe('res.status=', () => {
   });
 
   function strip(status){
-    it('should strip content related header fields', async () => {
+    it('should strip content related header fields', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -80,13 +80,13 @@ describe('res.status=', () => {
         .get('/')
         .expect(status);
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
-      assert.equal(res.headers.hasOwnProperty('content-length'), false);
-      assert.equal(res.headers.hasOwnProperty('content-encoding'), false);
-      assert.equal(res.text.length, 0);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-encoding'), false);
+      assert.strictEqual(res.text.length, 0);
     });
 
-    it('should strip content releated header fields after status set', async () => {
+    it('should strip content releated header fields after status set', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -101,10 +101,10 @@ describe('res.status=', () => {
         .get('/')
         .expect(status);
 
-      assert.equal(res.headers.hasOwnProperty('content-type'), false);
-      assert.equal(res.headers.hasOwnProperty('content-length'), false);
-      assert.equal(res.headers.hasOwnProperty('content-encoding'), false);
-      assert.equal(res.text.length, 0);
+      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
+      assert.strictEqual(res.headers.hasOwnProperty('content-encoding'), false);
+      assert.strictEqual(res.text.length, 0);
     });
   }
 

--- a/test/response/type.js
+++ b/test/response/type.js
@@ -9,8 +9,8 @@ describe('ctx.type=', () => {
     it('should set the Content-Type', () => {
       const ctx = context();
       ctx.type = 'text/plain';
-      assert.equal(ctx.type, 'text/plain');
-      assert.equal(ctx.response.header['content-type'], 'text/plain; charset=utf-8');
+      assert.strictEqual(ctx.type, 'text/plain');
+      assert.strictEqual(ctx.response.header['content-type'], 'text/plain; charset=utf-8');
     });
   });
 
@@ -18,8 +18,8 @@ describe('ctx.type=', () => {
     it('should lookup the mime', () => {
       const ctx = context();
       ctx.type = 'json';
-      assert.equal(ctx.type, 'application/json');
-      assert.equal(ctx.response.header['content-type'], 'application/json; charset=utf-8');
+      assert.strictEqual(ctx.type, 'application/json');
+      assert.strictEqual(ctx.response.header['content-type'], 'application/json; charset=utf-8');
     });
   });
 
@@ -27,8 +27,8 @@ describe('ctx.type=', () => {
     it('should default the charset', () => {
       const ctx = context();
       ctx.type = 'text/html';
-      assert.equal(ctx.type, 'text/html');
-      assert.equal(ctx.response.header['content-type'], 'text/html; charset=utf-8');
+      assert.strictEqual(ctx.type, 'text/html');
+      assert.strictEqual(ctx.response.header['content-type'], 'text/html; charset=utf-8');
     });
   });
 
@@ -36,8 +36,8 @@ describe('ctx.type=', () => {
     it('should not default the charset', () => {
       const ctx = context();
       ctx.type = 'text/html; charset=foo';
-      assert.equal(ctx.type, 'text/html');
-      assert.equal(ctx.response.header['content-type'], 'text/html; charset=foo');
+      assert.strictEqual(ctx.type, 'text/html');
+      assert.strictEqual(ctx.response.header['content-type'], 'text/html; charset=foo');
     });
   });
 
@@ -63,7 +63,7 @@ describe('ctx.type', () => {
     it('should return the mime', () => {
       const ctx = context();
       ctx.type = 'json';
-      assert.equal(ctx.type, 'application/json');
+      assert.strictEqual(ctx.type, 'application/json');
     });
   });
 });

--- a/test/response/vary.js
+++ b/test/response/vary.js
@@ -9,7 +9,7 @@ describe('ctx.vary(field)', () => {
     it('should set it', () => {
       const ctx = context();
       ctx.vary('Accept');
-      assert.equal(ctx.response.header.vary, 'Accept');
+      assert.strictEqual(ctx.response.header.vary, 'Accept');
     });
   });
 
@@ -18,7 +18,7 @@ describe('ctx.vary(field)', () => {
       const ctx = context();
       ctx.vary('Accept');
       ctx.vary('Accept-Encoding');
-      assert.equal(ctx.response.header.vary, 'Accept, Accept-Encoding');
+      assert.strictEqual(ctx.response.header.vary, 'Accept, Accept-Encoding');
     });
   });
 
@@ -29,7 +29,7 @@ describe('ctx.vary(field)', () => {
       ctx.vary('Accept-Encoding');
       ctx.vary('Accept');
       ctx.vary('Accept-Encoding');
-      assert.equal(ctx.response.header.vary, 'Accept, Accept-Encoding');
+      assert.strictEqual(ctx.response.header.vary, 'Accept, Accept-Encoding');
     });
   });
 });

--- a/test/response/writable.js
+++ b/test/response/writable.js
@@ -9,7 +9,7 @@ describe('res.writable', () => {
   describe('when continuous requests in one persistent connection', () => {
     function requestTwice(server, done){
       const port = server.address().port;
-      const buf = new Buffer('GET / HTTP/1.1\r\nHost: localhost:' + port + '\r\nConnection: keep-alive\r\n\r\n');
+      const buf = Buffer.from('GET / HTTP/1.1\r\nHost: localhost:' + port + '\r\nConnection: keep-alive\r\n\r\n');
       const client = net.connect(port);
       const datas = [];
       client
@@ -32,8 +32,8 @@ describe('res.writable', () => {
       const server = app.listen();
       requestTwice(server, (_, datas) => {
         const responses = Buffer.concat(datas).toString();
-        assert.equal(/request 1, writable: true/.test(responses), true);
-        assert.equal(/request 2, writable: true/.test(responses), true);
+        assert.strictEqual(/request 1, writable: true/.test(responses), true);
+        assert.strictEqual(/request 2, writable: true/.test(responses), true);
         done();
       });
     });
@@ -54,10 +54,10 @@ describe('res.writable', () => {
       const app = new Koa();
       app.use(ctx => {
         sleep(1000)
-        .then(() => {
-          if (ctx.writable) return done(new Error('ctx.writable should not be true'));
-          done();
-        });
+          .then(() => {
+            if (ctx.writable) return done(new Error('ctx.writable should not be true'));
+            done();
+          });
       });
       const server = app.listen();
       requestClosed(server);


### PR DESCRIPTION
- context.onerror destorys the request socket if it is called after
  headers have been sent to complete the request
- context.onerror now throws TypeError if passed a non-Error to align
  with application.onerror
- fixed lint errors
  - remove usages of deprecated assertions
  - removed space between async and opening parens
- replace calls to server.listen by passing app.callback() to supertest
  so that tests do not leave open event handlers
- replaced callback completion test with async tests in cases where the
  tests failed due to callbacks being called in unexpected order