### PR TITLE
Use req.originalUrl when used as express middleware

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -167,7 +167,7 @@ module.exports = class Application extends Emitter {
     request.ctx = response.ctx = context;
     request.response = response;
     response.request = request;
-    context.originalUrl = request.originalUrl = req.url;
+    context.originalUrl = request.originalUrl = req.originalUrl || req.url;
     context.state = {};
     return context;
   }


### PR DESCRIPTION
Attempt at fixing https://github.com/koajs/koa/issues/1367