### PR TITLE
docs: Fix definition of middleware in guide.md

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,7 +18,7 @@
 
 ## Writing Middleware
 
-  Koa middleware are simple functions which return a `MiddlewareFunction` with signature (ctx, next). When
+  Koa middleware are simple functions with the signature `(ctx, next)` (i.e. a `MiddlewareFunction`). When
   the middleware is run, it must manually invoke `next()` to run the "downstream" middleware.
 
   For example if you wanted to track how long it takes for a request to propagate through Koa by adding an


### PR DESCRIPTION
This PR is to fix the definition of what a middleware is in `guide.md`. The old definition says that middleware are "simple functions which return a `MiddlewareFunction`", however every other peice of documentation I could find refers to the `MiddlewareFunction` itself as the middleware (not the function that returns the `MiddlewareFunction`).

If the old definition is intentional and correct, I'm happy to close this PR, but it really seems like it's not correct. E.g. the very next sentence says "When the middleware is run, it must manually invoke `next()`", however if a middleware is the function that _returns_ the `MiddlewareFunction` then it wouldn't be able to invoke `next()` since `next` is passed to the `MiddlewareFunction` not the function that returns the `MiddlewareFunction`.

Sorry if this is pedantic, we just had a bit of a back-and-forth on this in a PR and I decided to actually be productive and fix it instead of just complaining to coworkers 😅.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
