### PR TITLE
fix: Do not response Content-Length if Transfer-Encoding is defined

### DIFF
--- a/__tests__/response/length.js
+++ b/__tests__/response/length.js
@@ -64,3 +64,18 @@ describe('res.length', () => {
     });
   });
 });
+
+describe('res.length=', () => {
+  it('should set when Transfer-Encoding not present', () => {
+    const res = response();
+    res.length = 100;
+    assert.strictEqual(res.length, 100);
+  });
+
+  it('should not set when Transfer-Encoding present', () => {
+    const res = response();
+    res.set('Transfer-Encoding', 'chunked');
+    res.length = 100;
+    assert.strictEqual(res.length, undefined);
+  });
+});

--- a/lib/response.js
+++ b/lib/response.js
@@ -191,7 +191,9 @@ module.exports = {
    */
 
   set length(n) {
-    this.set('Content-Length', n);
+    if (!this.has('Transfer-Encoding')) {
+      this.set('Content-Length', n);
+    }
   },
 
   /**


### PR DESCRIPTION
pick from 39c0b48a7acfae950f41b1a001e35c9214b30a16