### PR TITLE
fix: only original value destroy if the new value is not a stream

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -139,7 +139,10 @@ module.exports = {
     const cleanupPreviousStream = () => {
       if (original && isStream(original)) {
         original.once('error', () => {})
-        destroy(original)
+        // Only destroy if the new value is not a stream
+        if (!isStream(val)) {
+          destroy(original)
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This PR adds a minimal fix + tests for #1913.
Thanks @nuintun for their observation and solutions. 

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
