### PR TITLE
fix: throw koa http errors from ctx.assert

### DIFF
--- a/__tests__/context/assert.test.js
+++ b/__tests__/context/assert.test.js
@@ -3,6 +3,7 @@
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
 const assert = require('node:assert/strict')
+const httpAssert = require('http-assert')
 const Koa = require('../..')
 
 describe('ctx.assert(value, status)', () => {
@@ -36,6 +37,20 @@ describe('ctx.assert(value, status)', () => {
     })
   })
 
+  it('should throw Koa HttpError instances with default status', () => {
+    const ctx = context()
+
+    assert.throws(() => {
+      ctx.assert(false, 'custom message without status')
+    }, err => {
+      assert.strictEqual(err instanceof Koa.HttpError, true)
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.message, 'custom message without status')
+      assert.strictEqual(err.expose, false)
+      return true
+    })
+  })
+
   it('should throw Koa HttpError instances from assertion helpers', () => {
     const ctx = context()
 
@@ -48,5 +63,40 @@ describe('ctx.assert(value, status)', () => {
       assert.strictEqual(err.expose, true)
       return true
     })
+  })
+
+  it('should throw Koa HttpError instances from assertion helpers without explicit status', () => {
+    const ctx = context()
+
+    assert.throws(() => {
+      ctx.assert.ok(false, 'custom helper message without status')
+    }, err => {
+      assert.strictEqual(err instanceof Koa.HttpError, true)
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.message, 'custom helper message without status')
+      assert.strictEqual(err.expose, false)
+      return true
+    })
+  })
+
+  it('should rethrow non-http assertion helper errors unchanged', () => {
+    const ctx = context()
+    const originalFail = httpAssert.fail
+    const error = new Error('custom helper failure')
+
+    httpAssert.fail = function () {
+      throw error
+    }
+
+    try {
+      assert.throws(() => {
+        ctx.assert.fail()
+      }, err => {
+        assert.strictEqual(err, error)
+        return true
+      })
+    } finally {
+      httpAssert.fail = originalFail
+    }
   })
 })

--- a/__tests__/context/assert.test.js
+++ b/__tests__/context/assert.test.js
@@ -3,6 +3,7 @@
 const { describe, it } = require('node:test')
 const context = require('../../test-helpers/context')
 const assert = require('node:assert/strict')
+const Koa = require('../..')
 
 describe('ctx.assert(value, status)', () => {
   it('should throw an error', () => {
@@ -19,5 +20,33 @@ describe('ctx.assert(value, status)', () => {
       assert.strictEqual(err.expose, true)
     }
     assert(assertionRan)
+  })
+
+  it('should throw Koa HttpError instances', () => {
+    const ctx = context()
+
+    assert.throws(() => {
+      ctx.assert(false, 404, 'custom message')
+    }, err => {
+      assert.strictEqual(err instanceof Koa.HttpError, true)
+      assert.strictEqual(err.status, 404)
+      assert.strictEqual(err.message, 'custom message')
+      assert.strictEqual(err.expose, true)
+      return true
+    })
+  })
+
+  it('should throw Koa HttpError instances from assertion helpers', () => {
+    const ctx = context()
+
+    assert.throws(() => {
+      ctx.assert.equal('actual', 'expected', 400, 'custom message')
+    }, err => {
+      assert.strictEqual(err instanceof Koa.HttpError, true)
+      assert.strictEqual(err.status, 400)
+      assert.strictEqual(err.message, 'custom message')
+      assert.strictEqual(err.expose, true)
+      return true
+    })
   })
 })

--- a/lib/context.js
+++ b/lib/context.js
@@ -18,7 +18,9 @@ function rethrowKoaHttpError (fn, args) {
     return fn(...args)
   } catch (err) {
     if (err && typeof err.status === 'number') {
-      throw createError(err.status, err.message, Object.assign({}, err))
+      const props = Object.assign({}, err)
+      props.stack = err.stack
+      throw createError(err.status, err.message, props)
     }
     throw err
   }

--- a/lib/context.js
+++ b/lib/context.js
@@ -13,6 +13,25 @@ const Cookies = require('cookies')
 
 const COOKIES = Symbol('context#cookies')
 
+function rethrowKoaHttpError (fn, args) {
+  try {
+    return fn(...args)
+  } catch (err) {
+    if (err && typeof err.status === 'number') {
+      throw createError(err.status, err.message, Object.assign({}, err))
+    }
+    throw err
+  }
+}
+
+function assert (...args) {
+  return rethrowKoaHttpError(httpAssert, args)
+}
+
+for (const method of Object.keys(httpAssert)) {
+  assert[method] = (...args) => rethrowKoaHttpError(httpAssert[method], args)
+}
+
 /**
  * Context prototype.
  */
@@ -69,7 +88,7 @@ const proto = module.exports = {
    * @api public
    */
 
-  assert: httpAssert,
+  assert,
 
   /**
    * Throw an error with `status` (default 500) and


### PR DESCRIPTION
Fixes #1925.

`ctx.assert` delegates to `http-assert`, which currently throws errors created by `http-assert`'s nested `http-errors@1.x` dependency. Since Koa exports `HttpError` from its own `http-errors@2.x` dependency, errors thrown by `ctx.assert()` do not satisfy `err instanceof Koa.HttpError`.

This keeps `http-assert`'s assertion behavior and helper methods, but converts thrown assertion errors through Koa's `http-errors` dependency so direct assertions and helper assertions return Koa `HttpError` instances.

Verification:
- Red before fix: `node --test __tests__/context/assert.test.js` failed on `err instanceof Koa.HttpError` for `ctx.assert(false, 404, ...)`.
- Green after fix: `node --test __tests__/context/assert.test.js`
- `npm run build`
- `npm run lint`
- `git diff --check`
- `npm test` (442 tests, 0 failures)

## Summary by Sourcery

Ensure context assertions throw Koa HttpError instances instead of raw http-assert errors.

Enhancements:
- Wrap ctx.assert and its helper methods to rethrow assertion failures as Koa HttpError instances while preserving status, message, and properties.

Tests:
- Add tests verifying that ctx.assert and its helper methods throw Koa HttpError instances with the expected status, message, and exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for context assertions to verify thrown errors' types, status codes, messages, and exposure flags, and to ensure non-HTTP assertion errors are rethrown unchanged.

* **Bug Fixes**
  * Improved assertion handling in the runtime context so assertion failures are converted to consistent HTTP-style errors while preserving original error details and stack traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->