### PR TITLE
fix: nodejs deprecated api <DEP0148>

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
       "require": "./lib/application.js",
       "import": "./dist/koa.mjs"
     },
-    "./": "./"
+    "./*": "./*.js",
+    "./*.js": "./*.js",
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "jest --forceExit",


### PR DESCRIPTION
Subpath folder mappings will be removed in a future release, so we should use direct subpath patterns instead.

The warning message is like below (with `node-v16.9.0`) when executing `require('koa/lib/response');`:

```bash
(node:80100) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /Users/hyj1991/git/eggjs/egg-core/node_modules/koa/package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)
```

This PR is to be compatible with the omitted specifier path with `require` after fixing **DEP0148**:

```js
require('koa/lib/application');
require('koa/lib/application.js');

require('koa/lib/response');
require('koa/lib/response.js');

require('koa/lib/request');
require('koa/lib/request.js');

require('koa/lib/context');
require('koa/lib/context.js');

require('koa/package.json');
require('koa/package');
```

Refs: 
* https://nodejs.org/api/deprecations.html#DEP0148
* https://nodejs.org/api/packages.html#packages_subpath_folder_mappings

