### PR TITLE
fix: Do not response Content-Length if Transfer-Encoding is defined

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,11 +1,14 @@
-小菜 <xtx1130@gmail.com>
 Aaron Heckmann <aaron.heckmann+github@gmail.com>
 Adam L <skyros@gmail.com>
 Adam Lau <skyros@gmail.com>
 Aesop Wolf <aesopwolf@users.noreply.github.com>
+AlbertAZ1992 <ziyuximing@163.com>
+Alex Berk <berkalexanderc@gmail.com>
 AlexeyKhristov <AlexeyKhristov@users.noreply.github.com>
 Alexsey <agat00@gmail.com>
 Amit Portnoy <amit.portnoy@gmail.com>
+Andrew Peterson <andrew@andpeterson.com>
+André Cruz <andre@cabine.org>
 Anton Harniakou <anton.harniakou@gmail.com>
 Arjun <arjun453@gmail.com>
 Asiel Leal <lealceldeiro@gmail.com>
@@ -13,40 +16,55 @@ Avindra Goolcharan <aavindraa@gmail.com>
 Bartol Karuza <bartol.k@gmail.com>
 Ben Reinhart <breinhart@groupon.com>
 Bernie Stern <bernzs@gmail.com>
+Brad Ito <phlogisticfugu@users.noreply.github.com>
 Bryan Bess <squarejaw@bsbess.com>
 C.T. Lin <chentsulin@gmail.com>
 Chiahao Lin <purepennons@users.noreply.github.com>
 Chris Tarquini <chris@ilsken.com>
 Christoffer Hallas <hallas@users.noreply.github.com>
 Clark Du <clark.duxin@gmail.com>
+Clayton Ray <iamclaytonray@gmail.com>
 Darren Cauthon <darren@cauthon.com>
 Debjeet Biswas <debjeet@vxtindia.com>
 Dmitry Mazuro <dmitry.mazuro@icloud.com>
+Dobes Vandermeer <dobesv@gmail.com>
 Douglas Christopher Wilson <doug@somethingdoug.com>
+Douglas Wade <douglas.b.wade@gmail.com>
+Edvard Chen <pigeon73101@gmail.com>
 Eivind Fjeldstad <eivind.fjeldstad@gmail.com>
 Equim <sayaka@ekyu.moe>
 Fangdun Cai <fundon@users.noreply.github.com>
 Felix Becker <felix.b@outlook.com>
 Filip Skokan <panva.ip@gmail.com>
 Francisco Presencia <franciscop@users.noreply.github.com>
+Francisco Ryan Tolmasky I <tolmasky@gmail.com>
 George Chung <Gerhut@GMail.com>
 Gilles De Mey <gilles.de.mey@gmail.com>
 Grand <sungg12138@163.com>
 Guilherme Pacheco <guilherme.f.pacheco@hotmail.com>
+Gunnlaugur Thor Briem <gunnlaugur@gmail.com>
 HanHor Wu <hanhor.wu@gmail.com>
 Hartley Melamed <hartley@melamed.biz>
+Hridayesh Sharma <vyasriday7@gmail.com>
 Hrvoje Šimić <hrvoje@twobucks.co>
 Hugh Kennedy <hughskennedy@gmail.com>
 Ian Storm Taylor <ian@ianstormtaylor.com>
+Igor Adamenko <igoradamenko@users.noreply.github.com>
+Ikko Ashimine <eltociear@gmail.com>
 Ilkka Oksanen <iao@iki.fi>
+Imed Jaberi <imed_jebari@hotmail.fr>
+Imon-Haque <38266345+Imon-Haque@users.noreply.github.com>
 Ivan Kleshnin <ivan@paqmind.com>
 Ivan Lyons <iliyang.cn@gmail.com>
 Jacob Bass <jacob@jacobbass.net>
+Jake <djakelambert@gmail.com>
+James George <jamesgeorge998001@gmail.com>
 JamesWang <likegun94@gmail.com>
 Jan Buschtöns <buschtoens@gmail.com>
 Jan Carlo Viray <virayjancarlo@yahoo.com>
 Jason Macgowan <jason.macgowan@icloud.com>
 Jed Schmidt <where@jed.is>
+Jeff <jeff.tian@outlook.com>
 Jeff Moore <jeff@procata.com>
 Jesus Rodriguez <foxandxss@gmail.com>
 Jesús Rodríguez Rodríguez <Foxandxss@gmail.com>
@@ -55,39 +73,53 @@ Johan Bergström <bugs@bergstroem.nu>
 Jonas Zhang <106856363@qq.com>
 Jonathan Ong <jonathanrichardong@gmail.com>
 Jonathan Ong <me@jongleberry.com>
+Jordan <mingmingwon@gmail.com>
 Joseph Lin <josephlin55555@gmail.com>
 Julian Gruber <julian@juliangruber.com>
+Julien Wajsberg <felash@gmail.com>
 Kareem Kwong <kareem.kwong@gmail.com>
 Karl Böhlmark <karl.bohlmark@gmail.com>
 Kenneth Ormandy <kenneth@chloi.io>
 Kim Joar Bekkelund <kjbekkelund@gmail.com>
+Konstantin Vyatkin <tino@vtkn.io>
 Kwyn Alice Meagher <kwyn.meagher@gmail.com>
 Kyle Suss <susskyle@gmail.com>
 Lee Bousfield <ljbousfield@gmail.com>
 Louis DeScioli <louis.descioli@gmail.com>
 Luke Bousfield <math.master.champion@gmail.com>
 Malcolm <noinkling@users.noreply.github.com>
+Marc-Aurèle DARCHE <152407+madarche@users.noreply.github.com>
 Marceli.no <me@marceli.no>
 Mars Wong <marswong618@gmail.com>
 Martin Iwanowski <martin@iwanowski.se>
 Martin Iwanowski <me@fl0w.io>
+Martin Michaelis <code@mgjm.de>
 Martin fl0w Iwanowski <martin@iwanowski.se>
+Matan Shavit <71092861+matanshavit@users.noreply.github.com>
 Matheus Azzi <matheuslazzi@gmail.com>
 Mathieu Gallé-Tessonneau <mathieu.galletessonneau@gmail.com>
+Matt Kubej <mkubej@gmail.com>
 Matthew Chase Whittemore <matthew@socialtables.com>
 Matthew King <mking@users.noreply.github.com>
 Matthew Mueller <mattmuelle@gmail.com>
 Mengdi Gao <gaomdev@gmail.com>
 Michaël Zasso <mic.besace@gmail.com>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
+Micheal Hill <micheal.hill@trunkplatform.com>
+Mike Vosseller <michael.vosseller@gmail.com>
+Mikhail Bodrov <connormiha1@gmail.com>
 Nathan Rajlich <nathan@tootallnate.net>
 New Now Nohow <empty@cqdr.es>
 Nick McCurdy <nick@nickmccurdy.com>
 Nicolae Vartolomei <nvartolomei@gmail.com>
+Olle Jonsson <olle.jonsson@gmail.com>
 PatrickJS <github@gdi2290.com>
 Paul Anderson <thesamuraipanda@gmail.com>
+Paul Annekov <paul.annekov@gmail.com>
 Pedro Pablo Aste Kompen <wachunei@gmail.com>
 Peeyush Kushwaha <peeyush.p97@gmail.com>
+Peng Jie <bivinity.pengzjie@gmail.com>
+Peng Jie <dean.leehom@gmail.com>
 Phillip Alexander <git@phillipalexander.io>
 PlasmaPower <ljbousfield@gmail.com>
 Prayag Verma <prayag.verma@gmail.com>
@@ -96,6 +128,7 @@ Remek Ambroziak <remek.ambroziak@gmail.com>
 Riceball LEE <snowyu.lee@gmail.com>
 Richard Marmorstein <twitchard@users.noreply.github.com>
 Rico Sta. Cruz <rstacruz@users.noreply.github.com>
+Robert Nagy <ronagy@icloud.com>
 Robert Sköld <robert@publicclass.se>
 Robin Pokorný <me@robinpokorny.com>
 Ruben Bridgewater <ruben@bridgewater.de>
@@ -124,11 +157,16 @@ Todor Stoychev <pretodor@gmail.com>
 Tomas Ruud <tomasruud@users.noreply.github.com>
 Travis Jeffery <tj@travisjeffery.com>
 Usman Hussain <usmandap@gmail.com>
+Vern Brandl <tkvern@users.noreply.github.com>
 Veselin Todorov <veselin@veselin.bg>
+Vijay Krishnavanshi <vijaykrishnavanshi@gmail.com>
+Vikram Rangaraj <vik120@icloud.com>
+Waleed Ashraf <waleedashraf@outlook.com>
 Wang Dàpéng <wonderfuly@gmail.com>
 Xavier Damman <xdamman@gmail.com>
 Xiang Gao <geekplux@qq.com>
 Yanick Rochon <yanick.rochon@gmail.com>
+Yazan Medanat <medanat@gmail.com>
 Yazhong Liu <l900422@vip.qq.com>
 Yazhong Liu <yorkiefixer@gmail.com>
 Yiyu He <dead-horse@users.noreply.github.com>
@@ -136,16 +174,22 @@ Yiyu He <dead_horse@qq.com>
 Yoshua Wuyts <yoshuawuyts@gmail.com>
 Yu Qi <iyuq@outlook.com>
 Yu Qi <njuyuqi@gmail.com>
+ZYSzys <zhangyongsheng@youzan.com>
+ZYSzys <zyszys98@gmail.com>
+Zac Anger <zac@zacanger.com>
 Zack Tanner <zacktanner@gmail.com>
 alsotang <alsotang@gmail.com>
 bananaappletw <bananaappletw@gmail.com>
 bhanuc <bhanuc@iitk.ac.in>
 blaz <blaz@menems.net>
 broucz <broucapierre@gmail.com>
+call me saisai <1457358080@qq.com>
+chenglezeng <chenglezeng@tencent.com>
 d3v <cr1s@users.noreply.github.com>
 dead-horse <dead_horse@qq.com>
 dead_horse <dead_horse@qq.com>
 designgrill <anshul@designgrill.com>
+ejose19 <8742215+ejose19@users.noreply.github.com>
 fengmk2 <fengmk2@gmail.com>
 fengmk2 <m@fengmk2.com>
 frank <frankxin93@hotmail.com>
@@ -154,23 +198,34 @@ gyson <eilian.yunsong@gmail.com>
 haoxin <coderhaoxin@outlook.com>
 haoxin <haoxins@icloud.com>
 iamchenxin <iamchenxin@gmail.com>
+imed jaberi <imed_jebari@hotmail.fr>
 initial-wu <initial-wu@outlook.com>
+jeremiG <gendronjeremi@gmail.com>
 jeromew <jerome.wagner@m4x.org>
 joehecn <leanbrown@live.cn>
 jongleberry <jonathanong@users.noreply.github.com>
 jongleberry <me@jongleberry.com>
+kzhang <godky@users.noreply.github.com>
+laffachan <45162759+laffachan@users.noreply.github.com>
 llambda <xxgsoftware@gmail.com>
 mako-taco <jake.y.scott@gmail.com>
 mdemo <mds@xue.bi>
+miwnwski <m@iwnw.ski>
 nicoder <nicolas.dermine@gmail.com>
+niftylettuce <niftylettuce@gmail.com>
 nswbmw <gxqzk@126.com>
 pana <pana.wang@outlook.com>
 qingming <358242939@qq.com>
+rosald <35028438+rosald@users.noreply.github.com>
 song <xiongsongsong@outlook.com>
 superchink <superchink@gmail.com>
 tmilewski <tmilewski@gmail.com>
+urugator <j.placek@centrum.cz>
 yoshuawuyts <i@yoshuawuyts.com>
 yosssi <yoshida.keiji.84@gmail.com>
 zensh <admin@zensh.com>
 ziyunfei <446240525@qq.com>
+小雷 <863837949@qq.com>
+小菜 <xtx1130@gmail.com>
+谭九鼎 <109224573@qq.com>
 石发磊 <sshsfl@yeah.net>

--- a/lib/response.js
+++ b/lib/response.js
@@ -191,7 +191,9 @@ module.exports = {
    */
 
   set length(n) {
-    this.set('Content-Length', n);
+    if (!this.has('Transfer-Encoding')) {
+      this.set('Content-Length', n);
+    }
   },
 
   /**

--- a/test/application/response.js
+++ b/test/application/response.js
@@ -12,6 +12,8 @@ describe('app.response', () => {
   const app3 = new Koa();
   const app4 = new Koa();
   const app5 = new Koa();
+  const app6 = new Koa();
+  const app7 = new Koa();
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
@@ -70,5 +72,28 @@ describe('app.response', () => {
     return request(app5.listen())
       .get('/')
       .expect(204);
+  });
+
+  it('should add Content-Length when Transfer-Encoding is not defined', () => {
+    app6.use((ctx, next) => {
+      ctx.body = 'hello world';
+      assert.equal(ctx.response.get('Content-Length'), 11);
+    });
+
+    return request(app6.listen())
+      .get('/')
+      .expect(200);
+  });
+
+  it('should not add Content-Length when Transfer-Encoding is defined', () => {
+    app7.use((ctx, next) => {
+      ctx.set('Transfer-Encoding', 'chunked');
+      ctx.body = 'hello world';
+      assert.equal(ctx.response.get('Content-Length'), '');
+    });
+
+    return request(app7.listen())
+      .get('/')
+      .expect(200);
   });
 });


### PR DESCRIPTION
## Background
Nodejs http module can not handle response that contains both Content-Length and Transfer-Encoding header, you can see it at https://github.com/nodejs/node/blob/v16.6.1/deps/llhttp/src/llhttp.c#L5811.

## Problem
Koa will auto set Content-Length response header when use `ctx.body = ...`, but if Transfer-Encoding response header is defined, Content-Length should not be set. Otherwise, the response can not be handled by nodejs http module.

## How To Appear
```javascript
// server.js
const Koa = require('koa');

const app = new Koa();
app.use((ctx) => {
  ctx.set('Transfer-Encoding', 'chunked');
  ctx.body = 'hello world';
});
app.listen(9000);

// client.js
const http = require('http');

http.get('http://127.0.0.1:9000');
```
As above, run `node server.js` to start server, then run `node client.js` to send a request. Finally, you'll get an error as follow:
![image](https://user-images.githubusercontent.com/6988251/128830073-d2dd2adf-de6a-4a15-9fbc-450eefdf0152.png)

## How To Resolve
Don't set Content-Length header if Transfer-Encoding is defined.

