### PR TITLE
feat: Allow non 204 status for `null` JSON responses

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -59,6 +59,7 @@ module.exports = class Application extends Emitter {
     this.context = Object.create(context);
     this.request = Object.create(request);
     this.response = Object.create(response);
+    this.responseOptions = options.response;
     if (util.inspect.custom) {
       this[util.inspect.custom] = this.inspect;
     }
@@ -176,6 +177,7 @@ module.exports = class Application extends Emitter {
     const context = Object.create(this.context);
     const request = context.request = Object.create(this.request);
     const response = context.response = Object.create(this.response);
+    response.options = this.responseOptions;
     context.app = request.app = response.app = this;
     context.req = request.req = response.req = req;
     context.res = request.res = response.res = res;
@@ -237,7 +239,7 @@ function respond(ctx) {
   }
 
   // status body
-  if (null == body) {
+  if (null == body && false !== ctx.response.options.emptyBodyAs204) {
     if (ctx.req.httpVersionMajor >= 2) {
       body = String(code);
     } else {

--- a/lib/response.js
+++ b/lib/response.js
@@ -137,7 +137,7 @@ module.exports = {
     this._body = val;
 
     // no content
-    if (null == val) {
+    if (null == val && this.options.emptyBodyAs204 !== false) {
       if (!statuses.empty[this.status]) this.status = 204;
       this.remove('Content-Type');
       this.remove('Content-Length');
@@ -166,7 +166,7 @@ module.exports = {
     }
 
     // stream
-    if ('function' == typeof val.pipe) {
+    if (val && 'function' == typeof val.pipe) {
       onFinish(this.res, destroy.bind(null, val));
       ensureErrorHandler(val, err => this.ctx.onerror(err));
 
@@ -567,6 +567,30 @@ module.exports = {
    */
   flushHeaders() {
     this.res.flushHeaders();
+  },
+
+  /**
+   * Sets response options. This is called from the Application when the
+   * context is created.
+   *
+   * Currently supported:
+   *   emptyBodyAs204: boolean
+   *
+   *  @param {object} val options
+   * @api private
+   */
+  set options(val) {
+    this._options = val;
+  },
+
+  /**
+   * Gives access to the response options set by the Application when the
+   * context was created.
+   *
+   * @return {object} the response options
+   */
+  get options() {
+    return this._options || {};
   }
 };
 

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -465,6 +465,29 @@ describe('app.respond', () => {
       assert.equal(res.headers.hasOwnProperty('content-type'), false);
     });
 
+    it('should respond 200 with status=200 and emptyBodyAs204=false', async() => {
+      const app = new Koa({
+        response: {
+          emptyBodyAs204: false
+        }
+      });
+
+      app.use(ctx => {
+        ctx.status = 200;
+        ctx.body = null;
+        ctx.type = 'json';
+      });
+
+      const server = app.listen();
+
+      await request(server)
+        .get('/')
+        .expect(200)
+        .expect('null')
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect('Content-Length', '4');
+    });
+
     it('should respond 205 with status=205', async() => {
       const app = new Koa();
 


### PR DESCRIPTION
Introduces a new application option `emptyBodyAs204` that must be set explictly to `false` when creating the Koa app to prevent Koa from treating `null` body as 204.

Set it via

```js
new Koa({
  response: {
    emptyBodyAs204: false
  }
});
```
Closes #998

I'll provide documentation updates when we decided on a final name.