### PR TITLE
docs: use correct term "Server-Sent Events" in guide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,7 +16,7 @@
   - [Async operations](#async-operations)
   - [Debugging Koa](#debugging-koa)
   - [HTTP2](#http2)
-  - [Server-Side Events](#server-side-events)
+  - [Server-Sent Events](#server-sent-events)
 
 ## Writing Middleware
 
@@ -272,9 +272,9 @@ const server = http2.createSecureServer(serverOptions, onRequestHandler);
 server.listen(3000);
 ```
 
-## Server-Side Events
+## Server-Sent Events
 
-An example of using server-side events with Koa:
+An example of using server-sent events with Koa:
 
 ```js
 import { PassThrough } from 'node:stream'


### PR DESCRIPTION
This PR updates the terminology in `docs/guide.md` from **"Server-Side Events"** to the correct term **"Server-Sent Events" (SSE)**.

Changes:

- Rename the section heading from `Server-Side Events` to `Server-Sent Events`.
- Update the description text to use “server-sent events” consistently.

This aligns the docs with the standard naming used in the HTML specification and MDN Web Docs, and should make it easier for readers to search for related resources (e.g. “Server-Sent Events”, “SSE”, `EventSource`).

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
