### PR TITLE
update ESLint and plugins/configs

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -7,13 +7,13 @@ const app = new Koa();
 // number of middleware
 
 let n = parseInt(process.env.MW || '1', 10);
-let useAsync = process.env.USE_ASYNC === 'true';
+const useAsync = process.env.USE_ASYNC === 'true';
 
 console.log(`  ${n}${useAsync ? ' async' : ''} middleware`);
 
 while (n--) {
   if (useAsync) {
-    app.use(async(ctx, next) => await next());
+    app.use(async(ctx, next) => next());
   } else {
     app.use((ctx, next) => next());
   }

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
   },
   "devDependencies": {
     "egg-bin": "^4.13.0",
-    "eslint": "^6.0.1",
+    "eslint": "^6.5.1",
     "eslint-config-koa": "^2.0.0",
-    "eslint-config-standard": "^7.0.1",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^2.1.1",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
     "mm": "^2.5.0",
     "supertest": "^3.1.0"
   },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,0 @@
-env:
-  jest: true
-
-rules:
-  space-before-blocks: [2, {functions: never, keywords: always}]
-  no-unused-expressions: 0

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,12 @@
+env:
+  mocha: true
+
+rules:
+  space-before-blocks: [2, {functions: never, keywords: always}]
+  no-unused-expressions: 0
+  node/no-deprecated-api: 'warn'
+  quote-props: 'warn'
+  no-prototype-builtins: 'warn'
+  array-bracket-spacing: 'warn'
+  object-curly-spacing: 'warn'
+  dot-notation: 'warn'


### PR DESCRIPTION
1. Updates ESLint to the version 6.5.x
2. Updates `eslint-config-standard` to the version 14.x from 7.x. It brings two more required peerDependencies, `eslint-plugin-import` and `eslint-plugin-node`, and the last one if very helpful with Koa tricky `engines`
3. Add explicit extension to the eslint config for tests, lowering newly discovered errors to warning for now, and fixing env from `jest` to `mocha`
4. Fixing lint errors in benchmark.