### PR TITLE
Added exports.default to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "require": "./lib/application.js",
-      "import": "./dist/koa.mjs"
+      "import": "./dist/koa.mjs",
+      "default": "./dist/koa.mjs"
     },
     "./*": "./*.js",
     "./*.js": "./*.js",


### PR DESCRIPTION
Per NodeJS documentation on the `package.json` `exports` object, there seems to be a need for a fallback `default` key:
https://nodejs.org/api/packages.html#conditional-exports

Additionally, I'm seeing things like eslint fail to resolve until a `default` key has been specified. I've not dug any further into why, but I think _some_ default should be defined until more options should later be added.