### PR TITLE
Update koa-vs-express.md

### DIFF
--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -11,11 +11,11 @@
 
 | Feature           | Koa | Express | Connect |
 |------------------:|-----|---------|---------|
-| Middleware Kernel | ✓   | ✓       | ✓       |
-| Routing           |     | ✓       |         |
-| Templating        |     | ✓       |         |
-| Sending Files     |     | ✓       |         |
-| JSONP             |     | ✓       |         |
+| Middleware Kernel | ✓ built-in    | ✓       | ✓       |
+| Routing           | via middleware | ✓       |         |
+| Templating        | via middleware | ✓       |         |
+| Sending Files     | via middleware | ✓       |         |
+| JSONP             | via middleware | ✓       |         |
 
 
   Thus, if you'd like to be closer to node.js and traditional node.js-style coding, you probably want to stick to Connect/Express or similar frameworks.


### PR DESCRIPTION
As it was, this table made it look like Koa doesn't support routing, templating, sending files, jsonp, which is technically true, but there is Koa middleware built for each of those, so it's helpful to clarify that in the table, rather than leaving those cells empty. It paints Koa in a better light for those who are unfamiliar and are comparing their options, which is the target audience of this page.