### PR TITLE
handling Objects for streaming bodies

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -256,6 +256,7 @@ function respond(ctx) {
         (body._readableState &&
           body._readableState.objectMode)) {
       let first = true;
+      res.write('[');
       body = body
         .pipe(new Stream.Transform({
           writableObjectMode: true,
@@ -263,7 +264,7 @@ function respond(ctx) {
           transform(data, encoding, callback) {
             const str = JSON.stringify(data);
             if (first) {
-              this.push(`[${str}`);
+              this.push(`${str}`);
               first = false;
             } else {
               this.push(`,${str}`);
@@ -271,7 +272,7 @@ function respond(ctx) {
             return callback();
           },
           flush(callback) {
-            if (!first) this.push(`]`);
+            this.push(`]`);
             this.push(null);
             return callback();
           }

--- a/lib/application.js
+++ b/lib/application.js
@@ -262,13 +262,10 @@ function respond(ctx) {
           writableObjectMode: true,
           readableObjectMode: false,
           transform(data, encoding, callback) {
-            const str = JSON.stringify(data);
-            if (first) {
-              this.push(`${str}`);
-              first = false;
-            } else {
-              this.push(`,${str}`);
-            }
+            if (!first) this.push(',');
+            else first = false;
+
+            this.push(JSON.stringify(data));
             return callback();
           },
           flush(callback) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -249,7 +249,36 @@ function respond(ctx) {
   // responses
   if (Buffer.isBuffer(body)) return res.end(body);
   if ('string' == typeof body) return res.end(body);
-  if (body instanceof Stream) return body.pipe(res);
+  if (body instanceof Stream) {
+    // check if it's an objectMode stream
+    // readableObjectMode is available since Node 12.3
+    if (body.readableObjectMode ||
+        (body._readableState &&
+          body._readableState.objectMode)) {
+      let first = true;
+      body = body
+        .pipe(new Stream.Transform({
+          writableObjectMode: true,
+          readableObjectMode: false,
+          transform(data, encoding, callback) {
+            const str = JSON.stringify(data);
+            if (first) {
+              this.push(`[${str}`);
+              first = false;
+            } else {
+              this.push(`,${str}`);
+            }
+            return callback();
+          },
+          flush(callback) {
+            if (!first) this.push(`]`);
+            this.push(null);
+            return callback();
+          }
+        }));
+    }
+    return body.pipe(res);
+  }
 
   // body: json
   body = JSON.stringify(body);

--- a/lib/application.js
+++ b/lib/application.js
@@ -273,7 +273,7 @@ function respond(ctx) {
             return callback();
           },
           flush(callback) {
-            this.push(`]`);
+            this.push(']');
             this.push(null);
             return callback();
           }

--- a/lib/response.js
+++ b/lib/response.js
@@ -166,14 +166,21 @@ module.exports = {
     }
 
     // stream
-    if ('function' == typeof val.pipe) {
+    if (val instanceof Stream) {
       onFinish(this.res, destroy.bind(null, val));
       ensureErrorHandler(val, err => this.ctx.onerror(err));
 
       // overwriting
       if (null != original && original != val) this.remove('Content-Length');
 
-      if (setType) this.type = 'bin';
+      if (setType) {
+        // check if it's an objectMode stream
+        // readableObjectMode is available since Node 12.3
+        this.type = (val.readableObjectMode ||
+                    (val._readableState &&
+                    val._readableState.objectMode))
+          ? 'json' : 'bin';
+      }
       return;
     }
 

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -641,6 +641,24 @@ describe('app.respond', () => {
       assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
     });
 
+    it('empty object mode stream should result in empty array', async() => {
+      const app = new Koa();
+
+      app.use(ctx => {
+        const stream = new PassThrough({ objectMode: true, autoDestroy: false });
+        ctx.body = stream;
+        setImmediate(() => stream.end());
+      });
+
+      const server = app.listen();
+
+      const res = await request(server)
+        .get('/')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect('[]');
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
+    });
+
     it('should handle errors', done => {
       const app = new Koa();
 

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -619,7 +619,7 @@ describe('app.respond', () => {
         assert.deepEqual(res.body, pkg);
       });
 
-    it('should serve object mode streams as JSON', () => {
+    it('should serve object mode streams as JSON', async() => {
       const app = new Koa();
 
       app.use(ctx => {
@@ -634,10 +634,11 @@ describe('app.respond', () => {
 
       const server = app.listen();
 
-      return request(server)
+      const res = await request(server)
         .get('/')
         .expect('Content-Type', 'application/json; charset=utf-8')
         .expect('[{"foo":1},{"boo":[true]},{"finish":true}]');
+      assert.strictEqual(res.headers.hasOwnProperty('content-length'), false);
     });
 
     it('should handle errors', done => {

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -4,6 +4,7 @@
 const response = require('../helpers/context').response;
 const assert = require('assert');
 const fs = require('fs');
+const { PassThrough } = require('stream');
 
 describe('res.body=', () => {
   describe('when Content-Type is set', () => {
@@ -107,6 +108,13 @@ describe('res.body=', () => {
       const res = response();
       res.body = fs.createReadStream('LICENSE');
       assert.equal('application/octet-stream', res.header['content-type']);
+    });
+
+    it('object mode stream', () => {
+      const res = response();
+      const stream = new PassThrough({ objectMode: true });
+      res.body = stream;
+      assert.equal('application/json; charset=utf-8', res.header['content-type']);
     });
   });
 


### PR DESCRIPTION
Koa currently throws while attempting to pipe an object mode stream into HTTP response.
This PR fixes that behavior allowing to serve that streams as JSON body.

Node.js 12.3 introduced a [documented way to check that a stream in object mode](https://nodejs.org/api/stream.html#stream_readable_readableobjectmode) stream, so, I think Koa must support such streams as first-class citizens out of the box.