### PR TITLE
fix: Fix deprecated folder mapping "./" in the "exports" field module

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -504,7 +504,7 @@ module.exports = {
    * @api private
    */
   set accept(obj) {
-    return this._accept = obj;
+    this._accept = obj;
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "require": "./lib/application.js",
       "import": "./dist/koa.mjs"
     },
-    "./": "./"
+    "./*": "./*"
   },
   "scripts": {
     "test": "egg-bin test test",


### PR DESCRIPTION
Run in Node.js 16.x ，I got warning message. then fixed for Node.js 16.x

![image](https://user-images.githubusercontent.com/10667077/121772170-579f4f00-cba6-11eb-97d1-8190f08f6b5b.png)
