### PR TITLE
docs: remove dead Job Board links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,14 +189,6 @@ See [AUTHORS](AUTHORS).
  - [中文文档 v2.x](https://github.com/demopark/koa-docs-Zh-CN)
  - __[#koajs]__ on freenode
 
-## Job Board
-
-Looking for a career upgrade?
-
-<a href="https://astro.netlify.com/automattic"><img src="https://astro.netlify.com/static/automattic.png"></a>
-<a href="https://astro.netlify.com/segment"><img src="https://astro.netlify.com/static/segment.png"></a>
-<a href="https://astro.netlify.com/auth0"><img src="https://astro.netlify.com/static/auth0.png"/></a>
-
 ## Backers
 
 Support us with a monthly donation and help us continue our activities.


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

## Summary
- Remove the "Job Board" section from README as all links are dead (404)

## Details
The `astro.netlify.com` service was added by TJ Holowaychuk in April 2017 as a 
private job board sponsorship service for open source projects. This service is 
no longer operational - all URLs return 404 errors.

The affected links pointed to:
- Automattic
- Segment  
- Auth0

The Backers and Sponsors sections using OpenCollective remain functional and are preserved.

## Test plan
- [x] Verified all `astro.netlify.com` URLs return 404
- [x] Confirmed OpenCollective links still work


Issues: [[docs] Job Board three link and image not show in readme #1911](https://github.com/koajs/koa/issues/1911)
