### PR TITLE
fix(context): use strict equality

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -108,7 +108,7 @@ const proto = module.exports = {
     // don't do anything if there is no error.
     // this allows you to pass `this.onerror`
     // to node-style callbacks.
-    if (null == err) return;
+    if (err === null) return;
 
     if (!(err instanceof Error)) err = new Error(util.format('non-error thrown: %j', err));
 


### PR DESCRIPTION
Using strict equality when comparing error to null. When passing an `undefined` variable  to `onerror` function, you will not get `non-error` result. `exp: null == undefined  -> true`