### PR TITLE
fix: response content-type value amount as one with testcase

### DIFF
--- a/__tests__/application/response.test.js
+++ b/__tests__/application/response.test.js
@@ -14,6 +14,7 @@ describe('app.response', () => {
   const app5 = new Koa()
   const app6 = new Koa()
   const app7 = new Koa()
+  const app8 = new Koa()
 
   it('should merge properties', () => {
     app1.use((ctx, next) => {
@@ -95,6 +96,19 @@ describe('app.response', () => {
     return request(app7.callback())
       .get('/')
       .expect('Transfer-Encoding', 'chunked')
+      .expect(200)
+  })
+
+  it('should not assign multiple content-type for response header', () => {
+    app8.use((ctx, next) => {
+      assert.throws(() => {
+        ctx.set('Content-Type', ['image/jpg', 'application/json'])
+      }, Error)
+      ctx.body = {}
+    })
+
+    return request(app8.callback())
+      .get('/')
       .expect(200)
   })
 })

--- a/lib/response.js
+++ b/lib/response.js
@@ -510,6 +510,9 @@ module.exports = {
     if (this.headerSent || !field) return
 
     if (typeof field === 'string') {
+      if (field.toLowerCase() === 'content-type') {
+        assert(!Array.isArray(val), 'Assign multiple Content-Type for response header is not allowed')
+      }
       this.res.setHeader(field, val)
     } else {
       Object.keys(field).forEach(header => this.res.setHeader(header, field[header]))


### PR DESCRIPTION
Discussion #1697 [[link](https://github.com/koajs/koa/discussions/1697)]


## Mechanism
### Response header's contentType 
Content-Type should be a single value(string) for header's response.


## Checklist

- [* ] I have ensured my pull request is not behind the main or master branch of the original repository.
- [* ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [* ] I have written a commit message that passes commitlint linting.
- [* ] I have ensured that my code changes pass linting tests.
- [* ] I have ensured that my code changes pass unit tests.
- [* ] I have described my pull request and the reasons for code changes along with context if necessary.
