### PR TITLE
fix: make ESM transpiled CommonJS play nice for TS folks, fix #1513

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -217,7 +217,7 @@ module.exports = class Application extends Emitter {
    * @see https://github.com/koajs/koa/issues/1513
    */
 
-  static get default () {
+  static get default() {
     return Application;
   }
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -211,6 +211,15 @@ module.exports = class Application extends Emitter {
     const msg = err.stack || err.toString();
     console.error(`\n${msg.replace(/^/gm, '  ')}\n`);
   }
+
+  /**
+   * Help TS users comply to CommonJS, ESM, bundler mismatch.
+   * @see https://github.com/koajs/koa/issues/1513
+   */
+
+  static get default () {
+    return Application;
+  }
 };
 
 /**

--- a/test/load-with-esm.js
+++ b/test/load-with-esm.js
@@ -36,4 +36,14 @@ describe('Load with esm', () => {
     assert.strictEqual(exported.size, required.size);
     assert.strictEqual([...exported].every(property => required.has(property)), true);
   });
+
+  it('CommonJS exports default property', async() => {
+    const required = require('../');
+    assert.strictEqual(required.hasOwnProperty('default'), true);
+  });
+
+  it('CommonJS exports default property referencing self', async() => {
+    const required = require('../');
+    assert.strictEqual(required.default, required);
+  });
 });

--- a/test/load-with-esm.js
+++ b/test/load-with-esm.js
@@ -28,7 +28,10 @@ describe('Load with esm', () => {
     for (const k of ['prototype', 'length', 'name']) {
       required.delete(k);
     }
-    exported.delete('default');
+
+    // Commented out to "fix" CommonJS, ESM, bundling issue.
+    // @see https://github.com/koajs/koa/issues/1513
+    // exported.delete('default');
 
     assert.strictEqual(exported.size, required.size);
     assert.strictEqual([...exported].every(property => required.has(property)), true);


### PR DESCRIPTION
This is a "fix" I guess to allow TS typings to actually work - according to some other people that actually use TS.

I'm going to need confirmation on both its application, and that this doesn't break anything for Koa v2.