### PR TITLE
fix: fixes response.attachment behaviour leads to Content-Type Sniffing

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -351,7 +351,9 @@ module.exports = {
    */
 
   attachment (filename, options) {
-    if (filename) this.type = extname(filename)
+    if (filename && !this.has('Content-Type')) {
+      this.type = extname(filename)
+    }
     this.set('Content-Disposition', contentDisposition(filename, options))
   },
 


### PR DESCRIPTION
## Checklist

Added security-focused tests to verify:
  1. Content-Type is preserved when already set
  2. Content-Type is still set when not previously defined (backwards compatibility)
  3. The fix prevents XSS vulnerabilities with HTML and SVG files

credit "Luca Carettoni of Doyensec LLC" as [requested in the advisory](https://github.com/koajs/koa/security/advisories/GHSA-c5vw-j4hf-j526).

---

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
