### PR TITLE
docs: add missing entries to response aliases in context.md

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -185,6 +185,7 @@ Koa uses [http-assert](https://github.com/jshttp/http-assert) for assertions.
 
   - `ctx.body`
   - `ctx.body=`
+  - `ctx.has()`
   - `ctx.status`
   - `ctx.status=`
   - `ctx.message`
@@ -193,6 +194,7 @@ Koa uses [http-assert](https://github.com/jshttp/http-assert) for assertions.
   - `ctx.length`
   - `ctx.type=`
   - `ctx.type`
+  - `ctx.vary()`
   - `ctx.headerSent`
   - `ctx.redirect()`
   - `ctx.attachment()`
@@ -201,3 +203,4 @@ Koa uses [http-assert](https://github.com/jshttp/http-assert) for assertions.
   - `ctx.remove()`
   - `ctx.lastModified=`
   - `ctx.etag=`
+  - `ctx.writable`


### PR DESCRIPTION
Add `ctx.has()`, `ctx.vary()` and `ctx.writable` to the list of response aliases for context. https://github.com/koajs/koa/blob/master/lib/context.js#L199-L216

## Checklist

- ✔ I have ensured my pull request is not behind the main or master branch of the original repository.
- ✔ I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- ✔ I have written a commit message that passes commitlint linting.
- ✔ I have ensured that my code changes pass linting tests.
- ✔ I have ensured that my code changes pass unit tests.
- ✔ I have described my pull request and the reasons for code changes along with context if necessary.
