### PR TITLE
chore(deps): fix audit error by upgrading jest to ^24

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -180,7 +180,11 @@ module.exports = class Application extends Emitter {
    */
 
   onerror(err) {
-    if (!(err instanceof Error)) throw new TypeError(util.format('non-error thrown: %j', err));
+    // the jest vm may cause instanceof checks to fail e.g. fs ENOENT
+    // https://github.com/facebook/jest/issues/2549
+    if (!(err instanceof Error) && err.constructor.name !== 'Error') {
+      throw new TypeError(util.format('non-error thrown: %j', err));
+    }
 
     if (404 == err.status || err.expose) return;
     if (this.silent) return;

--- a/lib/context.js
+++ b/lib/context.js
@@ -110,7 +110,11 @@ const proto = module.exports = {
     // to node-style callbacks.
     if (null == err) return;
 
-    if (!(err instanceof Error)) err = new Error(util.format('non-error thrown: %j', err));
+    // the jest vm may cause instanceof checks to fail e.g. fs ENOENT
+    // https://github.com/facebook/jest/issues/2549
+    if (!(err instanceof Error) && err.constructor.name !== 'Error') {
+      err = new Error(util.format('non-error thrown: %j', err));
+    }
 
     let headerSent = false;
     if (this.headerSent || !this.writable) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-standard": "^7.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.1.1",
-    "jest": "^20.0.0",
+    "jest": "^24.0.0",
     "supertest": "^3.1.0"
   },
   "engines": {


### PR DESCRIPTION
Upgrade Jest due to npm audit errors, which gets me to what @jstewmon stumbled upon in #1318.

This PR **only** upgrades Jest (due to audit errors), and unlike #1318 it does not change the error type in [lib/context#116](https://github.com/koajs/koa/pull/1318/files#diff-d911385a221c0b7502eabe1fdac9d209R116), which to me is a breaking change. However the solution is the same.

I dislike having to work around Jest in lib for it to pass but the only other option is to move away from Jest.

Referens from comments to Jest issue: https://github.com/facebook/jest/issues/2549