### PR TITLE
fix: response content-type value alignment mechanism of native Node.js and browser defaults.

### DIFF
--- a/__tests__/application/response.test.js
+++ b/__tests__/application/response.test.js
@@ -14,6 +14,7 @@ describe('app.response', () => {
   const app5 = new Koa()
   const app6 = new Koa()
   const app7 = new Koa()
+  const app8 = new Koa()
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
@@ -95,6 +96,23 @@ describe('app.response', () => {
     return request(app7.callback())
       .get('/')
       .expect('Transfer-Encoding', 'chunked')
+      .expect(200)
+  })
+
+  it('should hold the first value when the Content-Type parameter is an Array', () => {
+    app8.use((ctx, next) => {
+      ctx.set('Content-Type', ['image/jpg', 'application/json'])
+      assert.strictEqual(ctx.response.type, 'application/json')
+      ctx.body = {}
+    })
+
+    return request(app8.callback())
+      .get('/')
+      .expect(ctx => {
+        const rawHeaders = ctx.res.rawHeaders
+        const collection = new Set(rawHeaders.filter((_, ind, arr) => (ind % 2 === 1) && arr[ind - 1] === 'Content-Type'))
+        return collection.has('image/jpg') && collection.has('application/json')
+      })
       .expect(200)
   })
 })

--- a/lib/response.js
+++ b/lib/response.js
@@ -430,7 +430,7 @@ module.exports = {
   get type () {
     const type = this.get('Content-Type')
     if (!type) return ''
-    return type.split(';', 1)[0]
+    return (Array.isArray(type) ? type[type.length - 1] : type).split(';', 1)[0]
   },
 
   /**


### PR DESCRIPTION
Discussion #1697 [[link](https://github.com/koajs/koa/discussions/1697)]


## Mechanism
### Align contentType with browser defaults (use the last one as usual)
The test case shows the app8 callback(simulate the page) header contains all values of 'Content-Type'

### Align contentType with native Node.js behavior (keep original information)
The test case shows the assert value with 'application/json'(the last one)

### Concern
The content-type value could not fit with the resource if the developer sets the wrong value


## Checklist

- [* ] I have ensured my pull request is not behind the main or master branch of the original repository.
- [* ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [* ] I have written a commit message that passes commitlint linting.
- [* ] I have ensured that my code changes pass linting tests.
- [* ] I have ensured that my code changes pass unit tests.
- [* ] I have described my pull request and the reasons for code changes along with context if necessary.
