### PR TITLE
Fixed incorrect example of ctx.onerror usage

### DIFF
--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -171,7 +171,7 @@ app.use(async (ctx, next) => {
 const PassThrough = require('stream').PassThrough;
 
 app.use(async ctx => {
-  ctx.body = someHTTPStream.on('error', ctx.onerror).pipe(PassThrough());
+  ctx.body = someHTTPStream.on('error', (err) => ctx.onerror(err)).pipe(PassThrough());
 });
 ```
 


### PR DESCRIPTION
https://koajs.com/#stream provides the following example on how to handle errors in koa handler:
```
const PassThrough = require('stream').PassThrough;

app.use(async ctx => {
  ctx.body = someHTTPStream.on('error', ctx.onerror).pipe(PassThrough());
});
```

but this example is buggy. Consider the following code:

```
const request = require('request');
const { PassThrough } = require('stream');
const Koa = require('koa');
const route = require('koa-route');

function getFile(ctx) {
    ctx.body = request
        .get('http://asdasd.com/')
        .on('error', ctx.onerror)
        .pipe(new PassThrough());
}

const init = () => {
    const app = new Koa();

    app.use(route.get(`/get`, getFile));

    app.listen(12345);
};

init();

```

If you will execute `curl http://localhost:12345/get` it will result in exception:

```
/home/node/app/node_modules/koa/lib/context.js:117
    this.app.emit('error', err, this);
             ^

TypeError: Cannot read property 'emit' of undefined
    at Request.onerror (/home/node/app/node_modules/koa/lib/context.js:117:14)
    at Request.emit (events.js:203:15)
    at Request.onRequestError (/home/node/app/node_modules/request/request.js:877:8)
    at ClientRequest.emit (events.js:198:13)
    at Socket.socketErrorListener (_http_client.js:392:9)
    at Socket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

That's because `.on('error', ctx.onerror)` will call `onerror` with different context, not `ctx`. That context doesn't have `app` property (https://github.com/koajs/koa/blob/8d52105a34234be9e771ff3b76b43e4e30328943/lib/context.js#L121), which results in exception.

I have updated docs to preserve context.