### PR TITLE
feat: support sameSite=none cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cache-content-type": "^1.0.0",
     "content-disposition": "~0.5.2",
     "content-type": "^1.0.4",
-    "cookies": "~0.7.1",
+    "cookies": "~0.8.0",
     "debug": "~3.1.0",
     "delegates": "^1.0.0",
     "depd": "^1.1.2",


### PR DESCRIPTION
This bumps the `cookies` package dependency to add support for `sameSite` cookie attribute value `none`.