### PR TITLE
[Fix] Content-Length header on explicit null body response

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -256,6 +256,7 @@ function respond(ctx) {
     if (ctx.response._explicitNullBody) {
       ctx.response.remove('Content-Type');
       ctx.response.remove('Transfer-Encoding');
+      ctx.length = 0;
       return res.end();
     }
     if (ctx.req.httpVersionMajor >= 2) {

--- a/test/application/respond.js
+++ b/test/application/respond.js
@@ -866,7 +866,46 @@ describe('app.respond', () => {
         .expect('')
         .expect({});
 
+      assert.equal(res.headers.hasOwnProperty('transfer-encoding'), false);
       assert.equal(res.headers.hasOwnProperty('content-type'), false);
+      assert.equal(res.headers.hasOwnProperty('content-length'), true);
+    });
+    it('should return content-length equal to 0', async() => {
+      const app = new Koa();
+
+      app.use(ctx => {
+        ctx.body = null;
+        ctx.status = 401;
+      });
+
+      const server = app.listen();
+
+      const res = await request(server)
+        .get('/')
+        .expect(401)
+        .expect('')
+        .expect({});
+
+      assert.equal(res.headers['content-length'], 0);
+    });
+    it('should not overwrite the content-length', async() => {
+      const app = new Koa();
+
+      app.use(ctx => {
+        ctx.body = null;
+        ctx.length = 10;
+        ctx.status = 404;
+      });
+
+      const server = app.listen();
+
+      const res = await request(server)
+        .get('/')
+        .expect(404)
+        .expect('')
+        .expect({});
+
+      assert.equal(res.headers['content-length'], 0);
     });
   });
 });


### PR DESCRIPTION
Fixes *#1525*

### Changes
* Set the context length value to 0 for *explicit null body* response(s),
* Provided the necessary set of tests for this change,
* Maintained the test coverage of 100%.

### Checklist
After the changes I ensured that:
 * no stylistic or unwanted errors are present, by running `npm run lint` from the root directory,
 * no tests are failing, by running `npm run test` from the root directory,
 * build passes with no issues, by running `npm run build` from the root directory.

### Done
- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
