### PR TITLE
emit more events

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -155,6 +155,7 @@ module.exports = class Application extends Emitter {
    */
 
   handleRequest(ctx, fnMiddleware) {
+    this.emit('request', ctx);
     const res = ctx.res;
     res.statusCode = 404;
     const onerror = err => ctx.onerror(err);
@@ -218,18 +219,21 @@ function respond(ctx) {
   let body = ctx.body;
   const code = ctx.status;
 
+  ctx.app.emit('respond', ctx);
+  const onResponded = () => ctx.app.emit('responded', ctx);
+
   // ignore body
   if (statuses.empty[code]) {
     // strip headers
     ctx.body = null;
-    return res.end();
+    return res.end(onResponded);
   }
 
   if ('HEAD' == ctx.method) {
     if (!res.headersSent && isJSON(body)) {
       ctx.length = Buffer.byteLength(JSON.stringify(body));
     }
-    return res.end();
+    return res.end(onResponded);
   }
 
   // status body
@@ -243,12 +247,12 @@ function respond(ctx) {
       ctx.type = 'text';
       ctx.length = Buffer.byteLength(body);
     }
-    return res.end(body);
+    return res.end(body, onResponded);
   }
 
   // responses
-  if (Buffer.isBuffer(body)) return res.end(body);
-  if ('string' == typeof body) return res.end(body);
+  if (Buffer.isBuffer(body)) return res.end(body, onResponded);
+  if ('string' == typeof body) return res.end(body, onResponded);
   if (body instanceof Stream) return body.pipe(res);
 
   // body: json
@@ -256,7 +260,7 @@ function respond(ctx) {
   if (!res.headersSent) {
     ctx.length = Buffer.byteLength(body);
   }
-  res.end(body);
+  res.end(body, onResponded);
 }
 
 /**


### PR DESCRIPTION
Koa extends `EventEmitter` but doesn't use that fact for anything apart of `error` event.
However, there are lifecycle hooks that have real world use and otherwise hard to implement. This PR adds 3 events: 'request', 'respond' and 'responded' as well as documenting the fact that `Application` is an EventEmitter in more clear way.