### PR TITLE
chore: updates tests to use `node:assert/strict`

### DIFF
--- a/__tests__/application/compose.test.js
+++ b/__tests__/application/compose.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.compose', () => {

--- a/__tests__/application/context.test.js
+++ b/__tests__/application/context.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.context', () => {

--- a/__tests__/application/currentContext.test.js
+++ b/__tests__/application/currentContext.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.currentContext', () => {

--- a/__tests__/application/index.test.js
+++ b/__tests__/application/index.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app', () => {

--- a/__tests__/application/inspect.test.js
+++ b/__tests__/application/inspect.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const util = require('util')
 const Koa = require('../..')
 

--- a/__tests__/application/onerror.test.js
+++ b/__tests__/application/onerror.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it, mock } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.onerror(err)', () => {

--- a/__tests__/application/request.test.js
+++ b/__tests__/application/request.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.request', () => {

--- a/__tests__/application/respond.test.js
+++ b/__tests__/application/respond.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require('node:test')
 const request = require('supertest')
 const statuses = require('statuses')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 const fs = require('fs')
 
@@ -893,7 +893,7 @@ describe('app.respond', () => {
         .expect('')
         .expect({})
 
-      assert.equal(res.headers['content-length'], 0)
+      assert.equal(res.headers['content-length'], '0')
     })
     it('should not overwrite the content-length', async () => {
       const app = new Koa()
@@ -910,7 +910,7 @@ describe('app.respond', () => {
         .expect('')
         .expect({})
 
-      assert.equal(res.headers['content-length'], 0)
+      assert.equal(res.headers['content-length'], '0')
     })
   })
 })

--- a/__tests__/application/response.test.js
+++ b/__tests__/application/response.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.response', () => {

--- a/__tests__/application/toJSON.test.js
+++ b/__tests__/application/toJSON.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.toJSON()', () => {

--- a/__tests__/application/use.test.js
+++ b/__tests__/application/use.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('app.use(fn)', () => {

--- a/__tests__/context/assert.test.js
+++ b/__tests__/context/assert.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('ctx.assert(value, status)', () => {
   it('should throw an error', () => {

--- a/__tests__/context/cookies.test.js
+++ b/__tests__/context/cookies.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('supertest')
 const Koa = require('../..')
 

--- a/__tests__/context/inspect.test.js
+++ b/__tests__/context/inspect.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const prototype = require('../../lib/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const util = require('util')
 const context = require('../../test-helpers/context')
 

--- a/__tests__/context/onerror.test.js
+++ b/__tests__/context/onerror.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('supertest')
 const Koa = require('../..')
 const context = require('../../test-helpers/context')

--- a/__tests__/context/state.test.js
+++ b/__tests__/context/state.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('ctx.state', () => {

--- a/__tests__/context/throw.test.js
+++ b/__tests__/context/throw.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('ctx.throw(msg)', () => {
   it('should set .status to 500', () => {

--- a/__tests__/context/toJSON.test.js
+++ b/__tests__/context/toJSON.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.toJSON()', () => {

--- a/__tests__/lib/search-params.test.js
+++ b/__tests__/lib/search-params.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test')
 const sp = require('../../lib/search-params')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('search-params', () => {
   describe('stringify', () => {

--- a/__tests__/load-with-esm.test.js
+++ b/__tests__/load-with-esm.test.js
@@ -1,5 +1,5 @@
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('Load with esm', () => {
   it('should default export koa', async () => {

--- a/__tests__/request/accept.test.js
+++ b/__tests__/request/accept.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const Accept = require('accepts')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.accept', () => {

--- a/__tests__/request/accepts.test.js
+++ b/__tests__/request/accepts.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.accepts(types)', () => {

--- a/__tests__/request/acceptsCharsets.test.js
+++ b/__tests__/request/acceptsCharsets.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.acceptsCharsets()', () => {

--- a/__tests__/request/acceptsEncodings.test.js
+++ b/__tests__/request/acceptsEncodings.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.acceptsEncodings()', () => {

--- a/__tests__/request/acceptsLanguages.test.js
+++ b/__tests__/request/acceptsLanguages.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.acceptsLanguages(langs)', () => {

--- a/__tests__/request/charset.test.js
+++ b/__tests__/request/charset.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('req.charset', () => {
   describe('with no content-type present', () => {

--- a/__tests__/request/fresh.test.js
+++ b/__tests__/request/fresh.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.fresh', () => {

--- a/__tests__/request/get.test.js
+++ b/__tests__/request/get.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.get(name)', () => {

--- a/__tests__/request/header.test.js
+++ b/__tests__/request/header.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.header', () => {

--- a/__tests__/request/headers.test.js
+++ b/__tests__/request/headers.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.headers', () => {

--- a/__tests__/request/host.test.js
+++ b/__tests__/request/host.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('req.host', () => {
   it('should return host with port', () => {

--- a/__tests__/request/hostname.test.js
+++ b/__tests__/request/hostname.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('req.hostname', () => {
   it('should return hostname void of port', () => {

--- a/__tests__/request/href.test.js
+++ b/__tests__/request/href.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Stream = require('stream')
 const http = require('http')
 const Koa = require('../../')

--- a/__tests__/request/idempotent.test.js
+++ b/__tests__/request/idempotent.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('ctx.idempotent', () => {

--- a/__tests__/request/inspect.test.js
+++ b/__tests__/request/inspect.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const util = require('util')
 
 describe('req.inspect()', () => {

--- a/__tests__/request/ip.test.js
+++ b/__tests__/request/ip.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Stream = require('stream')
 const Koa = require('../..')
 const Request = require('../../test-helpers/context').request

--- a/__tests__/request/ips.test.js
+++ b/__tests__/request/ips.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.ips', () => {

--- a/__tests__/request/is.test.js
+++ b/__tests__/request/is.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('ctx.is(type)', () => {
   it('should ignore params', () => {

--- a/__tests__/request/length.test.js
+++ b/__tests__/request/length.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('ctx.length', () => {
   it('should return length in content-length', () => {

--- a/__tests__/request/origin.test.js
+++ b/__tests__/request/origin.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Stream = require('stream')
 const context = require('../../test-helpers/context')
 

--- a/__tests__/request/path.test.js
+++ b/__tests__/request/path.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 const parseurl = require('parseurl')
 

--- a/__tests__/request/protocol.test.js
+++ b/__tests__/request/protocol.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.protocol', () => {

--- a/__tests__/request/query.test.js
+++ b/__tests__/request/query.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.query', () => {

--- a/__tests__/request/querystring.test.js
+++ b/__tests__/request/querystring.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 const parseurl = require('parseurl')
 

--- a/__tests__/request/search.test.js
+++ b/__tests__/request/search.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.search=', () => {

--- a/__tests__/request/secure.test.js
+++ b/__tests__/request/secure.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.secure', () => {

--- a/__tests__/request/stale.test.js
+++ b/__tests__/request/stale.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('req.stale', () => {

--- a/__tests__/request/subdomains.test.js
+++ b/__tests__/request/subdomains.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('../../test-helpers/context').request
 
 describe('req.subdomains', () => {

--- a/__tests__/request/type.test.js
+++ b/__tests__/request/type.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('req.type', () => {
   it('should return type void of parameters', () => {

--- a/__tests__/request/whatwg-url.test.js
+++ b/__tests__/request/whatwg-url.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('../../test-helpers/context').request
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('req.URL', () => {
   it('should not throw when host is void', () => {

--- a/__tests__/response/append.test.js
+++ b/__tests__/response/append.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.append(name, val)', () => {

--- a/__tests__/response/attachment.test.js
+++ b/__tests__/response/attachment.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 const request = require('supertest')
 const Koa = require('../..')

--- a/__tests__/response/back.test.js
+++ b/__tests__/response/back.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.back([alt])', () => {

--- a/__tests__/response/body.test.js
+++ b/__tests__/response/body.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require('node:test')
 const response = require('../../test-helpers/context').response
 const CustomStream = require('../../test-helpers/stream')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const fs = require('fs')
 const Stream = require('stream')
 

--- a/__tests__/response/etag.test.js
+++ b/__tests__/response/etag.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const response = require('../../test-helpers/context').response
 
 describe('res.etag=', () => {

--- a/__tests__/response/flushHeaders.test.js
+++ b/__tests__/response/flushHeaders.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const request = require('supertest')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 const http = require('http')
 

--- a/__tests__/response/get.test.js
+++ b/__tests__/response/get.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.get(name)', () => {

--- a/__tests__/response/has.test.js
+++ b/__tests__/response/has.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.response.has(name)', () => {

--- a/__tests__/response/header.test.js
+++ b/__tests__/response/header.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('supertest')
 const response = require('../../test-helpers/context').response
 const Koa = require('../..')

--- a/__tests__/response/headers.test.js
+++ b/__tests__/response/headers.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const response = require('../../test-helpers/context').response
 
 describe('res.header', () => {

--- a/__tests__/response/inspect.test.js
+++ b/__tests__/response/inspect.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const response = require('../../test-helpers/context').response
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const util = require('util')
 
 describe('res.inspect()', () => {

--- a/__tests__/response/is.test.js
+++ b/__tests__/response/is.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('response.is(type)', () => {
   it('should ignore params', () => {

--- a/__tests__/response/last-modified.test.js
+++ b/__tests__/response/last-modified.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const response = require('../../test-helpers/context').response
 
 describe('res.lastModified', () => {

--- a/__tests__/response/length.test.js
+++ b/__tests__/response/length.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const response = require('../../test-helpers/context').response
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const fs = require('fs')
 
 describe('res.length', () => {

--- a/__tests__/response/message.test.js
+++ b/__tests__/response/message.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const response = require('../../test-helpers/context').response
 
 describe('res.message', () => {

--- a/__tests__/response/redirect.test.js
+++ b/__tests__/response/redirect.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const request = require('supertest')
 const context = require('../../test-helpers/context')
 const Koa = require('../..')

--- a/__tests__/response/remove.test.js
+++ b/__tests__/response/remove.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.remove(name)', () => {

--- a/__tests__/response/set.test.js
+++ b/__tests__/response/set.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.set(name, val)', () => {

--- a/__tests__/response/socket.test.js
+++ b/__tests__/response/socket.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const response = require('../../test-helpers/context').response
 const Stream = require('stream')
 

--- a/__tests__/response/status.test.js
+++ b/__tests__/response/status.test.js
@@ -4,7 +4,7 @@ const { describe, it, beforeEach } = require('node:test')
 const response = require('../../test-helpers/context').response
 const request = require('supertest')
 const statuses = require('statuses')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../..')
 
 describe('res.status=', () => {

--- a/__tests__/response/type.test.js
+++ b/__tests__/response/type.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 describe('ctx.type=', () => {
   describe('with a mime', () => {

--- a/__tests__/response/vary.test.js
+++ b/__tests__/response/vary.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const context = require('../../test-helpers/context')
 
 describe('ctx.vary(field)', () => {

--- a/__tests__/response/writable.test.js
+++ b/__tests__/response/writable.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, it } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert/strict')
 const Koa = require('../../')
 const net = require('net')
 


### PR DESCRIPTION
## Description

First PR. Migrates tests from `assert` to `node:assert/strict`.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
