### PR TITLE
test: fix ESM tests

### DIFF
--- a/__tests__/load-with-esm.js
+++ b/__tests__/load-with-esm.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 
 let importESM = () => {}
 
-describe.skip('Load with esm', () => {
+describe('Load with esm', () => {
   beforeAll(function (){
     // ESM support is flagged on v12.x.
     const majorVersion = +process.version.split('.')[0].slice(1)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "test": "jest --forceExit",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --forceExit",
     "lint": "eslint --ignore-path .gitignore .",
     "authors": "git log --format='%aN <%aE>' | sort -u > AUTHORS",
     "build": "gen-esm-wrapper . ./dist/koa.mjs",


### PR DESCRIPTION
Regarding to the [jest documentation](https://jestjs.io/docs/ecmascript-modules) we should use `--experimental-vm-modules` command-line option for enabling ES modules.
Closes #1571