### PR TITLE
enable codecov partial coverage and use bash uploader

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  parsers:
+    javascript:
+      enable_partials: yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   - npm run bench
 after_script:
   # only upload the coverage.json file
-  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.json
+  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ script:
   - npm run test-cov
   - npm run bench
 after_script:
-  - npm install codecov
-  - ./node_modules/.bin/codecov
+  # only upload the coverage.json file
+  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.json


### PR DESCRIPTION
Enables [partial line coverage](https://docs.codecov.io/docs/node#section-partial-line-coverage) for Codecov and uses faster Bash uploader targeting just one particular file

This will lower reported coverage because CI tests currently runs only on Node >=8 and Koa has some legacy code for earlier versions of Node