### PR TITLE
use response.get to get just one header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -204,7 +204,7 @@ module.exports = {
     const len = this.get('Content-Length');
     const body = this.body;
 
-    if (null == len) {
+    if (!len) {
       if (!body) return;
       if ('string' == typeof body) return Buffer.byteLength(body);
       if (Buffer.isBuffer(body)) return body.length;

--- a/lib/response.js
+++ b/lib/response.js
@@ -201,7 +201,7 @@ module.exports = {
    */
 
   get length() {
-    const len = this.header['content-length'];
+    const len = this.get('Content-Length');
     const body = this.body;
 
     if (null == len) {


### PR DESCRIPTION
It's more semantical to use `response.get` to get just one header and if #1392 will be merged it's also will be more performant. 