### PR TITLE
Document response status with empty body

### DIFF
--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -90,6 +90,16 @@ __NOTE__: don't worry too much about memorizing these strings,
 if you have a typo an error will be thrown, displaying this list
 so you can make a correction.
 
+  Since `response.status` default is set to `404`, to send a response
+  without a body and with a different status is to be done like this:
+
+```js
+ctx.response.status = 200;
+
+// Or whatever other status
+ctx.response.status = 204;
+```
+
 ### response.message
 
   Get response status message. By default, `response.message` is


### PR DESCRIPTION
Hello,

This is a very simple addition to the docs to explicitly document how to return a status code different than 400 when one doesn't set any body in the response.

As a new Koa user (coming from Express) this is a topic that has puzzled me at the beginning. Of course after having used Koa for a little while, the answer seems obvious. But I believe this addition will speed up even more the learning curve.