### PR TITLE
fix: restore request origin URL

### DIFF
--- a/__tests__/request/origin.test.js
+++ b/__tests__/request/origin.test.js
@@ -11,17 +11,28 @@ describe('ctx.origin', () => {
     const req = {
       url: '/users/1?next=/dashboard',
       headers: {
-        host: 'localhost',
-        origin: 'http://example.com'
+        host: 'localhost'
       },
       socket,
       __proto__: Stream.Readable.prototype
     }
     const ctx = context(req)
-    assert.strictEqual(ctx.origin, 'http://example.com')
+    assert.strictEqual(ctx.origin, 'http://localhost')
 
     // change it also work
     ctx.url = '/foo/users/1?next=/dashboard'
-    assert.strictEqual(ctx.origin, 'http://example.com')
+    assert.strictEqual(ctx.origin, 'http://localhost')
+  })
+
+  it('should not use the Origin header', () => {
+    const ctx = context({
+      url: '/users/1',
+      headers: {
+        host: 'localhost',
+        origin: 'http://example.com'
+      }
+    })
+
+    assert.strictEqual(ctx.origin, 'http://localhost')
   })
 })

--- a/lib/request.js
+++ b/lib/request.js
@@ -89,14 +89,14 @@ module.exports = {
   },
 
   /**
-   * Get the origin header.
+   * Get origin of URL.
    *
    * @return {String}
    * @api public
    */
 
   get origin () {
-    return this.req.headers.origin || null
+    return `${this.protocol}://${this.host}`
   },
 
   /**
@@ -109,7 +109,7 @@ module.exports = {
   get href () {
     // support: `GET http://example.com/foo`
     if (/^https?:\/\//i.test(this.originalUrl)) return this.originalUrl
-    return this.protocol + '://' + this.host + this.originalUrl
+    return this.origin + this.originalUrl
   },
 
   /**


### PR DESCRIPTION
Fixes #1958.

## Summary
- restore `ctx.origin` / `ctx.request.origin` to return `protocol://host`, matching the documented API and Koa v2 behavior
- keep `ctx.href` building from the computed origin
- add coverage that the request `Origin` header does not override Koa request origin

## Tests
- `npm_config_cache=$PWD/.npm-cache npm test -- __tests__/request/origin.test.js __tests__/request/href.test.js __tests__/request/host.test.js __tests__/request/protocol.test.js`
- `npm_config_cache=$PWD/.npm-cache npm run lint -- lib/request.js __tests__/request/origin.test.js`
- `npm_config_cache=$PWD/.npm-cache npm test`
- `npm_config_cache=$PWD/.npm-cache npm run lint`
- `git diff --check`