### PR TITLE
Add custom stream support

### DIFF
--- a/__tests__/response/body.js
+++ b/__tests__/response/body.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const response = require('../../test-helpers/context').response
+const CustomStream = require('../../test-helpers/stream')
 const assert = require('assert')
 const fs = require('fs')
 const Stream = require('stream')
@@ -106,6 +107,12 @@ describe('res.body=', () => {
     it('should default to an octet stream', () => {
       const res = response()
       res.body = fs.createReadStream('LICENSE')
+      assert.strictEqual('application/octet-stream', res.header['content-type'])
+    })
+
+    it('should support custom stream', () => {
+      const res = response()
+      res.body = new CustomStream.Readable()
       assert.strictEqual('application/octet-stream', res.header['content-type'])
     })
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -16,6 +16,7 @@ const Emitter = require('events')
 const util = require('util')
 const Stream = require('stream')
 const http = require('http')
+const isStream = require('./is-stream.js')
 const only = require('./only.js')
 const { HttpError } = require('http-errors')
 
@@ -303,10 +304,10 @@ function respond (ctx) {
 
   if (Buffer.isBuffer(body)) return res.end(body)
   if (typeof body === 'string') return res.end(body)
-  if (body instanceof Stream) return body.pipe(res)
   if (body instanceof Blob) return Stream.Readable.from(body.stream()).pipe(res)
   if (body instanceof ReadableStream) return Stream.Readable.from(body).pipe(res)
   if (body instanceof Response) return Stream.Readable.from(body?.body).pipe(res)
+  if (isStream(body)) return body.pipe(res)
 
   // body: json
   body = JSON.stringify(body)

--- a/lib/is-stream.js
+++ b/lib/is-stream.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const Stream = require('stream')
+
+module.exports = (stream) => {
+  return (
+    stream instanceof Stream ||
+    (stream !== null &&
+      typeof stream === 'object' &&
+      !!stream.readable &&
+      typeof stream.pipe === 'function' &&
+      typeof stream.read === 'function' &&
+      typeof stream.readable === 'boolean' &&
+      typeof stream.readableObjectMode === 'boolean' &&
+      typeof stream.destroy === 'function' &&
+      typeof stream.destroyed === 'boolean')
+  )
+}

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,10 +14,10 @@ const destroy = require('destroy')
 const assert = require('assert')
 const extname = require('path').extname
 const vary = require('vary')
+const isStream = require('./is-stream.js')
 const only = require('./only.js')
 const util = require('util')
 const encodeUrl = require('encodeurl')
-const Stream = require('stream')
 
 /**
  * Prototype.
@@ -171,7 +171,7 @@ module.exports = {
     }
 
     // stream
-    if (val instanceof Stream) {
+    if (isStream(val)) {
       onFinish(this.res, destroy.bind(null, val))
       if (original !== val) {
         val.once('error', err => this.ctx.onerror(err))
@@ -242,7 +242,7 @@ module.exports = {
     }
 
     const { body } = this
-    if (!body || body instanceof Stream) return undefined
+    if (!body || isStream(body)) return undefined
     if (typeof body === 'string') return Buffer.byteLength(body)
     if (Buffer.isBuffer(body)) return body.length
     return Buffer.byteLength(JSON.stringify(body))

--- a/test-helpers/stream.js
+++ b/test-helpers/stream.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { EventEmitter } = require('events')
+
+class Readable extends EventEmitter {
+  pipe () {}
+  read () {}
+  destroy () {}
+  get readable () {
+    return true
+  }
+
+  get readableObjectMode () {
+    return false
+  }
+
+  get destroyed () {
+    return false
+  }
+}
+
+module.exports = {
+  Readable
+}


### PR DESCRIPTION
## Description

There are situations when we need to send response stream that is not an instance of node `Readable` stream and current way of checking for stream `value instanceof Stream` fails.
e.g. when using alternative module like [readable-stream](https://github.com/nodejs/readable-stream) or some [other cases](https://stackoverflow.com/questions/23885095/nodejs-check-if-variable-is-readable-stream)

## My usecase

```js
import archiver from 'archiver'

const archive = archiver('zip')
const stream = ...
archive.append(stream, { name: 'archive.zip'})

res.body = archive
```

## Solution

- Added tests to reproduce issue with mocked custom stream object that represents possible `Readable` stream implementation.
- Addopted code from [is-stream](https://github.com/sindresorhus/is-stream)

## Tested also with this code

```js
const archiver = require('archiver')
const Stream = require('stream')
const CustomStream = require('./test-helpers/stream.js')
const isReadableStream = require('./lib/is-readable-stream.js')

const stream = new Stream()
const archive = archiver('zip')
const customstream = new CustomStream.Readable()

console.log(stream instanceof Stream) // true
console.log(customstream instanceof Stream) // false
console.log(archive instanceof Stream) // false

console.log(isReadableStream(stream)) // true
console.log(isReadableStream(customstream)) // true
console.log(isReadableStream(archive)) // true
```
