### PR TITLE
Remove outdated links from README Getting Started section.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,9 +40,7 @@ app.listen(3000);
 ## Getting started
 
  - [Kick-Off-Koa](https://github.com/koajs/kick-off-koa) - An intro to Koa via a set of self-guided workshops.
- - [Workshop](https://github.com/koajs/workshop) - A workshop to learn the basics of Koa, Express' spiritual successor.
- - [Introduction Screencast](https://knowthen.com/episode-3-koajs-quickstart-guide/) - An introduction to installing and getting started with Koa
-
+ - [Guide](docs/guide.md) - Go straight to the docs.
 
 ## Middleware
 


### PR DESCRIPTION
I found these links really confusing and outdated. After following one and watching the Youtube video from 2014 on the front page explaining how Koa middleware uses generators (seemingly "because generators!") I almost threw up hands and moved back to Express straight away. AFAIK (and hopefully) the generator thing is obsolete now.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
