### PR TITLE
docs: parameter of request.get is case-insensitive

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -386,4 +386,4 @@ ctx.acceptsLanguages();
 
 ### request.get(field)
 
-  Return request header.
+  Return request header with case-insensitive `field`.


### PR DESCRIPTION
Note case-insensitivity for `request.get`, as [docs already do for `response.get`](https://github.com/koajs/koa/blob/master/docs/api/response.md#responsegetfield)