### PR TITLE
support `writableEnded`

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -502,7 +502,11 @@ module.exports = {
 
   get writable() {
     // can't write any more after response finished
-    if (this.res.finished) return false;
+    // response.writableEnded is available since Node > 12.9
+    // https://nodejs.org/api/http.html#http_response_writableended
+    // response.finished is undocumented feature of previous Node versions
+    // https://stackoverflow.com/questions/16254385/undocumented-response-finished-in-node-js
+    if (this.res.writableEnded || this.res.finished) return false;
 
     const socket = this.res.socket;
     // There are already pending outgoing res, but still writable


### PR DESCRIPTION
Add support for documented since Node >= 12.9 [response.writableEnded](https://nodejs.org/api/http.html#http_response_writableended) property alongside undocumented [response.finished](https://stackoverflow.com/questions/16254385/undocumented-response-finished-in-node-js) used currently.