### PR TITLE
feat: support sameSite=none cookies (bump cookies dependency) (#1390)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "composition": "^2.1.1",
     "content-disposition": "~0.5.0",
     "content-type": "^1.0.0",
-    "cookies": "~0.7.0",
+    "cookies": "~0.8.0",
     "debug": "^2.6.9",
     "delegates": "^1.0.0",
     "destroy": "^1.0.3",


### PR DESCRIPTION
Updated cookie dependency on v1 branch to support sameSite=none cookies.

This change was already applied to the current (v2) but we needed this same functionality for v1.