### PR TITLE
remove `error-inject` and fix error handling

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -6,7 +6,6 @@
  */
 
 const contentDisposition = require('content-disposition');
-const ensureErrorHandler = require('error-inject');
 const getType = require('cache-content-type');
 const onFinish = require('on-finished');
 const escape = require('escape-html');
@@ -166,12 +165,14 @@ module.exports = {
     }
 
     // stream
-    if ('function' == typeof val.pipe) {
+    if (val instanceof Stream) {
       onFinish(this.res, destroy.bind(null, val));
-      ensureErrorHandler(val, err => this.ctx.onerror(err));
 
-      // overwriting
-      if (null != original && original != val) this.remove('Content-Length');
+      if (original != val) {
+        val.once('error', err => this.ctx.onerror(err));
+        // overwriting
+        if (null != original) this.remove('Content-Length');
+      }
 
       if (setType) this.type = 'bin';
       return;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "depd": "^1.1.2",
     "destroy": "^1.0.4",
     "encodeurl": "^1.0.2",
-    "error-inject": "^1.0.0",
     "escape-html": "^1.0.3",
     "fresh": "~0.5.2",
     "http-assert": "^1.3.0",

--- a/test/response/body.js
+++ b/test/response/body.js
@@ -4,6 +4,7 @@
 const response = require('../helpers/context').response;
 const assert = require('assert');
 const fs = require('fs');
+const Stream = require('stream');
 
 describe('res.body=', () => {
   describe('when Content-Type is set', () => {
@@ -107,6 +108,16 @@ describe('res.body=', () => {
       const res = response();
       res.body = fs.createReadStream('LICENSE');
       assert.equal('application/octet-stream', res.header['content-type']);
+    });
+
+    it('should add error handler to the stream, but only once', () => {
+      const res = response();
+      const body = new Stream.PassThrough();
+      assert.strictEqual(body.listenerCount('error'), 0);
+      res.body = body;
+      assert.strictEqual(body.listenerCount('error'), 1);
+      res.body = body;
+      assert.strictEqual(body.listenerCount('error'), 1);
     });
   });
 


### PR DESCRIPTION
The whole `error-inject` functionality (it's [3 lines actually](https://github.com/stream-utils/error-inject/blob/2070e23a55611a19f20e41bd88c3bcbb79b160d2/index.js#L4)) is to add `error` event listener as `on` listener, while **working around the fact that Node doesn't check if that handler already exists**, so, that check was added.

However, by obscuring this logic in 3 lines module even module author @dead-horse probably forgot what exactly his module is doing while introducing #800, which basically rendered this check useless by creating inline function.

To prevent this to happen again, and also taking into account that `ctx.onerror` calls `res.end` and so, `.once` is the more appropriate listener, I'm proposing removing `error-inject` dependency and use the fact that respond body assignment already has logic to make something once per stream.