### PR TITLE
feat: allow bodyless responses for non empty status codes

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -238,6 +238,11 @@ function respond(ctx) {
 
   // status body
   if (null == body) {
+    if (ctx.response._explicitNullBody) {
+      ctx.response.remove('Content-Type');
+      ctx.response.remove('Transfer-Encoding');
+      return res.end();
+    }
     if (ctx.req.httpVersionMajor >= 2) {
       body = String(code);
     } else {

--- a/lib/response.js
+++ b/lib/response.js
@@ -139,6 +139,7 @@ module.exports = {
     // no content
     if (null == val) {
       if (!statuses.empty[this.status]) this.status = 204;
+      if (val === null) this._explicitNullBody = true;
       this.remove('Content-Type');
       this.remove('Content-Length');
       this.remove('Transfer-Encoding');

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -810,4 +810,41 @@ describe('app.respond', () => {
       assert.equal(res.headers.hasOwnProperty('content-type'), false);
     });
   });
+
+  describe('with explicit null body', () => {
+    it('should preserve given status', async() => {
+      const app = new Koa();
+
+      app.use(ctx => {
+        ctx.body = null;
+        ctx.status = 404;
+      });
+
+      const server = app.listen();
+
+      return request(server)
+        .get('/')
+        .expect(404)
+        .expect('')
+        .expect({});
+    });
+    it('should respond with correct headers', async() => {
+      const app = new Koa();
+
+      app.use(ctx => {
+        ctx.body = null;
+        ctx.status = 401;
+      });
+
+      const server = app.listen();
+
+      const res = await request(server)
+        .get('/')
+        .expect(401)
+        .expect('')
+        .expect({});
+
+      assert.equal(res.headers.hasOwnProperty('content-type'), false);
+    });
+  });
 });

--- a/test/application/response.js
+++ b/test/application/response.js
@@ -10,6 +10,8 @@ describe('app.response', () => {
   app1.response.msg = 'hello';
   const app2 = new Koa();
   const app3 = new Koa();
+  const app4 = new Koa();
+  const app5 = new Koa();
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
@@ -42,5 +44,31 @@ describe('app.response', () => {
       .get('/')
       .expect(404);
     assert.equal(response.text, '404');
+  });
+
+  it('should set ._explicitNullBody correctly', async() => {
+    app4.use((ctx, next) => {
+      ctx.body = null;
+      assert.strictEqual(ctx.response._explicitNullBody, true);
+    });
+
+    return request(app4.listen())
+      .get('/')
+      .expect(204);
+  });
+
+  it('should not set ._explicitNullBody incorrectly', async() => {
+    app5.use((ctx, next) => {
+      ctx.body = undefined;
+      assert.strictEqual(ctx.response._explicitNullBody, undefined);
+      ctx.body = '';
+      assert.strictEqual(ctx.response._explicitNullBody, undefined);
+      ctx.body = false;
+      assert.strictEqual(ctx.response._explicitNullBody, undefined);
+    });
+
+    return request(app5.listen())
+      .get('/')
+      .expect(204);
   });
 });


### PR DESCRIPTION
Fixes #1446

Either "Content-Length" must be left (resulting in 0) or we need to add "Connection: close" header as well. The former is what it's in this PR, but opinions are welcomed if the later is better.

If approved will add test cases. Usage:

```js
app.use((ctx, next) => {
  ctx.body = null; // Must be set first, as this sets status to 204 automatically
  ctx.status = 404;
});
```