### PR TITLE
prefer standard functions over external dependencies

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -5,7 +5,6 @@
  * Module dependencies.
  */
 
-const isGeneratorFunction = require('is-generator-function');
 const debug = require('debug')('koa:application');
 const onFinished = require('on-finished');
 const response = require('./response');
@@ -15,6 +14,9 @@ const request = require('./request');
 const statuses = require('statuses');
 const Emitter = require('events');
 const util = require('util');
+const isGeneratorFunction = util.types
+  ? util.types.isGeneratorFunction
+  : require('is-generator-function');
 const Stream = require('stream');
 const http = require('http');
 const only = require('only');

--- a/lib/application.js
+++ b/lib/application.js
@@ -6,7 +6,6 @@
  */
 
 const debug = require('debug')('koa:application');
-const onFinished = require('on-finished');
 const response = require('./response');
 const compose = require('koa-compose');
 const context = require('./context');
@@ -18,6 +17,7 @@ const isGeneratorFunction = util.types
   ? util.types.isGeneratorFunction
   : require('is-generator-function');
 const Stream = require('stream');
+const onFinished = Stream.finished || require('on-finished');
 const http = require('http');
 const only = require('only');
 const convert = require('koa-convert');

--- a/lib/application.js
+++ b/lib/application.js
@@ -21,7 +21,6 @@ const Stream = require('stream');
 const http = require('http');
 const only = require('only');
 const convert = require('koa-convert');
-const deprecate = require('depd')('koa');
 const { HttpError } = require('http-errors');
 
 /**
@@ -118,9 +117,13 @@ module.exports = class Application extends Emitter {
   use(fn) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
     if (isGeneratorFunction(fn)) {
-      deprecate('Support for generators will be removed in v3. ' +
-                'See the documentation for examples of how to convert old middleware ' +
-                'https://github.com/koajs/koa/blob/master/docs/migration.md');
+      process.emitWarning([
+        'Support for generators will be removed in v3.',
+        'See the documentation for examples of how to convert old middleware ',
+        'https://github.com/koajs/koa/blob/master/docs/migration.md'
+      ].join('\n'),
+      fn.name || fn.toString().split('\n', 1)[0].substr(0, 20)
+      );
       fn = convert(fn);
     }
     debug('use %s', fn._name || fn.name || '-');

--- a/lib/application.js
+++ b/lib/application.js
@@ -117,7 +117,7 @@ module.exports = class Application extends Emitter {
   use(fn) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
     if (isGeneratorFunction(fn)) {
-      if (!this.warnedDeprecation) {
+      if (!process.env.warned_generator_deprecation) {
         process.emitWarning([
           'Support for generators will be removed in v3.',
           'See the documentation for examples of how to convert old middleware ',
@@ -125,7 +125,7 @@ module.exports = class Application extends Emitter {
         ].join('\n'),
         'DeprecationWarning'
         );
-        this.warnedDeprecation = true;
+        process.env.warned_generator_deprecation = 'done';
       }
       fn = convert(fn);
     }

--- a/lib/application.js
+++ b/lib/application.js
@@ -117,13 +117,16 @@ module.exports = class Application extends Emitter {
   use(fn) {
     if (typeof fn !== 'function') throw new TypeError('middleware must be a function!');
     if (isGeneratorFunction(fn)) {
-      process.emitWarning([
-        'Support for generators will be removed in v3.',
-        'See the documentation for examples of how to convert old middleware ',
-        'https://github.com/koajs/koa/blob/master/docs/migration.md'
-      ].join('\n'),
-      fn.name || fn.toString().split('\n', 1)[0].substr(0, 20)
-      );
+      if (!this.warnedDeprecation) {
+        process.emitWarning([
+          'Support for generators will be removed in v3.',
+          'See the documentation for examples of how to convert old middleware ',
+          'https://github.com/koajs/koa/blob/master/docs/migration.md'
+        ].join('\n'),
+        'DeprecationWarning'
+        );
+        this.warnedDeprecation = true;
+      }
       fn = convert(fn);
     }
     debug('use %s', fn._name || fn.name || '-');

--- a/lib/response.js
+++ b/lib/response.js
@@ -8,7 +8,6 @@
 const contentDisposition = require('content-disposition');
 const ensureErrorHandler = require('error-inject');
 const getType = require('cache-content-type');
-const onFinish = require('on-finished');
 const escape = require('escape-html');
 const typeis = require('type-is').is;
 const statuses = require('statuses');
@@ -20,6 +19,7 @@ const only = require('only');
 const util = require('util');
 const encodeUrl = require('encodeurl');
 const Stream = require('stream');
+const onFinish = Stream.finished || require('on-finished');
 
 /**
  * Prototype.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "cookies": "~0.8.0",
     "debug": "~3.1.0",
     "delegates": "^1.0.0",
-    "depd": "^1.1.2",
     "destroy": "^1.0.4",
     "encodeurl": "^1.0.2",
     "error-inject": "^1.0.0",

--- a/test/application/index.js
+++ b/test/application/index.js
@@ -15,7 +15,10 @@ describe('app', () => {
     });
 
     app.on('error', err => {
-      assert.equal(err.message, 'boom');
+      // Stream.finished throws different error than `on-finished` module
+      assert.ok(
+        err.code === 'ERR_STREAM_PREMATURE_CLOSE' || err.message === 'boom'
+      );
       done();
     });
 

--- a/test/application/use.js
+++ b/test/application/use.js
@@ -86,7 +86,7 @@ describe('app.use(fn)', () => {
   });
 
   it('should accept both generator and function middleware', () => {
-    process.once('deprecation', () => {}); // silence deprecation message
+    process.once('warning', () => {}); // silence deprecation message
     const app = new Koa();
 
     app.use((ctx, next) => next());
@@ -107,6 +107,7 @@ describe('app.use(fn)', () => {
   });
 
   it('should output deprecation message for generator functions', done => {
+    delete process.env.warned_generator_deprecation;
     process.once('warning', message => {
       assert(/Support for generators will be removed/.test(message));
       done();

--- a/test/application/use.js
+++ b/test/application/use.js
@@ -107,7 +107,7 @@ describe('app.use(fn)', () => {
   });
 
   it('should output deprecation message for generator functions', done => {
-    process.once('deprecation', message => {
+    process.once('warning', message => {
       assert(/Support for generators will be removed/.test(message));
       done();
     });

--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -6,8 +6,8 @@ const Koa = require('../..');
 
 module.exports = (req, res, app) => {
   const socket = new Stream.Duplex();
-  req = Object.assign({ headers: {}, socket }, Stream.Readable.prototype, req);
-  res = Object.assign({ _headers: {}, socket }, Stream.Writable.prototype, res);
+  req = Object.assign(new Stream.Readable(), { headers: {}, socket }, req);
+  res = Object.assign(new Stream.Writable(), { _headers: {}, socket }, res);
   req.socket.remoteAddress = req.socket.remoteAddress || '127.0.0.1';
   app = app || new Koa();
   res.getHeader = k => res._headers[k.toLowerCase()];


### PR DESCRIPTION
This PR fixes three issues, two happens to be related to generator functions middleware. 
While this functionality will be removed completely in Koa 3.0, the next major version is not on the radar yet (unfortunately), but these small changes will make Koa a little bit faster and safer _today_.

1. Use `util.types.isGeneratorFunction` when available (Node >= 10) instead of loading external dependency.

2. Remove `depd` dependency and use `process.emitWarning`. `depd` is huge for the purpose [![install size](https://packagephobia.now.sh/badge?p=depd)](https://packagephobia.now.sh/result?p=depd) - it's 500+ lines of code (twice as big as Koa' `application.js`) and used just once - to deprecate generator middleware. `process.emitWarning` coupled with `--no-deprecation` and `--trace-deprecation` command-line flags resulting in the same functionality while having one less external dependency to load.

3. Use standard (since Node >= 10), `Stream.finished` instead of external `on-finished` module when supported. This required small change in context mocking to actually create stream (I think that was necessary anyway for correctness)
