### PR TITLE
docs: correct response.back() signature and behavior

### DIFF
--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -305,9 +305,18 @@ ctx.redirect('/cart');
 ctx.body = 'Redirecting to shopping cart';
 ```
 
-### response.back(url)
+### response.back([alt])
 
-  Similar to `.redirect(url)`, but first checks the `referer` header to redirect.
+  Redirect back to the URL in the `Referrer` header (only when it points to the
+  same host as the current request). When the `Referrer` header is missing, or
+  refers to a different host, redirects to `alt` instead, falling back to `/`
+  when `alt` is not provided.
+
+```js
+ctx.back();
+ctx.back('/index.html');
+```
+
   This is new in v3 as `.redirect(url, alt)` removes the special case `url = 'back'` option.
 
 ### response.attachment([filename], [options])


### PR DESCRIPTION

**Repo:** koajs/koa (⭐ 35000)
**Type:** docs
**Files changed:** 1
**Lines:** +11/-2

## What
Fixes the `response.back()` API doc entry in `docs/api/response.md`. The
heading previously documented the method as `response.back(url)` and called the
parameter "url", but the actual implementation in `lib/response.js` accepts a
single optional `alt` parameter that is only used as a fallback when the
`Referrer` header is missing (or points to a different host). The doc is
updated to `response.back([alt])`, with a clearer description and a small
example matching the migration guide.

## Why
The previous entry was misleading: readers could reasonably believe the
argument was the redirect target, when it is actually the fallback. This is
the same `back([alt])` shape used in `lib/response.js` and the migration
guide (`docs/migration-v2-to-v3.md`), so the API reference is now consistent
with the rest of the docs and with the source.

## Testing
Docs-only change. Verified the new wording matches the implementation in
`lib/response.js` (`back (alt)` — uses `Referrer` when same-host, otherwise
`alt || '/'`) and the example from `docs/migration-v2-to-v3.md`.

## Risk
Low — documentation only, no runtime behavior change.
