### PR TITLE
fix: for-in loop is missing hasOwnProperty check

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -463,7 +463,9 @@ module.exports = {
       this.res.setHeader(field, val);
     } else {
       for (const key in field) {
-        this.set(key, field[key]);
+        if (field.hasOwnProperty(key)) {
+          this.set(key, field[key]);
+        }
       }
     }
   },

--- a/lib/response.js
+++ b/lib/response.js
@@ -463,7 +463,7 @@ module.exports = {
       this.res.setHeader(field, val);
     } else {
       for (const key in field) {
-        if (field.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(field, key)) {
           this.set(key, field[key]);
         }
       }


### PR DESCRIPTION
Inspection info checks for unfiltered for-in loops, The use of this construct results in processing inherited or unexpected properties.