### PR TITLE
request.params missing in the docs. Issue#1683.

### DIFF
--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -150,6 +150,18 @@ ctx.request.charset;
 ctx.query = { next: '/login' };
 ```
 
+### request.params
+
+  Get parsed route parameters, which are named URL segments. Key in the object (`request.params`) is the name of the parameter.
+  Value is the captured value specified at the position of the parameter in the route path.
+
+  For example, if the route path is `/:id` and it is hit as `/123`, then `request.params` will have following value:
+```js
+{
+  id: '123'
+}
+```
+
 ### request.fresh
 
   Check if a request cache is "fresh", aka the contents have not changed. This


### PR DESCRIPTION
This PR will solve issue: https://github.com/koajs/koa/issues/1683

request.params documentation was missing. I have included it with suitable example.