### PR TITLE
Export respond() in application.js

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -275,6 +275,12 @@ function respond(ctx) {
 }
 
 /**
+ * Export respond() for the users who want to call it elsewhere
+ */
+
+module.exports.respond = respond;
+
+/**
  * Make HttpError available to consumers of the library so that consumers don't
  * have a direct dependency upon `http-errors`
  */


### PR DESCRIPTION
I want to use koa as a middleware into koa-compose, so I need to implement my own Application.callback() and Application.handleRequest() functions, which uses the 'function respond(ctx)' in application.js.
By now, I just copied respond()'s source code into my file, but it is helpful that this function can be exported by koa.