### PR TITLE
docs: improve JSDoc parameter descriptions for `Application` constructor

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -64,7 +64,7 @@ ctx.state.user = await User.find(id);
 
 ### ctx.app.emit
 
-  Koa applications extend an internal [EventEmitter](https://nodejs.org/dist/latest-v11.x/docs/api/events.html). `ctx.app.emit` emits an event with a type, defined by the first argument. For each event you can hook up "listeners", which is a function that is called when the event is emitted. Consult the [error handling docs](https://koajs.com/#error-handling) for more information.
+  Koa applications extend an internal [EventEmitter](https://nodejs.org/docs/latest/api/events.html). `ctx.app.emit` emits an event with a type, defined by the first argument. For each event you can hook up "listeners", which is a function that is called when the event is emitted. Consult the [error handling docs](https://koajs.com/#error-handling) for more information.
 
 ### ctx.cookies.get(name, [options])
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -90,10 +90,11 @@ app.listen(3000);
   - `app.env` defaulting to the __NODE_ENV__ or "development"
   - `app.keys` array of signed cookie keys
   - `app.proxy` when true proxy header fields will be trusted
-  - `app.subdomainOffset` offset of `.subdomains` to ignore, default to 2
-  - `app.proxyIpHeader` proxy ip header, default to `X-Forwarded-For`
-  - `app.maxIpsCount` max ips read from proxy ip header, default to 0 (means infinity)
-  - `app.asyncLocalStorage<Boolean|asyncLocalStorage>` - pass `true` or an instance of `AsyncLocalStorage` to enable async local storage. See below for details.
+  - `app.subdomainOffset` offset of `.subdomains` to ignore, defaults to 2
+  - `app.proxyIpHeader` proxy ip header, defaults to `X-Forwarded-For`
+  - `app.maxIpsCount` max ips read from proxy ip header, defaults to 0 (means infinity)
+  - `app.compose` - function to handle middleware composition
+  - `app.asyncLocalStorage` pass `true` or an instance of `AsyncLocalStorage` to enable async local storage. See below for details.
 
   You can pass the settings to the constructor:
   ```js
@@ -232,7 +233,7 @@ function callSomeFunction () {
 }
 ```
 
-Starting in v3.1.0, you can also pass your own AsyncLocalStorage instance:
+Starting in v3.1.0, you can also pass your own `AsyncLocalStorage` instance:
 
 ```js
 const asyncLocalStorage = new AsyncLocalStorage()

--- a/lib/application.js
+++ b/lib/application.js
@@ -58,14 +58,14 @@ module.exports = class Application extends Emitter {
   /**
    *
    * @param {object} [options] Application options
-   * @param {string} [options.env='development'] Environment
+   * @param {string} [options.env='development'] Environment. Defaults to `NODE_ENV` or `'development'`.
    * @param {string[]} [options.keys] Signed cookie keys
-   * @param {boolean} [options.proxy] Trust proxy headers
-   * @param {number} [options.subdomainOffset] Subdomain offset
-   * @param {string} [options.proxyIpHeader] Proxy IP header, defaults to X-Forwarded-For
-   * @param {number} [options.maxIpsCount] Max IPs read from proxy IP header, default to 0 (means infinity)
+   * @param {boolean} [options.proxy] When `true`, proxy header fields will be trusted.
+   * @param {number} [options.subdomainOffset] Subdomain offset, defaults to `2`
+   * @param {string} [options.proxyIpHeader] Proxy IP header, defaults to `X-Forwarded-For`
+   * @param {number} [options.maxIpsCount] Max IPs read from proxy IP header, defaults to `0` (means infinity)
    * @param {function} [options.compose] Function to handle middleware composition
-   * @param {boolean} [options.asyncLocalStorage] Enable AsyncLocalStorage, default to false
+   * @param {boolean|AsyncLocalStorage} [options.asyncLocalStorage] Pass `true` or an instance of `AsyncLocalStorage` to enable async local storage.
    *
    */
 


### PR DESCRIPTION
**Improve JSDoc and docs for `Application` constructor options**

- `lib/application.js`: improve JSDoc param descriptions 
  - add missing defaults
  - update wording for `proxy` parameter
  - fix `asyncLocalStorage` type and description
- `docs/api/index.md`: 
  -  add missing `app.compose` entry
- `docs/api/context.md`: update stale Node.js docs URL

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Node.js Events API reference link.
  * Added and clarified application settings documentation, including `app.compose`, proxy and subdomain defaults, and async local storage configuration.
  * Improved descriptions of application options and their default values.
  * Clarified `app.currentContext` documentation and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->