### PR TITLE
Drop unused Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - 8


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).