### PR TITLE
fix(lib/doc): fix jsdoc and typo

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Fangdun Cai <fundon@users.noreply.github.com>
 Felix Becker <felix.b@outlook.com>
 Filip Skokan <panva.ip@gmail.com>
 Francisco Presencia <franciscop@users.noreply.github.com>
+Gao Sheng <gaosheng08@meituan.com>
 George Chung <Gerhut@GMail.com>
 Gilles De Mey <gilles.de.mey@gmail.com>
 Grand <sungg12138@163.com>

--- a/docs/koa-vs-express.md
+++ b/docs/koa-vs-express.md
@@ -39,7 +39,7 @@
 ## Does Koa replace Connect?
 
   No, just a different take on similar functionality
-  now that generators allow us to write code with less
+  now that generators allow us to write code with fewer
   callbacks. Connect is equally capable, and some may still prefer it,
   it's up to what you prefer.
 
@@ -51,7 +51,7 @@
   the entire application, so we thought it would be more appropriate
   to create a new library.
 
-## How is Koa different than Connect/Express?
+## How is Koa different from Connect/Express?
 
 ### Promises-based control flow
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -376,7 +376,7 @@ module.exports = {
   /**
    * Return parsed Content-Length when present.
    *
-   * @return {Number}
+   * @return {Number|void}
    * @api public
    */
 
@@ -503,7 +503,7 @@ module.exports = {
   /**
    * Set accept object.
    *
-   * @param {Object}
+   * @param {Object} obj
    * @api private
    */
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -288,7 +288,10 @@ module.exports = {
   /**
    * Set Content-Disposition header to "attachment" with optional `filename`.
    *
-   * @param {String} filename
+   * @param {String} [filename]
+   * @param {object} [options]
+   * @param {string} [options.type=attachment]
+   * @param {string|boolean} [options.fallback=true]
    * @api public
    */
 
@@ -328,7 +331,7 @@ module.exports = {
    *     this.response.lastModified = new Date();
    *     this.response.lastModified = '2013-09-13';
    *
-   * @param {String|Date} type
+   * @param {String|Date} val
    * @api public
    */
 
@@ -357,7 +360,7 @@ module.exports = {
    *     this.response.etag = '"md5hashsum"';
    *     this.response.etag = 'W/"123456789"';
    *
-   * @param {String} etag
+   * @param {String} val
    * @api public
    */
 
@@ -460,7 +463,7 @@ module.exports = {
    *    this.set({ Accept: 'text/plain', 'X-API-Key': 'tobi' });
    *
    * @param {String|Object|Array} field
-   * @param {String} val
+   * @param {*} val
    * @api public
    */
 
@@ -490,7 +493,7 @@ module.exports = {
    * ```
    *
    * @param {String} field
-   * @param {String|Array} val
+   * @param {*} val
    * @api public
    */
 
@@ -509,7 +512,7 @@ module.exports = {
   /**
    * Remove header `field`.
    *
-   * @param {String} name
+   * @param {String} field
    * @api public
    */
 


### PR DESCRIPTION
When I read Koa's source, I noticed some typo errors in JSDoc and documentation, so I tried to fix them.