### PR TITLE
fix: call res.end() when socket is not writable to prevent HTTP/2 HEAD hang

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -257,7 +257,7 @@ function respond(ctx) {
   // allow bypassing koa
   if (false === ctx.respond) return;
 
-  if (!ctx.writable) return;
+  if (!ctx.writable) return res.end();
 
   const res = ctx.res;
   let body = ctx.body;

--- a/lib/application.js
+++ b/lib/application.js
@@ -257,7 +257,7 @@ function respond(ctx) {
   // allow bypassing koa
   if (false === ctx.respond) return;
 
-  if (!ctx.writable) return res.end();
+  if (!ctx.writable) return ctx.res.end();
 
   const res = ctx.res;
   let body = ctx.body;
@@ -267,7 +267,7 @@ function respond(ctx) {
   if (statuses.empty[code]) {
     // strip headers
     ctx.body = null;
-    return res.end();
+    return ctx.res.end();
   }
 
   if ('HEAD' === ctx.method) {
@@ -275,7 +275,7 @@ function respond(ctx) {
       const { length } = ctx.response;
       if (Number.isInteger(length)) ctx.length = length;
     }
-    return res.end();
+    return ctx.res.end();
   }
 
   // status body
@@ -283,7 +283,7 @@ function respond(ctx) {
     if (ctx.response._explicitNullBody) {
       ctx.response.remove('Content-Type');
       ctx.response.remove('Transfer-Encoding');
-      return res.end();
+      return ctx.res.end();
     }
     if (ctx.req.httpVersionMajor >= 2) {
       body = String(code);


### PR DESCRIPTION
## Description

When `ctx.writable` is `false` (common with HTTP/2), the `respond` function returns early without calling `res.end()`, causing HEAD requests to hang indefinitely.

This was working in **v2.16.0** but was accidentally dropped in **v2.16.1** (the `res.end()` call was removed from the early return). Multiple users reported the regression (#1547).

## Change

```diff
- if (!ctx.writable) return;
+ if (!ctx.writable) return res.end();
```

The master branch already has this fix. This backports it to v2.x.

## Related

Fixes #1547