### PR TITLE
fix: Request.protocol returns 'https' for HTTP/2 after RST_STREAM (#1736)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -96,7 +96,8 @@ module.exports = {
    */
 
   get origin () {
-    return this.req.headers.origin || null
+    if (!this.host) return null
+    return `${this.protocol}://${this.host}`
   },
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -96,8 +96,7 @@ module.exports = {
    */
 
   get origin () {
-    if (!this.host) return null
-    return `${this.protocol}://${this.host}`
+    return this.req.headers.origin || null
   },
 
   /**
@@ -410,6 +409,12 @@ module.exports = {
 
   get protocol () {
     if (this.socket.encrypted) return 'https'
+    // HTTP/2: after RST_STREAM, socket may switch to ServerHttp2Stream
+    // which lacks `encrypted`. Check the underlying session socket instead.
+    const stream = this.req.stream
+    if (stream && stream.session && stream.session.socket && stream.session.socket.encrypted) {
+      return 'https'
+    }
     if (!this.app.proxy) return 'http'
     const proto = this.get('X-Forwarded-Proto')
     return proto ? splitCommaSeparatedValues(proto, 1)[0] : 'http'


### PR DESCRIPTION
Fixes #1736

When using koa with `http2.createSecureServer`, `Request.secure` could incorrectly return `false` after the client sends `RST_STREAM`.

## Root Cause

In HTTP/2, after a stream reset, `req.socket` may switch from `TLSSocket` to `ServerHttp2Stream`, which lacks the `encrypted` property. The `protocol` getter only checked `this.socket.encrypted`, so it fell through to `'http'`.

## Fix

When `this.socket.encrypted` is falsy, fall back to checking `req.stream.session.socket.encrypted` for HTTP/2 connections.