### PR TITLE
accept options in the Application constructor

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -112,8 +112,21 @@ app.listen(3000);
   the following are supported:
 
   - `app.env` defaulting to the __NODE_ENV__ or "development"
+  - `app.keys` array of signed cookie keys
   - `app.proxy` when true proxy header fields will be trusted
   - `app.subdomainOffset` offset of `.subdomains` to ignore [2]
+
+  You can pass the settings to the constructor:
+  ```js
+  const Koa = require('koa');
+  const app = new Koa({ proxy: true });
+  ```
+  or dynamically:
+  ```js
+  const Koa = require('koa');
+  const app = new Koa();
+  app.proxy = true;
+  ```
 
 ## app.listen(...)
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -34,13 +34,22 @@ module.exports = class Application extends Emitter {
    * @api public
    */
 
-  constructor() {
+  /**
+    *
+    * @param {object} [options] Application options
+    * @param {string} [options.env='development'] Environment
+    * @param {string[]} [options.keys] Signed cookie keys
+    * @param {string} [options.proxy] Trust proxy headers
+    * @param {number} [options.subdomainOffset] Subdomain offset
+    *
+    */
+  constructor(options = {}) {
     super();
-
-    this.proxy = false;
+    this.proxy = options.proxy || false;
     this.middleware = [];
-    this.subdomainOffset = 2;
-    this.env = process.env.NODE_ENV || 'development';
+    this.subdomainOffset = options.subdomainOffset || 2;
+    this.env = options.env || process.env.NODE_ENV || 'development';
+    this.keys = options.keys || undefined;
     this.context = Object.create(context);
     this.request = Object.create(request);
     this.response = Object.create(response);

--- a/lib/application.js
+++ b/lib/application.js
@@ -43,6 +43,7 @@ module.exports = class Application extends Emitter {
     * @param {number} [options.subdomainOffset] Subdomain offset
     *
     */
+
   constructor(options = {}) {
     super();
     this.proxy = options.proxy || false;

--- a/lib/application.js
+++ b/lib/application.js
@@ -39,7 +39,7 @@ module.exports = class Application extends Emitter {
     * @param {object} [options] Application options
     * @param {string} [options.env='development'] Environment
     * @param {string[]} [options.keys] Signed cookie keys
-    * @param {string} [options.proxy] Trust proxy headers
+    * @param {boolean} [options.proxy] Trust proxy headers
     * @param {number} [options.subdomainOffset] Subdomain offset
     *
     */

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -72,7 +72,7 @@ describe('app', () => {
     assert.strictEqual(app.keys, keys);
   });
 
-  it('should set env from the constructor', () => {
+  it('should set subdomainOffset from the constructor', () => {
     const subdomainOffset = 3;
     const app = new Koa({ subdomainOffset });
     assert.strictEqual(app.subdomainOffset, subdomainOffset);

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -53,4 +53,28 @@ describe('app', () => {
     process.env.NODE_ENV = NODE_ENV;
     assert.equal(app.env, 'development');
   });
+
+  it('should set env from the constructor', () => {
+    const env = 'custom';
+    const app = new Koa({ env });
+    assert.strictEqual(app.env, env);
+  });
+
+  it('should set proxy flag from the constructor', () => {
+    const proxy = true;
+    const app = new Koa({ proxy });
+    assert.strictEqual(app.proxy, proxy);
+  });
+
+  it('should set signed cookie keys from the constructor', () => {
+    const keys = ['customkey'];
+    const app = new Koa({ keys });
+    assert.strictEqual(app.keys, keys);
+  });
+
+  it('should set env from the constructor', () => {
+    const subdomainOffset = 3;
+    const app = new Koa({ subdomainOffset });
+    assert.strictEqual(app.subdomainOffset, subdomainOffset);
+  });
 });


### PR DESCRIPTION
Accept an options object on the application constructor to configure app.env, app.proxy, app.keys, and app.subdomainOffset.

https://github.com/koajs/koa/issues/1370
