### PR TITLE
breaking: remove special ENOENT support

### DIFF
--- a/__tests__/application/respond.test.js
+++ b/__tests__/application/respond.test.js
@@ -678,21 +678,6 @@ describe('app.respond', () => {
         assert.deepStrictEqual(res.body, pkg)
       })
 
-    it('should handle errors', (t, done) => {
-      const app = new Koa()
-
-      app.use(ctx => {
-        ctx.set('Content-Type', 'application/json; charset=utf-8')
-        ctx.body = fs.createReadStream('does not exist')
-      })
-
-      request(app.callback())
-        .get('/')
-        .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(404)
-        .end(done)
-    })
-
     it('should handle errors when no content status', () => {
       const app = new Koa()
 
@@ -704,21 +689,6 @@ describe('app.respond', () => {
       return request(app.callback())
         .get('/')
         .expect(204)
-    })
-
-    it('should handle all intermediate stream body errors', (t, done) => {
-      const app = new Koa()
-
-      app.use(ctx => {
-        ctx.body = fs.createReadStream('does not exist')
-        ctx.body = fs.createReadStream('does not exist')
-        ctx.body = fs.createReadStream('does not exist')
-      })
-
-      request(app.callback())
-        .get('/')
-        .expect(404)
-        .end(done)
     })
   })
 

--- a/__tests__/context/onerror.test.js
+++ b/__tests__/context/onerror.test.js
@@ -152,24 +152,6 @@ describe('ctx.onerror(err)', () => {
           .expect('Internal Server Error')
       })
     })
-    describe('when ENOENT error', () => {
-      it('should respond 404', () => {
-        const app = new Koa()
-
-        app.use((ctx, next) => {
-          ctx.body = 'something else'
-          const err = new Error('test for ENOENT')
-          err.code = 'ENOENT'
-          throw err
-        })
-
-        return request(app.callback())
-          .get('/')
-          .expect(404)
-          .expect('Content-Type', 'text/plain; charset=utf-8')
-          .expect('Not Found')
-      })
-    })
     describe('not http status code', () => {
       it('should respond 500', () => {
         const app = new Koa()

--- a/lib/context.js
+++ b/lib/context.js
@@ -150,9 +150,6 @@ const proto = module.exports = {
 
     let statusCode = err.status || err.statusCode
 
-    // ENOENT support
-    if (err.code === 'ENOENT') statusCode = 404
-
     // default to 500
     if (typeof statusCode !== 'number' || !statuses.message[statusCode]) statusCode = 500
 


### PR DESCRIPTION
This is a huge breaking change as it breaks `fs.createReadStream` support. Instead, you'll have to make sure you'll handle the stream's errors before it reaches the koa response logic. This is good as you'd want to do this for all streams anyways. You can have an upstream middleware like:


```js
app.use(async (ctx, next) {
  await next()

  // check if the object is a stream
  if (ctx.body?.readable && typeof ctx.body?.pipe === 'function') {
    await new Promise((resolve, reject) => { // wait for it to be either readable or throw an error
      ctx.body.on('readable', () => resolve())
      ctx.body.on('error', (err) => reject(err)) // TODO handle errors
    })
  }
})
```

closes #1420