### PR TITLE
use pipeline() instead of pipe()

### DIFF
--- a/__tests__/application/respond.test.js
+++ b/__tests__/application/respond.test.js
@@ -678,12 +678,12 @@ describe('app.respond', () => {
         assert.deepStrictEqual(res.body, pkg)
       })
 
-    it('should handle errors when no content status', () => {
+    it('should not handle errors when no content status, but let user do it self', () => {
       const app = new Koa()
 
       app.use(ctx => {
         ctx.status = 204
-        ctx.body = fs.createReadStream('does not exist')
+        ctx.body = fs.createReadStream('does not exist').on('error', (err) => {})
       })
 
       return request(app.callback())

--- a/__tests__/response/body.test.js
+++ b/__tests__/response/body.test.js
@@ -117,14 +117,14 @@ describe('res.body=', () => {
       assert.strictEqual('application/octet-stream', res.header['content-type'])
     })
 
-    it('should add error handler to the stream, but only once', () => {
+    it('should not add error handler to the stream, but let the user do it self', () => {
       const res = response()
       const body = new Stream.PassThrough()
       assert.strictEqual(body.listenerCount('error'), 0)
       res.body = body
-      assert.strictEqual(body.listenerCount('error'), 1)
+      assert.strictEqual(body.listenerCount('error'), 0)
       res.body = body
-      assert.strictEqual(body.listenerCount('error'), 1)
+      assert.strictEqual(body.listenerCount('error'), 0)
     })
   })
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -304,10 +304,10 @@ function respond (ctx) {
 
   if (Buffer.isBuffer(body)) return res.end(body)
   if (typeof body === 'string') return res.end(body)
-  if (body instanceof Blob) { return Stream.Readable.from(body.stream()).pipe(res) }
-  if (body instanceof ReadableStream) { return Stream.Readable.from(body).pipe(res) }
-  if (body instanceof Response) { return Stream.Readable.from(body?.body || '').pipe(res) }
-  if (isStream(body)) return body.pipe(res)
+  if (body instanceof Blob) { return Stream.pipeline(body.stream(), res, (err) => {}) }
+  if (body instanceof ReadableStream) { return Stream.pipeline(body, res, (err) => {}) }
+  if (body instanceof Response) { return Stream.pipeline(body?.body || '', res, (err) => {}) }
+  if (isStream(body)) { return Stream.pipeline(body, res, (err) => {}) }
 
   // body: json
   body = JSON.stringify(body)

--- a/lib/response.js
+++ b/lib/response.js
@@ -9,7 +9,7 @@ const extname = require('node:path').extname
 const util = require('node:util')
 
 const contentDisposition = require('content-disposition')
-const onFinish = require('on-finished')
+const onFinished = require('on-finished')
 const escape = require('escape-html')
 const typeis = require('type-is').is
 const statuses = require('statuses')
@@ -174,9 +174,8 @@ module.exports = {
 
     // stream
     if (isStream(val)) {
-      onFinish(this.res, destroy.bind(null, val))
+      onFinished(this.res, destroy.bind(null, val))
       if (original !== val) {
-        val.once('error', err => this.ctx.onerror(err))
         // overwriting
         if (original != null) this.remove('Content-Length')
       }


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

pipe(rs, res) will not destroy res, when an error occurs. Thus causing client "hang" infinite when it has received some part of data.

Following code example, a readable stream has been implemented. When client request, the server will send some data, but after the error occurs, the client hang, the server doesn't close the socket. Chrome will hang. curl and ab will end in timeout.

After replacing with pipeline, when error occur, koa immediately close the socket, Chrome will say "Check internet connection" in download page. curl and ab will finish request as soon as possible.

stream.pipeline() will call stream.destroy(err) on all streams except they have already been closed.

the behavior may be better than hanging the request. Instead of client waitting indefinitely for the remaining bytes, closing the connection will break the expectation, but it's the only way to signal that the response is incomplete. The client will know that the response is truncated. Headers are already sent, an error occurs mid-stream, the client could handle this predictably.


Here's another to consider:

It's koa duty to close connection, it's app writer's duty to close the readable stream, and it's (better) stream implementers duty to release corresponding resources(request socket, fd, etc) of the readable stream when error occurs(but if it didn't work well, app writer should handle it, not koa).


Last benifit is pipeline() added support for webstreams(v18.16.0), making it easier.

```js
import { Readable } from 'node:stream';
import http from 'http';
import Koa from 'koa';

class MyStream extends Readable {
  #count = 0;
  _read(size) {
    this.#count++;
    this.push(':-)');
    if (this.#count === 4) {
      try {
        // https://nodejs.org/api/stream.html#errors-while-reading
        throw new Error('Error in stream');
      } catch (e) {
        this.destroy(e);
        return;
      }
    }
    if (this.#count === 5) {
      this.push(null);
    }
  }
}

const httpPort = 8081;
const app = new Koa();

app.use((ctx) => {
  if (ctx.request.path === '/favicon.ico') {
    ctx.status = 404;
    return;
  }

  const stream = new MyStream();

  ctx.body = stream;
});

http.createServer(app.callback()).listen(httpPort);

```