### PR TITLE
use rest params for request/response .is

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -622,15 +622,14 @@ module.exports = {
    *
    *     this.is('html'); // => false
    *
-   * @param {String|Array} types...
+   * @param {String|String[]} [type]
+   * @param {String[]} [types]
    * @return {String|false|null}
    * @api public
    */
 
-  is(types) {
-    if (!types) return typeis(this.req);
-    if (!Array.isArray(types)) types = [].slice.call(arguments);
-    return typeis(this.req, types);
+  is(type, ...types) {
+    return typeis(this.req, type, ...types);
   },
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -389,16 +389,14 @@ module.exports = {
    * Check whether the response is one of the listed types.
    * Pretty much the same as `this.request.is()`.
    *
-   * @param {String|Array} types...
+   * @param {String|String[]} [type]
+   * @param {String[]} [types]
    * @return {String|false}
    * @api public
    */
 
-  is(types) {
-    const type = this.type;
-    if (!types) return type || false;
-    if (!Array.isArray(types)) types = [].slice.call(arguments);
-    return typeis(type, types);
+  is(type, ...types) {
+    return typeis(this.type, type, ...types);
   },
 
   /**


### PR DESCRIPTION
Using rest params and validation/concatenating logic is built-in into `type-is`
Also fixes JSDoc declaration