### PR TITLE
Use single console.error() statement in error handler

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -201,9 +201,7 @@ module.exports = class Application extends Emitter {
     if (this.silent) return;
 
     const msg = err.stack || err.toString();
-    console.error();
-    console.error(msg.replace(/^/gm, '  '));
-    console.error();
+    console.error(`\n${msg.replace(/^/gm, '  ')}\n`);
   }
 };
 

--- a/test/application/onerror.js
+++ b/test/application/onerror.js
@@ -51,7 +51,7 @@ describe('app.onerror(err)', () => {
       if (input) msg = input;
     });
     app.onerror(err);
-    assert(msg === '  Foo');
+    assert(msg === '\n  Foo\n');
   });
 
   it('should use err.toString() instad of err.stack', () => {
@@ -68,6 +68,6 @@ describe('app.onerror(err)', () => {
       if (input) msg = input;
     });
     app.onerror(err);
-    assert(msg === '  Error: mock stack null');
+    assert(msg === '\n  Error: mock stack null\n');
   });
 });


### PR DESCRIPTION
Removes two `console.error()` statements that take no arguments and appears only to be used for formatting purposes. To maintain the current formatting this adds a `\n` before and after the logged error message.

This fixes https://github.com/koajs/koa/issues/1470 which reports that `console.error()` statements with no arguments cause noise in AWS Cloudwatch.
